### PR TITLE
Add ability to output completions to stdout

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/nao1215/gup/internal/completion"
 	"github.com/spf13/cobra"
 )
@@ -8,11 +11,28 @@ import (
 func newCompletionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "completion",
-		Short: "Create shell completion files (bash, fish, zsh) for the gup",
-		Long: `Create shell completion files (bash, fish, zsh) for the gup command
-if it is not already on the system`,
-		Run: func(cmd *cobra.Command, args []string) {
-			completion.DeployShellCompletionFileIfNeeded(newRootCmd())
+		Short: "Generate shell completions (bash, fish, zsh) for gup",
+		Long: `Generate shell completions (bash, fish, zsh) for the gup command.
+With no arguments, generate files to the file system if they are not already there,
+with shell name as argument, output completion for the shell to standard output.`,
+		Args:      cobra.MatchAll(cobra.MaximumNArgs(1), cobra.OnlyValidArgs),
+		ValidArgs: []string{"bash", "fish", "zsh"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rootCmd := newRootCmd()
+			if len(args) == 0 {
+				completion.DeployShellCompletionFileIfNeeded(rootCmd)
+				return nil
+			}
+			switch args[0] {
+			case "bash":
+				return rootCmd.GenBashCompletion(os.Stdout)
+			case "fish":
+				return rootCmd.GenFishCompletion(os.Stdout, false)
+			case "zsh":
+				return rootCmd.GenZshCompletion(os.Stdout)
+			default:
+				return fmt.Errorf("internal error, should not happen with arg %q", args[0])
+			}
 		},
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,11 +51,12 @@ oh-my-zsh alias is disabled (e.g. $ \gup update).
 }
 
 // Execute run gup process.
-func Execute() {
+func Execute() (err error) {
 	assets.DeployIconIfNeeded()
 	rootCmd := newRootCmd()
 
-	if err := rootCmd.Execute(); err != nil {
+	if err = rootCmd.Execute(); err != nil {
 		print.Err(err)
 	}
+	return
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,7 +50,7 @@ oh-my-zsh alias is disabled (e.g. $ \gup update).
 }
 
 // Execute run gup process.
-func Execute() (err error) {
+func Execute() error {
 	assets.DeployIconIfNeeded()
 	rootCmd := newRootCmd()
 	return rootCmd.Execute()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/nao1215/gup/internal/assets"
 	"github.com/nao1215/gup/internal/completion"
-	"github.com/nao1215/gup/internal/print"
 	"github.com/spf13/cobra"
 )
 
@@ -54,9 +53,5 @@ oh-my-zsh alias is disabled (e.g. $ \gup update).
 func Execute() (err error) {
 	assets.DeployIconIfNeeded()
 	rootCmd := newRootCmd()
-
-	if err = rootCmd.Execute(); err != nil {
-		print.Err(err)
-	}
-	return
+	return rootCmd.Execute()
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -41,7 +41,7 @@ func TestExecute(t *testing.T) {
 			err := Execute()
 			gotErr := err != nil
 			if tt.wantErr != gotErr {
-				t.Errorf("expected error return %v, got %v", tt.wantErr, gotErr)
+				t.Errorf("expected error return %v, got %v: %v", tt.wantErr, gotErr, err)
 			}
 		})
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -20,22 +20,29 @@ import (
 
 func TestExecute(t *testing.T) {
 	tests := []struct {
-		name string
-		args []string
+		name    string
+		args    []string
+		wantErr bool
 	}{
 		{
-			name: "success",
-			args: []string{""},
+			name:    "success",
+			args:    []string{""},
+			wantErr: false,
 		},
 		{
-			name: "fail",
-			args: []string{"no-exist-subcommand", "--no-exist-option"},
+			name:    "fail",
+			args:    []string{"no-exist-subcommand", "--no-exist-option"},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		os.Args = tt.args
 		t.Run(tt.name, func(t *testing.T) {
-			Execute()
+			err := Execute()
+			gotErr := err != nil
+			if tt.wantErr != gotErr {
+				t.Errorf("expected error return %v, got %v", tt.wantErr, gotErr)
+			}
 		})
 	}
 }
@@ -64,10 +71,13 @@ func TestExecute_Check(t *testing.T) {
 	}()
 
 	os.Args = []string{"gup", "check"}
-	Execute()
+	err = Execute()
 	pw.Close()
 	print.Stdout = orgStdout
 	print.Stderr = orgStderr
+	if err != nil {
+		t.Error(err)
+	}
 
 	buf := bytes.Buffer{}
 	_, err = io.Copy(&buf, pr)
@@ -109,11 +119,14 @@ func TestExecute_Version(t *testing.T) {
 
 		os.Args = tt.args
 		t.Run(tt.name, func(t *testing.T) {
-			Execute()
+			err = Execute()
 		})
 		pw.Close()
 		os.Stdout = orgStdout
 		os.Stderr = orgStderr
+		if err != nil {
+			t.Error(err)
+		}
 
 		buf := bytes.Buffer{}
 		_, err = io.Copy(&buf, pr)
@@ -182,11 +195,14 @@ func TestExecute_List(t *testing.T) {
 
 		os.Args = tt.args
 		t.Run(tt.name, func(t *testing.T) {
-			Execute()
+			err = Execute()
 		})
 		pw.Close()
 		print.Stdout = orgStdout
 		print.Stderr = orgStderr
+		if err != nil {
+			t.Error(err)
+		}
 
 		buf := bytes.Buffer{}
 		_, err = io.Copy(&buf, pr)
@@ -286,7 +302,9 @@ func TestExecute_Remove_Force(t *testing.T) {
 
 		os.Args = tt.args
 		t.Run(tt.name, func(t *testing.T) {
-			Execute()
+			if err := Execute(); err != nil {
+				t.Error(err)
+			}
 		})
 
 		if file.IsFile(filepath.Join(dest)) {
@@ -359,7 +377,9 @@ subaru = github.com/nao1215/subaru
 
 		os.Args = tt.args
 		t.Run(tt.name, func(t *testing.T) {
-			Execute()
+			if err := Execute(); err != nil {
+				t.Error(err)
+			}
 		})
 
 		if !file.IsFile(config.FilePath()) {
@@ -429,11 +449,14 @@ func TestExecute_Export_WithOutputOption(t *testing.T) {
 
 		os.Args = tt.args
 		t.Run(tt.name, func(t *testing.T) {
-			Execute()
+			err = Execute()
 		})
 		pw.Close()
 		os.Stdout = orgStdout
 		os.Stderr = orgStderr
+		if err != nil {
+			t.Error(err)
+		}
 
 		buf := bytes.Buffer{}
 		_, err = io.Copy(&buf, pr)
@@ -491,11 +514,14 @@ func TestExecute_Import_WithInputOption(t *testing.T) {
 		confFile = "testdata/gup_config/windows.conf"
 	}
 	os.Args = []string{"gup", "import", "-i", confFile}
-	Execute()
+	err = Execute()
 
 	pw.Close()
 	print.Stdout = orgStdout
 	print.Stderr = orgStderr
+	if err != nil {
+		t.Error(err)
+	}
 
 	buf := bytes.Buffer{}
 	_, err = io.Copy(&buf, pr)
@@ -557,11 +583,14 @@ func TestExecute_Import_WithBadInputFile(t *testing.T) {
 			print.Stderr = pw
 
 			os.Args = []string{"gup", "import", "-i", tt.inputFile}
-			Execute()
+			err = Execute()
 
 			pw.Close()
 			print.Stdout = orgStdout
 			print.Stderr = orgStderr
+			if err != nil {
+				t.Error(err)
+			}
 
 			buf := bytes.Buffer{}
 			_, err = io.Copy(&buf, pr)
@@ -647,10 +676,13 @@ func TestExecute_Update(t *testing.T) {
 	print.Stderr = pw
 
 	os.Args = []string{"gup", "update"}
-	Execute()
+	err = Execute()
 	pw.Close()
 	print.Stdout = orgStdout
 	print.Stderr = orgStderr
+	if err != nil {
+		t.Error(err)
+	}
 
 	buf := bytes.Buffer{}
 	_, err = io.Copy(&buf, pr)
@@ -741,10 +773,13 @@ func TestExecute_Update_DryRunAndNotify(t *testing.T) {
 	print.Stderr = pw
 
 	os.Args = []string{"gup", "update", "--dry-run", "--notify"}
-	Execute()
+	err = Execute()
 	pw.Close()
 	print.Stdout = orgStdout
 	print.Stderr = orgStderr
+	if err != nil {
+		t.Error(err)
+	}
 
 	buf := bytes.Buffer{}
 	_, err = io.Copy(&buf, pr)
@@ -768,7 +803,9 @@ func TestExecute_Update_DryRunAndNotify(t *testing.T) {
 func TestExecute_Completion(t *testing.T) {
 	t.Run("generate completion file", func(t *testing.T) {
 		os.Args = []string{"gup", "completion"}
-		Execute()
+		if err := Execute(); err != nil {
+			t.Error(err)
+		}
 
 		bash := filepath.Join(os.Getenv("HOME"), ".bash_completion.d", cmdinfo.Name)
 		if runtime.GOOS == "windows" {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -841,3 +841,66 @@ func TestExecute_Completion(t *testing.T) {
 		}
 	})
 }
+
+func TestExecute_CompletionForShell(t *testing.T) {
+	tests := []struct {
+		shell      string
+		wantOutput bool
+		wantErr    bool
+	}{
+		{
+			shell:      "bash",
+			wantOutput: true,
+			wantErr:    false,
+		},
+		{
+			shell:      "fish",
+			wantOutput: true,
+			wantErr:    false,
+		},
+		{
+			shell:      "zsh",
+			wantOutput: true,
+			wantErr:    false,
+		},
+		{
+			shell:      "unknown-shell",
+			wantOutput: false,
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.shell, func(t *testing.T) {
+			orgStdout := os.Stdout
+			orgStderr := os.Stderr
+			pr, pw, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			os.Stdout = pw
+			os.Stderr = pw
+
+			os.Args = []string{"gup", "completion", tt.shell}
+			err = Execute()
+			pw.Close()
+			os.Stdout = orgStdout
+			os.Stderr = orgStderr
+
+			gotErr := err != nil
+			if tt.wantErr != gotErr {
+				t.Errorf("expected error return %v, got %v", tt.wantErr, gotErr)
+			}
+
+			buf := bytes.Buffer{}
+			_, err = io.Copy(&buf, pr)
+			t.Cleanup(func() { pr.Close() })
+			if err != nil {
+				t.Error(err)
+			}
+			gotOutput := buf.Len() != 0
+			if tt.wantOutput != gotOutput {
+				t.Errorf("expected output %v, got %v", tt.wantOutput, gotOutput)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -3,5 +3,5 @@ package main
 import "github.com/nao1215/gup/cmd"
 
 func main() {
-	cmd.Execute()
+	_ = cmd.Execute()
 }

--- a/main.go
+++ b/main.go
@@ -1,7 +1,12 @@
 package main
 
-import "github.com/nao1215/gup/cmd"
+import (
+	"github.com/nao1215/gup/cmd"
+	"github.com/nao1215/gup/internal/print"
+)
 
 func main() {
-	_ = cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		print.Err(err)
+	}
 }


### PR DESCRIPTION
This is so that e.g. a bash dynamic completion loader can be set up to generate the completion on demand from the invoked gup executable, instead of user having to update completions between gup versions.

When this is in, I'll ad such a loader to [bash-completion](https://github.com/scop/bash-completion/), see e.g. https://github.com/scop/bash-completion/blob/master/completions/_golangci-lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Modified error handling in the `Execute` function to improve clarity and avoid variable shadowing.
	- Updated error handling in test functions for better reporting and comparison with `wantErr`.

- **Chores**
	- Adjusted assignment in the `main` function to enhance error handling and avoid unnecessary variable usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->