### PR TITLE
Fixed unit-test that produced different test results on mac and linux

### DIFF
--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/nao1215/gup/internal/file"
 	"github.com/nao1215/gup/internal/goutil"
 	"github.com/nao1215/gup/internal/print"
 	"github.com/spf13/cobra"
@@ -109,12 +110,9 @@ func Test_export(t *testing.T) {
 				cmd:  &cobra.Command{},
 				args: []string{},
 			},
-			gobin: "",
-			want:  1,
-			stderr: []string{
-				"gup:ERROR: can not make config directory: mkdir /.config: permission denied",
-				"",
-			},
+			gobin:  "",
+			want:   1,
+			stderr: []string{},
 		},
 		{
 			name: "not exist gobin directory",
@@ -158,7 +156,7 @@ func Test_export(t *testing.T) {
 
 			if tt.name == "can not make .config directory" {
 				oldHome := os.Getenv("HOME")
-				if err := os.Setenv("HOME", "/"); err != nil {
+				if err := os.Setenv("HOME", "/root"); err != nil {
 					t.Fatal(err)
 				}
 				defer func() {
@@ -192,8 +190,14 @@ func Test_export(t *testing.T) {
 			defer pr.Close()
 			got := strings.Split(buf.String(), "\n")
 
-			if diff := cmp.Diff(tt.stderr, got); diff != "" {
-				t.Errorf("value is mismatch (-want +got):\n%s", diff)
+			if tt.name != "can not make .config directory" {
+				if diff := cmp.Diff(tt.stderr, got); diff != "" {
+					t.Errorf("value is mismatch (-want +got):\n%s", diff)
+				}
+			} else {
+				if file.IsFile("/.config") {
+					t.Errorf("permissions are incomplete because '/.config' was created")
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Fix [this problem](https://github.com/nao1215/gup/pull/42#issuecomment-1250061896)

In PR #42, unit tests for write permissions were added. However, this PR may occur error.
This error occurs because the error message for no write permission is different between macOS and Linux. Error messages returned by the code in the layer close to the system call are different between macOS and Linux.

Therefore, unit test did not check the error message. Instead, unit test check for the existence of the file (it's /.config).