### PR TITLE
must return the inner error when cant check the latest versionf of a given module

### DIFF
--- a/internal/goutil/goutil.go
+++ b/internal/goutil/goutil.go
@@ -292,7 +292,7 @@ func install(importPath, version string) error {
 func GetLatestVer(modulePath string) (string, error) {
 	out, err := exec.Command(goExe, "list", "-m", "-f", "{{.Version}}", modulePath+"@latest").Output() //#nosec
 	if err != nil {
-		return "", fmr.Errorf("can't check %s:\n%w", modulePath, err)
+		return "", fmt.Errorf("can't check %s:\n%w", modulePath, err)
 	}
 	return strings.TrimRight(string(out), "\n"), nil
 }


### PR DESCRIPTION
I was trying to run "gup update" from one of my open projects and the error was not clear.

then I realize that  "gup update" execute "go list -m ..."  and go was trying to use the local go.mod and was returning an error. 

Usually I execute gup update from my HOME directory, and the error was just "can't check <module name>" and I was thinking it was an issue with network.

perhaps gup can check if there is a "go.mod" file and warn about it too

Regards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when checking module versions: failure messages now include the module identifier and preserve the original error details for clearer troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->