### PR TITLE
Trim potential GOEXPERIMENT flag in buildinfo

### DIFF
--- a/internal/goutil/goutil.go
+++ b/internal/goutil/goutil.go
@@ -131,11 +131,11 @@ func (p *Package) IsAlreadyUpToDate() bool {
 	}
 
 	return versionUpToDate(
-		strings.TrimLeft(p.Version.Current, "v"),
-		strings.TrimLeft(p.Version.Latest, "v"),
+		strings.TrimPrefix(p.Version.Current, "v"),
+		strings.TrimPrefix(p.Version.Latest, "v"),
 	) && versionUpToDate(
-		strings.TrimLeft(p.GoVersion.Current, "go"),
-		strings.TrimLeft(p.GoVersion.Latest, "go"),
+		strings.TrimPrefix(p.GoVersion.Current, "go"),
+		strings.TrimPrefix(p.GoVersion.Latest, "go"),
 	)
 }
 
@@ -367,7 +367,7 @@ func GetPackageInformation(binList []string) []Package {
 			GoVersion:  NewVersion(),
 		}
 		pkg.Version.Current = info.Main.Version
-		pkg.GoVersion.Current = info.GoVersion
+		pkg.GoVersion.Current, _, _ = strings.Cut(info.GoVersion, " ")
 		pkg.GoVersion.Latest = goVer
 		pkgs = append(pkgs, pkg)
 	}


### PR DESCRIPTION
On my Fedora system, Go is built with GOEXPERIMENT=nodwarf5, so GoVersion includes X:nodwarf5 in the end. <https://github.com/golang/go/blob/80038586ed2814a03dcb95cd6f130766f8d803c3/src/runtime/extern.go#L368-L369>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version normalization to more reliably strip common prefixes and ignore trailing Go metadata, reducing false “out-of-date” results and improving displayed version accuracy.
  * Better handling when Go version info is missing to avoid showing incorrect values.

* **Chores**
  * Internal parsing refined to broaden version recognition without changing any public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->