### PR TITLE
fix: Use canonical name for bash_completion.d

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -770,7 +770,7 @@ func TestExecute_Completion(t *testing.T) {
 		os.Args = []string{"gup", "completion"}
 		Execute()
 
-		bash := filepath.Join(os.Getenv("HOME"), ".bash_completions.d", cmdinfo.Name)
+		bash := filepath.Join(os.Getenv("HOME"), ".bash_completion.d", cmdinfo.Name)
 		if runtime.GOOS == "windows" {
 			if file.IsFile(bash) {
 				t.Errorf("generate %s, however shell completion file is not generated on Windows", bash)

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -222,7 +222,7 @@ func isSameZshCompletionFile(cmd *cobra.Command) bool {
 
 // bashCompletionFilePath return bash-completion file path.
 func bashCompletionFilePath() string {
-	return filepath.Join(os.Getenv("HOME"), ".bash_completions.d", cmdinfo.Name)
+	return filepath.Join(os.Getenv("HOME"), ".bash_completion.d", cmdinfo.Name)
 }
 
 // fishCompletionFilePath return fish-completion file path.


### PR DESCRIPTION
the canonical name for the bash_completion.d directory is the singular form.
