### PR TITLE
Add completion subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,11 +129,11 @@ $ gup export --output > gup.conf
 $ gup import --input=gup.conf
 ```
 
-### Auto-generate shell completion file (for bash, zsh, fish)
-gup command automatically generates shell completion files for bash, zsh, and fish. After the user executes gup, if the shell completion file does not exist in the system, the auto-generation process will begin. To activate the completion feature, restart the shell.
+### Generate shell completion file (for bash, zsh, fish)
+completion subcommand generates shell completion files for bash, zsh, and fish. If the shell completion file does not exist in the system, the generation process will begin. To activate the completion feature, restart the shell.
 
 ```
-$ gup 
+$ gup completion
 gup:INFO : create bash-completion file: /home/nao/.bash_completion
 gup:INFO : create fish-completion file: /home/nao/.config/fish/completions/gup.fish
 gup:INFO : create zsh-completion file: /home/nao/.zsh/completion/_gup

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/nao1215/gup/internal/completion"
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:   "completion",
+	Short: "Create shell completion files (bash, fish, zsh) for the gup",
+	Long: `Create shell completion files (bash, fish, zsh) for the gup command
+if it is not already on the system`,
+	Run: func(cmd *cobra.Command, args []string) {
+		completion.DeployShellCompletionFileIfNeeded(rootCmd)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/nao1215/gup/internal/assets"
-	"github.com/nao1215/gup/internal/completion"
 	"github.com/nao1215/gup/internal/print"
 	"github.com/spf13/cobra"
 )
@@ -22,8 +21,6 @@ var OsExit = os.Exit
 // Execute run gup process.
 func Execute() {
 	assets.DeployIconIfNeeded()
-	completion.DeployShellCompletionFileIfNeeded(rootCmd)
-
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
 	if err := rootCmd.Execute(); err != nil {
 		print.Err(err)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/nao1215/gup/internal/cmdinfo"
 	"github.com/nao1215/gup/internal/config"
 	"github.com/nao1215/gup/internal/file"
 	"github.com/nao1215/gup/internal/goutil"
@@ -803,4 +804,26 @@ func TestExecute_Update_DryRun(t *testing.T) {
 	if !contain {
 		t.Errorf("failed to update posixer command")
 	}
+}
+
+func TestExecute_Completion(t *testing.T) {
+	t.Run("generate completion file", func(t *testing.T) {
+		os.Args = []string{"gup", "completion"}
+		Execute()
+
+		bash := filepath.Join(os.Getenv("HOME"), ".bash_completion")
+		if !file.IsFile(bash) {
+			t.Errorf("not generate %s", bash)
+		}
+
+		fish := filepath.Join(os.Getenv("HOME"), ".config", "fish", "completions", cmdinfo.Name+".fish")
+		if !file.IsFile(fish) {
+			t.Errorf("not generate %s", fish)
+		}
+
+		zsh := filepath.Join(os.Getenv("HOME"), ".zsh", "completion", "_"+cmdinfo.Name)
+		if !file.IsFile(zsh) {
+			t.Errorf("not generate %s", zsh)
+		}
+	})
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -812,18 +812,36 @@ func TestExecute_Completion(t *testing.T) {
 		Execute()
 
 		bash := filepath.Join(os.Getenv("HOME"), ".bash_completion")
-		if !file.IsFile(bash) {
-			t.Errorf("not generate %s", bash)
+		if runtime.GOOS == "windows" {
+			if file.IsFile(bash) {
+				t.Errorf("generate %s, however shell completion file is not generated on Windows", bash)
+			}
+		} else {
+			if !file.IsFile(bash) {
+				t.Errorf("failed to generate %s", bash)
+			}
 		}
 
 		fish := filepath.Join(os.Getenv("HOME"), ".config", "fish", "completions", cmdinfo.Name+".fish")
-		if !file.IsFile(fish) {
-			t.Errorf("not generate %s", fish)
+		if runtime.GOOS == "windows" {
+			if file.IsFile(fish) {
+				t.Errorf("generate %s, however shell completion file is not generated on Windows", fish)
+			}
+		} else {
+			if !file.IsFile(fish) {
+				t.Errorf("failed to generate %s", fish)
+			}
 		}
 
 		zsh := filepath.Join(os.Getenv("HOME"), ".zsh", "completion", "_"+cmdinfo.Name)
-		if !file.IsFile(zsh) {
-			t.Errorf("not generate %s", zsh)
+		if runtime.GOOS == "windows" {
+			if file.IsFile(zsh) {
+				t.Errorf("generate %s, however shell completion file is not generated on Windows", zsh)
+			}
+		} else {
+			if !file.IsFile(zsh) {
+				t.Errorf("failed to generate  %s", zsh)
+			}
 		}
 	})
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -517,16 +517,6 @@ func TestExecute_Import_WithInputOption(t *testing.T) {
 		}
 	}
 
-	defer func() {
-		os.RemoveAll(filepath.Join("testdata", ".config", "fish"))
-		os.RemoveAll(filepath.Join("testdata", ".zsh"))
-		os.RemoveAll(filepath.Join("testdata", ".zshrc"))
-		os.RemoveAll(filepath.Join("testdata", ".bash_completion"))
-		os.RemoveAll(filepath.Join("testdata", ".config", "gup", "assets"))
-		os.RemoveAll(filepath.Join("testdata", "go"))
-		os.RemoveAll(filepath.Join("testdata", ".cache"))
-	}()
-
 	orgStdout := print.Stdout
 	orgStderr := print.Stderr
 	pr, pw, err := os.Pipe()
@@ -687,16 +677,6 @@ func TestExecute_Update(t *testing.T) {
 		}
 	}
 
-	defer func() {
-		os.RemoveAll(filepath.Join("testdata", ".config", "fish"))
-		os.RemoveAll(filepath.Join("testdata", ".zsh"))
-		os.RemoveAll(filepath.Join("testdata", ".zshrc"))
-		os.RemoveAll(filepath.Join("testdata", ".bash_completion"))
-		os.RemoveAll(filepath.Join("testdata", ".config", "gup", "assets"))
-		os.RemoveAll(filepath.Join("testdata", "go"))
-		os.RemoveAll(filepath.Join("testdata", ".cache"))
-	}()
-
 	orgStdout := print.Stdout
 	orgStderr := print.Stderr
 	pr, pw, err := os.Pipe()
@@ -790,16 +770,6 @@ func TestExecute_Update_DryRun(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-
-	defer func() {
-		os.RemoveAll(filepath.Join("testdata", ".config", "fish"))
-		os.RemoveAll(filepath.Join("testdata", ".zsh"))
-		os.RemoveAll(filepath.Join("testdata", ".zshrc"))
-		os.RemoveAll(filepath.Join("testdata", ".bash_completion"))
-		os.RemoveAll(filepath.Join("testdata", ".config", "gup", "assets"))
-		os.RemoveAll(filepath.Join("testdata", "go"))
-		os.RemoveAll(filepath.Join("testdata", ".cache"))
-	}()
 
 	orgStdout := print.Stdout
 	orgStderr := print.Stderr


### PR DESCRIPTION
This PR is for https://github.com/nao1215/gup/issues/28.

There are two problems with the automatic creation of shell completion files:
1. the creation of shell completion files without the user's permission may cause discomfort to the user
2. the deletion process is necessary because a shell completion file is created each time the root command is unit tested.

gup is designed to automatically create shell completion files to reduce user work. Therefore, the completion subcommand (default) of the cobra library is not used. Also, PowerShell support will be implemented as soon as possible.

@Akimon658 
Although you may not already use the original gup, I report to you. 