### PR TITLE
Add test for gotuil.GetPackageVersion() function

### DIFF
--- a/internal/goutil/examples_test.go
+++ b/internal/goutil/examples_test.go
@@ -65,23 +65,27 @@ func ExampleGetLatestVer() {
 }
 
 func ExampleGetPackageInformation() {
-	pkgInfo := goutil.GetPackageInformation([]string{"../../cmd/testdata/check_success/gal"})
+	// Prepare the path of go binary module for the example
+	nameDirCheckSuccess := "check_success"
+	nameFileBin := "gal"
+
+	if runtime.GOOS == "windows" {
+		nameDirCheckSuccess = "check_success_for_windows"
+		nameFileBin = "gal.exe" // remember the extension
+	}
+
+	pathFileBin := filepath.Join("..", "..", "cmd", "testdata", nameDirCheckSuccess, nameFileBin)
+
+	pkgInfo := goutil.GetPackageInformation([]string{pathFileBin})
 	if pkgInfo == nil {
 		log.Fatal("example GetPackageInformation failed. The returned package information is nil")
 	}
 
 	// Expected package information on Linux and macOS
 	want := []string{
-		"gal",
+		nameFileBin,
 		"github.com/nao1215/gal/cmd/gal",
 		"github.com/nao1215/gal",
-	}
-
-	// On Windows, paths are missing
-	if runtime.GOOS == "windows" {
-		want = []string{
-			"gal", "", "",
-		}
 	}
 
 	// Actual package information
@@ -99,8 +103,9 @@ func ExampleGetPackageInformation() {
 	// Output: Example GetPackageInformation: OK
 }
 
-func ExampleGetPackageVersion() {
+func ExampleGetPackageVersion_unknown() {
 	// GetPackageVersion returns the version of the package installed via `go install`.
+	// In this example, we specify a package that is not installed.
 	got := goutil.GetPackageVersion("gup_dummy")
 
 	// Non existing binary returns "unknown"

--- a/internal/goutil/goutil_test.go
+++ b/internal/goutil/goutil_test.go
@@ -6,6 +6,7 @@ import (
 	"go/build"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -94,6 +95,39 @@ func TestGetPackageInformation_unknown_module(t *testing.T) {
 	got := tmpBuff.String()
 	if !strings.Contains(got, wantContain) {
 		t.Errorf("it should print error message '%v'. got: %v", wantContain, got)
+	}
+}
+
+func TestGetPackageVersion_golden(t *testing.T) {
+	// Backaup and defer restore
+	oldKeyGoBin := keyGoBin
+	defer func() {
+		keyGoBin = oldKeyGoBin
+	}()
+
+	// Prepare the path of go binary module for testing
+	nameDirCheckSuccess := "check_success"
+	nameFileBin := "gal"
+	want := "v1.1.1"
+
+	if runtime.GOOS == "windows" {
+		nameDirCheckSuccess = "check_success_for_windows"
+		nameFileBin = "gal.exe"
+		want = "(devel)"
+	}
+
+	pathDirBin := filepath.Join("..", "..", "cmd", "testdata", nameDirCheckSuccess)
+
+	// Mock the search directory path of go module binaries
+	t.Setenv("GOBINTMP", pathDirBin)
+	keyGoBin = "GOBINTMP"
+
+	// Get the package version of specified module
+	got := GetPackageVersion(nameFileBin)
+
+	// Require to get the expected version of go module binary
+	if want != got {
+		t.Fatalf("GetPackageVersion() should return %v. got: %v", want, got)
 	}
 }
 


### PR DESCRIPTION
This should bring the coverage back to 100%. Hopefully 🤞 

- Add test for `gotuil.GetPackageVersion()` function.
- Modification of the `gotuil.GetPackageInformation()` function example to make it clearer.
