### PR TITLE
Generate cobra's v2 bash completions

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -25,7 +25,7 @@ with shell name as argument, output completion for the shell to standard output.
 			}
 			switch args[0] {
 			case "bash":
-				return rootCmd.GenBashCompletion(os.Stdout)
+				return rootCmd.GenBashCompletionV2(os.Stdout, false)
 			case "fish":
 				return rootCmd.GenFishCompletion(os.Stdout, false)
 			case "zsh":

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -36,7 +36,7 @@ func makeBashCompletionFileIfNeeded(cmd *cobra.Command) {
 
 	path := bashCompletionFilePath()
 	bashCompletion := new(bytes.Buffer)
-	if err := cmd.GenBashCompletion(bashCompletion); err != nil {
+	if err := cmd.GenBashCompletionV2(bashCompletion, false); err != nil {
 		print.Err(fmt.Errorf("can not generate bash completion content: %w", err))
 		return
 	}
@@ -167,7 +167,7 @@ func hasSameBashCompletionContent(cmd *cobra.Command) bool {
 	}
 
 	currentBashCompletion := new(bytes.Buffer)
-	if err := cmd.GenBashCompletion(currentBashCompletion); err != nil {
+	if err := cmd.GenBashCompletionV2(currentBashCompletion, false); err != nil {
 		return false
 	}
 	if !strings.Contains(string(bashCompletionFileInLocal), currentBashCompletion.String()) {


### PR DESCRIPTION
Inhibiting descriptions for consistency with fish completions.

Ref https://github.com/spf13/cobra/blob/main/site/content/completions/_index.md#bash-completion-v2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated shell completion generation to use the latest version for improved command-line experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->