### PR TITLE
Use buildinfo

### DIFF
--- a/internal/print/print.go
+++ b/internal/print/print.go
@@ -5,30 +5,36 @@ import (
 	"os"
 
 	"github.com/fatih/color"
+	"github.com/mattn/go-colorable"
 	"github.com/nao1215/gup/internal/cmdinfo"
+)
+
+var (
+	stdout = colorable.NewColorableStdout()
+	stderr = colorable.NewColorableStderr()
 )
 
 // Info print information message at STDOUT.
 func Info(msg string) {
-	fmt.Fprintf(os.Stdout, "%s:%s: %s\n",
+	fmt.Fprintf(stdout, "%s:%s: %s\n",
 		cmdinfo.Name(), color.GreenString("INFO"), msg)
 }
 
 // Warn print warning message at STDERR.
 func Warn(err interface{}) {
-	fmt.Fprintf(os.Stderr, "%s:%s: %v\n",
+	fmt.Fprintf(stderr, "%s:%s: %v\n",
 		cmdinfo.Name(), color.YellowString("WARN"), err)
 }
 
 // Err print error message at STDERR.
 func Err(err interface{}) {
-	fmt.Fprintf(os.Stderr, "%s:%s: %v\n",
+	fmt.Fprintf(stderr, "%s:%s: %v\n",
 		cmdinfo.Name(), color.HiYellowString("ERROR"), err)
 }
 
 // Fatal print dying message at STDERR.
 func Fatal(err interface{}) {
-	fmt.Fprintf(os.Stderr, "%s:%s: %v\n",
+	fmt.Fprintf(stderr, "%s:%s: %v\n",
 		cmdinfo.Name(), color.RedString("FATAL"), err)
 	os.Exit(1)
 }


### PR DESCRIPTION
Use debug/buildinfo to avoid to spawn "go version -m" for each binary files.