### PR TITLE
Polishing

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -55,6 +55,6 @@ func printPackageList(pkgs []goutil.Package) {
 		fmt.Fprintf(print.Stdout, "%"+strconv.Itoa(max)+"s: %s%s\n",
 			v.Name,
 			v.ImportPath,
-			color.GreenString("@"+goutil.GetPackageVersion(v.Name)))
+			color.GreenString("@"+v.Version.Current))
 	}
 }

--- a/internal/goutil/goutil.go
+++ b/internal/goutil/goutil.go
@@ -66,11 +66,6 @@ func NewVersion() *Version {
 	}
 }
 
-// SetCurrentVer set package current version.
-func (p *Package) SetCurrentVer() {
-	p.Version.Current = GetPackageVersion(p.Name)
-}
-
 // SetLatestVer set package latest version.
 func (p *Package) SetLatestVer() {
 	p.Version.Latest = GetPackageVersion(p.Name)
@@ -174,9 +169,7 @@ func (gp *GoPaths) EndDryRunMode() error {
 // removeTmpDir remove tmporary directory for dry run
 func (gp *GoPaths) removeTmpDir() error {
 	if gp.TmpPath != "" {
-		if err := os.RemoveAll(gp.TmpPath); err != nil {
-			return err
-		}
+		return os.RemoveAll(gp.TmpPath)
 	}
 	return nil
 }
@@ -307,7 +300,7 @@ func GetPackageInformation(binList []string) []Package {
 			ModulePath: info.Main.Path,
 			Version:    NewVersion(),
 		}
-		pkg.SetCurrentVer()
+		pkg.Version.Current = info.Main.Version
 		pkgs = append(pkgs, pkg)
 	}
 	return pkgs


### PR DESCRIPTION
Just found that spawning `go env` for each package is too expensive. We don't need to do that now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Refactor**
	- Improved package version retrieval and display process.
	- Simplified temporary directory removal process.
	- Streamlined package information retrieval with updated version setting method.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->