### PR TITLE
Auto generate homebrew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,3 +25,4 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,5 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 gup
-dist/
+dist
 cover.html

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,3 +39,11 @@ nfpms:
       - deb
       - rpm
       - apk
+brews:
+  - name: gup
+    description: gup - Update binaries installed by "go install"
+    license: Apache License 2.0
+    repository:
+      owner: nao1215
+      name: homebrew-tap
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -32,13 +32,12 @@ If you are using oh-my-zsh, then gup has an alias set up. The alias is `gup - gi
 ### Use "go install"
 If you does not have the golang development environment installed on your system, please install golang from the [golang official website](https://go.dev/doc/install).
 ```
-$ go install github.com/nao1215/gup@latest
+go install github.com/nao1215/gup@latest
 ```
 
-### For Mac user
-```
-$ brew tap nao1215/tap
-$ brew install nao1215/tap/gup
+### Use homebrew
+```shell
+brew install nao1215/tap/gup
 ```
 
 ### Install from Package or Binary


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new package `gup` to Homebrew for easier installation on Mac.
- **Documentation**
	- Updated installation instructions for the `gup` tool to use Homebrew on Mac.
- **Chores**
	- Updated GitHub Actions workflow to include a new environment variable.
	- Modified `.gitignore` to correctly handle the exclusion of the `dist` directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->