### PR TITLE
Issue #72: Change bash completion file path

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -770,7 +770,7 @@ func TestExecute_Completion(t *testing.T) {
 		os.Args = []string{"gup", "completion"}
 		Execute()
 
-		bash := filepath.Join(os.Getenv("HOME"), ".bash_completion")
+		bash := filepath.Join(os.Getenv("HOME"), ".bash_completions.d", cmdinfo.Name)
 		if runtime.GOOS == "windows" {
 			if file.IsFile(bash) {
 				t.Errorf("generate %s, however shell completion file is not generated on Windows", bash)

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -60,7 +60,6 @@ func makeBashCompletionFileIfNeeded(cmd *cobra.Command) {
 
 	if err := fp.Close(); err != nil {
 		print.Err(fmt.Errorf("can not close .bash_completion %w", err))
-		return
 	}
 	return
 }

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -41,40 +41,28 @@ func makeBashCompletionFileIfNeeded(cmd *cobra.Command) {
 		return
 	}
 
-	if !file.IsFile(path) {
-		fp, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0664)
-		if err != nil {
-			print.Err(fmt.Errorf("can not open .bash_completion: %w", err))
+	if !file.IsDir(path) {
+		if err := os.MkdirAll(filepath.Dir(path), 0775); err != nil {
+			print.Err(fmt.Errorf("can not create bash-completion file: %w", err))
 			return
 		}
-
-		if _, err := fp.WriteString(bashCompletion.String()); err != nil {
-			print.Err(fmt.Errorf("can not write .bash_completion %w", err))
-			return
-		}
-
-		if err := fp.Close(); err != nil {
-			print.Err(fmt.Errorf("can not close .bash_completion %w", err))
-			return
-		}
-		return
 	}
-
-	fp, err := os.OpenFile(path, os.O_RDWR|os.O_APPEND, 0664)
+	fp, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0664)
 	if err != nil {
 		print.Err(fmt.Errorf("can not open .bash_completion: %w", err))
 		return
 	}
 
 	if _, err := fp.WriteString(bashCompletion.String()); err != nil {
-		print.Err(fmt.Errorf("can not append .bash_completion: %w", err))
+		print.Err(fmt.Errorf("can not write .bash_completion %w", err))
 		return
 	}
 
 	if err := fp.Close(); err != nil {
-		print.Err(fmt.Errorf("can not close .bash_completion: %w", err))
+		print.Err(fmt.Errorf("can not close .bash_completion %w", err))
 		return
 	}
+	return
 }
 
 func makeFishCompletionFileIfNeeded(cmd *cobra.Command) {
@@ -235,7 +223,7 @@ func isSameZshCompletionFile(cmd *cobra.Command) bool {
 
 // bashCompletionFilePath return bash-completion file path.
 func bashCompletionFilePath() string {
-	return filepath.Join(os.Getenv("HOME"), ".bash_completion")
+	return filepath.Join(os.Getenv("HOME"), ".bash_completions.d", cmdinfo.Name)
 }
 
 // fishCompletionFilePath return fish-completion file path.


### PR DESCRIPTION
Now, gup generates bash completion files in `~/.bash_completion`.
However, `~/.bash_completion` is a file containing the configuration for multiple commands and is not suitable for automatic writing by gup.

Therefore, we will change the specification to generate a gup-specific completion file in `~/.bash_completions.d/gup`. We believe that if the files are generated in this path, there is no need for a specification that allows the user to select the path where the files are generated.