### PR TITLE
Refactor bug report URL construction

### DIFF
--- a/cmd/bug_report.go
+++ b/cmd/bug_report.go
@@ -53,7 +53,11 @@ Any other useful data to share.
 	buf.WriteString(additionalDetails)
 
 	body := buf.String()
-	url := "https://github.com/nao1215/gup/issues/new?title=[Bug Report] Title&body=" + url.QueryEscape(body)
+	q := url.Values{
+		"title": {"[Bug Report] Title"},
+		"body":  {body},
+	}
+	url := "https://github.com/nao1215/gup/issues/new?" + q.Encode()
 
 	if !openBrowser(url) {
 		fmt.Print("Please file a new issue at https://github.com/nao1215/gup/issues/new using this template:\n\n")


### PR DESCRIPTION
The link didn't work correctly because the title was not URL Query encoded.

### My environment

OS: macOS 26.2（25C56)

```bash
% gup version
gup version v0.28.1 (under Apache License version 2.0)
```

browser: Firefox 146.0.1

### Original state

The result of `gup bug-report`: [link](https://github.com/nao1215/gup/issues/new?title=%5BBug%20Report%5D%20Title&body=%2523%2523+gup+version%250A%250A%250A%2523%2523+Description+%2528About+the+problem%2529%250AA+clear+description+of+the+bug+encountered.%250A%250A%2523%2523+Steps+to+reproduce%250ASteps+to+reproduce+the+bug.%250A%250A%2523%2523+Expected+behavior%250AExpected+behavior.%250A%250A%2523%2523+Additional+details%252A%252A%250AAny+other+useful+data+to+share.%250A)

<img width="1042" height="340" alt="image" src="https://github.com/user-attachments/assets/6ab75457-da67-41e1-a4cb-56cb9bf9cae3" />

### After this fix

The result of `go run . bug-report`: [link](https://github.com/nao1215/gup/issues/new?body=%23%23+gup+version%0A%0A%0A%23%23+Description+%28About+the+problem%29%0AA+clear+description+of+the+bug+encountered.%0A%0A%23%23+Steps+to+reproduce%0ASteps+to+reproduce+the+bug.%0A%0A%23%23+Expected+behavior%0AExpected+behavior.%0A%0A%23%23+Additional+details%2A%2A%0AAny+other+useful+data+to+share.%0A&title=%5BBug+Report%5D+Title)

<img width="1033" height="714" alt="image" src="https://github.com/user-attachments/assets/fb5332dd-3dec-405b-8626-c6d3535d4e22" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how bug report submissions are encoded and sent so special characters in titles and descriptions are handled reliably, reducing failed or mangled reports and improving submission accuracy.



<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->