### PR TITLE
Add default openBrowser function

### DIFF
--- a/cmd/bug_report_nobrowser.go
+++ b/cmd/bug_report_nobrowser.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !linux && !windows
+
+package cmd
+
+func openBrowser(string) bool {
+	return false
+}


### PR DESCRIPTION
All platforms other than Darwin, Linux, and Windows fail to build gup due to a missing openBrowser function.
This commit adds a default openBrowser function for those other systems to allow gup to build on other platforms like the BSDs, directing users to open the bug report URL in their preferred browser as intended.