### PR TITLE
Use strings.HasPrefix instead of regular expression

### DIFF
--- a/internal/goutil/goutil.go
+++ b/internal/goutil/goutil.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/nao1215/gup/internal/print"
@@ -106,12 +105,12 @@ func GetPackageInformation(binList []string) []Package {
 
 // extractPackagePath extract package path from result of "$ go version -m".
 func extractPackagePath(lines []string) string {
-	r := regexp.MustCompile(`\s+?path`)
 	for _, v := range lines {
-		if r.MatchString(v) {
-			v = r.ReplaceAllString(v, "")
-			v = strings.TrimSpace(v)
-			return strings.TrimRight(v, "\n")
+		vv := strings.TrimSpace(v)
+		if len(v) != len(vv) && strings.HasPrefix(vv, "path") {
+			vv = strings.TrimLeft(vv, "path")
+			vv = strings.TrimSpace(vv)
+			return strings.TrimRight(vv, "\n")
 		}
 	}
 	return ""


### PR DESCRIPTION
Since determining the path from the output of `go version -m` is a simple forward match, I think it would be sufficient to use `strings.HasPrefix`.