### PR TITLE
Drop go 1.18, support go 1.19 to 1.22

### DIFF
--- a/.github/workflows/multi_ver_unittest.yml
+++ b/.github/workflows/multi_ver_unittest.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.18", "1.20"]
+        go-version: ["1.19", "1.22"]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go ${{ matrix.go-version }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nao1215/gup
 
-go 1.18
+go 1.19
 
 require (
 	github.com/adrg/xdg v0.4.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Go versions in the workflow for enhanced compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->