### PR TITLE
chore: improve windows ux

### DIFF
--- a/cmd/bug_report_windows.go
+++ b/cmd/bug_report_windows.go
@@ -7,5 +7,5 @@ import (
 )
 
 func openBrowser(targetURL string) bool {
-	return exec.Command("cmd", "/C", "start", "msedge", targetURL).Start() == nil
+	return exec.Command("rundll32.exe", "url,OpenURL", targetURL).Start() == nil
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"runtime"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -261,10 +262,25 @@ func extractUserSpecifyPkg(pkgs []goutil.Package, targets []string) []goutil.Pac
 	if len(targets) == 0 {
 		return pkgs
 	}
+
+	if runtime.GOOS == "windows" {
+		for i, target := range targets {
+			if strings.HasSuffix(strings.ToLower(target), ".exe") {
+				targets[i] = target[:len(target)-4]
+			}
+		}
+	}
+
 	for _, v := range pkgs {
-		if slices.Contains(targets, v.Name) {
+		pkg := v.Name
+		if runtime.GOOS == "windows" {
+			if strings.HasSuffix(strings.ToLower(pkg), ".exe") {
+				pkg = pkg[:len(pkg)-4]
+			}
+		}
+		if slices.Contains(targets, pkg) {
 			result = append(result, v)
-			tmp = append(tmp, v.Name)
+			tmp = append(tmp, pkg)
 		}
 	}
 


### PR DESCRIPTION
gup requires you to type the full binary name under Windows, which is a little annoying.
At first, I thought it was an issue with GOPATH.

```
> gup update buf
gup:WARN : not found 'buf' package in $GOPATH/bin or $GOBIN
gup:ERROR: unable to update package: no package information or no package under $GOBIN
```

```
> gup update buf.exe
gup:INFO : update binary under $GOPATH/bin or $GOBIN
gup:INFO : [1/1] github.com/bufbuild/buf/cmd/buf (Already up-to-date: v1.27.0)
```

This PR:
- Improves bug-report command: launch in default browser instead of forcing msedge.
- Makes possible to use `gup update buf`, `gup update buf.exe` and even mix syntaxes:
```powershell
.\gup.exe update buf.exe goreleaser
gup:INFO : update binary under $GOPATH/bin or $GOBIN
gup:INFO : [1/2] github.com/bufbuild/buf/cmd/buf (Already up-to-date: v1.27.0)
gup:INFO : [2/2] github.com/goreleaser/goreleaser (Already up-to-date: v1.21.2)
```