### PR TITLE
[BUG FIX]  The auto generated homebrew tap contains extra double quotation.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,7 +32,7 @@ changelog:
       - "^test:"
 nfpms:
   - maintainer: Naohiro CHIKAMATSU <n.chika156@gmail.com>
-    description: gup - Update binaries installed by "go install"
+    description: gup - Update binaries installed by 'go install'
     homepage: https://github.com/nao1215/gup
     license: Apache License 2.0
     formats:
@@ -41,7 +41,7 @@ nfpms:
       - apk
 brews:
   - name: gup
-    description: gup - Update binaries installed by "go install"
+    description: gup - Update binaries installed by 'go install'
     license: Apache License 2.0
     repository:
       owner: nao1215


### PR DESCRIPTION
Fix [this problem](https://github.com/nao1215/gup/commit/c2a69629bc868f0bc317acb49009a935e272a3b0#r142268292).

>The [template](https://github.com/goreleaser/goreleaser/blob/main/internal/pipe/brew/templates/cask.rb) which goreleaser is using passes this as-is, adding surrounding double-quotes. Since the Homebrew formula is just a Ruby DSL, the strings need to be quoted, as such, with your double quotes, you will get a failure per:

>Error: nao1215/tap/gup: /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/nao1215/homebrew-tap/gup.rb:6: syntax error, unexpected local variable or method, expecting `end' or dummy end

I was able to reproduce it on my local machine as well.

```shell
$ brew install gup
==> Auto-updating Homebrew...
Adjust how often this is run with HOMEBREW_AUTO_UPDATE_SECS or disable with
HOMEBREW_NO_AUTO_UPDATE. Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).

Error: nao1215/tap/gup: /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/nao1215/homebrew-tap/gup.rb:6: syntax error, unexpected local variable or method, expecting `end' or dummy end
...pdate binaries installed by "go install""

```