### PR TITLE
Get `GOPATH` with `go env`

### DIFF
--- a/internal/goutil/goutil.go
+++ b/internal/goutil/goutil.go
@@ -244,6 +244,10 @@ func goPath() string {
 	if gopath != "" {
 		return gopath
 	}
+	out, err := exec.Command(goExe, "env", keyGoPath).Output()
+	if err == nil {
+		return strings.TrimSpace(string(out))
+	}
 	return build.Default.GOPATH
 }
 

--- a/internal/goutil/goutil_test.go
+++ b/internal/goutil/goutil_test.go
@@ -3,7 +3,6 @@ package goutil
 import (
 	"bytes"
 	"errors"
-	"go/build"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -135,13 +134,13 @@ func TestGetPackageVersion_getting_error_from_gobin(t *testing.T) {
 	t.Setenv("GOPATH", "")
 
 	// Backup and defer restore
-	oldBuildDefaultGOPATH := build.Default.GOPATH
+	oldKeyGoPath := keyGoPath
 	defer func() {
-		build.Default.GOPATH = oldBuildDefaultGOPATH
+		keyGoPath = oldKeyGoPath
 	}()
 
 	// Mock the value
-	build.Default.GOPATH = ""
+	keyGoPath = t.Name()
 
 	// Setting GOBIN, GOPATH and build.Default.GOPATH to empty string
 	// should be an error internally and return "unknown" as a version.
@@ -179,13 +178,13 @@ func TestGoBin_gobin_and_gopath_is_empty(t *testing.T) {
 	t.Setenv("GOPATH", "")
 
 	// Backup and defer restore
-	oldBuildDefaultGOPATH := build.Default.GOPATH
+	oldKeyGoPath := keyGoPath
 	defer func() {
-		build.Default.GOPATH = oldBuildDefaultGOPATH
+		keyGoPath = oldKeyGoPath
 	}()
 
 	// Mock the value
-	build.Default.GOPATH = ""
+	keyGoPath = t.Name()
 
 	wantContain := "$GOPATH is not set"
 	result, got := GoBin()
@@ -221,25 +220,6 @@ func TestGoBin_golden(t *testing.T) {
 	// Assert to be equal
 	if want != got {
 		t.Errorf("GoBin() should return %v. got: %v", want, got)
-	}
-}
-
-func Test_goPath_get_from_build_default_gopath(t *testing.T) {
-	// Backup and defer restore
-	oldKeyGoPath := keyGoPath
-	defer func() {
-		keyGoPath = oldKeyGoPath
-	}()
-
-	// Mock the private global variable.
-	// os.Getenv() in the goPath() shuld return empty since it doesn't exist.
-	keyGoPath = t.Name()
-
-	// Assert to be equal
-	want := build.Default.GOPATH
-	got := goPath()
-	if want != got {
-		t.Errorf("goPath() should return default GOPATH. got: %v, want: %v", got, want)
 	}
 }
 


### PR DESCRIPTION
https://github.com/golang/go/blob/35b1a146d9febca70db87dc4e1f8bac33de857bb/src/go/build/build.go#L289-L306

`build.Default.GOPATH` is hard-coded `~/go` while I use a custom `GOPATH` in `~/.config/go/env` managed by `go env`.

I don't tend to test `goPath` because `~/.config/go/env` could be read or written by other programs during the test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Removed unused imports and tests to clean up the codebase.
- **New Features**
	- Enhanced the method to retrieve GOPATH, ensuring functionality even when GOPATH is not explicitly set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->