### PR TITLE
Fix: check sub command print incorrect path.

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -118,7 +118,7 @@ func doCheck(pkgs []goutil.Package, cpus int) int {
 		v := <-ch
 		if v.err == nil {
 			print.Info(fmt.Sprintf(countFmt+" %s (%s)",
-				i+1, len(pkgs), v.pkg.ModulePath, v.pkg.VersionCheckResultStr()))
+				i+1, len(pkgs), v.pkg.ImportPath, v.pkg.VersionCheckResultStr()))
 		} else {
 			result = 1
 			print.Err(fmt.Errorf(countFmt+"%s", i+1, len(pkgs), v.err.Error()))


### PR DESCRIPTION
Closes #171

The check sub command was outputting module paths when it should have been outputting import paths.

Before fix:
```shell
[13/85] golang.org/x/tools (current: v0.16.1, latest: v0.25.0 / go1.23.0)
```

After fix:
```shell
[ 6/85] golang.org/x/tools/cmd/deadcode (v0.16.1 to v0.25.0)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated output to display the import path of the package instead of the module path during checks, enhancing clarity for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->