### PR TITLE
Update bash completion path

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -770,7 +770,7 @@ func TestExecute_Completion(t *testing.T) {
 		os.Args = []string{"gup", "completion"}
 		Execute()
 
-		bash := filepath.Join(os.Getenv("HOME"), ".bash_completion.d", cmdinfo.Name)
+		bash := filepath.Join(os.Getenv("HOME"), ".local", "share", "bash-completion", "completions", cmdinfo.Name)
 		if runtime.GOOS == "windows" {
 			if file.IsFile(bash) {
 				t.Errorf("generate %s, however shell completion file is not generated on Windows", bash)

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -222,7 +222,7 @@ func isSameZshCompletionFile(cmd *cobra.Command) bool {
 
 // bashCompletionFilePath return bash-completion file path.
 func bashCompletionFilePath() string {
-	return filepath.Join(os.Getenv("HOME"), ".bash_completion.d", cmdinfo.Name)
+	return filepath.Join(os.Getenv("HOME"), ".local", "share", "bash-completion", "completions", cmdinfo.Name)
 }
 
 // fishCompletionFilePath return fish-completion file path.


### PR DESCRIPTION
~/.local/share/bash-completion/completions is the path from where current bash-completion loads user completions on demand.

Ref https://github.com/scop/bash-completion/blob/23b8144d88451f31cb01cb59f3dcd4b787069f1c/bash_completion#L3164-L3171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
    - Enhanced compatibility with standard directory structures for bash completion file path generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->