### PR TITLE
Support go 1.24 or later

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -20,7 +20,6 @@ jobs:
         go:
           - "1"
           - "1.24"
-          - "1.23"
       fail-fast: false
     runs-on: ${{ matrix.os }}
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,39 +1,26 @@
+version: "2"
 run:
   go: "1.20"
-
-issues:
-  exclude-use-default: false
-
 linters:
-  disable-all: true
+  default: none
   enable:
-    - deadcode
-    - errcheck
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
-    - structcheck
-    - typecheck
-    - unused
-    - varcheck
     - asciicheck
     - bodyclose
     - dogsled
     - durationcheck
+    - errcheck
     - errorlint
     - exhaustive
-    - exportloopref
     - forcetypeassert
     - gochecknoglobals
     - gochecknoinits
     - goconst
     - gocritic
-    - goimports
-    - gomnd
     - gosec
-    - ifshort
+    - govet
+    - ineffassign
     - misspell
+    - mnd
     - nakedret
     - noctx
     - nolintlint
@@ -41,16 +28,32 @@ linters:
     - prealloc
     - rowserrcheck
     - sqlclosecheck
-    - stylecheck
+    - staticcheck
     - tagliatelle
     - thelper
     - unconvert
     - unparam
+    - unused
     - wastedassign
     - whitespace
-linters-settings:
-  tagliatelle:
-    case:
-      use-field-name: true
-      rules:
-        json: snake
+  settings:
+    tagliatelle:
+      case:
+        rules:
+          json: snake
+        use-field-name: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -383,7 +383,7 @@ subaru = github.com/nao1215/subaru
 		})
 
 		if !file.IsFile(config.FilePath()) {
-			t.Errorf(config.FilePath() + " does not exist. failed to generate")
+			t.Error(config.FilePath() + " does not exist. failed to generate")
 			continue
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/nao1215/gup
 
-go 1.23.0
-
-toolchain go1.24.0
+go 1.24.0
 
 require (
 	github.com/adrg/xdg v0.5.3
@@ -16,7 +14,7 @@ require (
 	github.com/shogo82148/pointer v1.3.0
 	github.com/spf13/cobra v1.9.1
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
-	golang.org/x/sync v0.12.0
+	golang.org/x/sync v0.13.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/tadvi/systray v0.0.0-20190226123456-11a2b8fa57af h1:6yITBqGTE2lEeTPG0
 github.com/tadvi/systray v0.0.0-20190226123456-11a2b8fa57af/go.mod h1:4F09kP5F+am0jAwlQLddpoMDM+iewkxxt6nxUQ5nq5o=
 golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
 golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
-golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
-golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/sync v0.13.0 h1:AauUjRAJ9OSnvULf/ARrrVywoJDy0YS2AwQ98I37610=
+golang.org/x/sync v0.13.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Go module to version 1.24.0 and upgraded a dependency.
  - Adjusted GitHub Actions workflow to test only against Go versions 1 (latest) and 1.24.
  - Revised linting configuration with updated linters, improved exclusions, and new formatting rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->