### PR TITLE
fix: version coloring to yellow=outdated, green=up-to-date

### DIFF
--- a/internal/goutil/goutil.go
+++ b/internal/goutil/goutil.go
@@ -86,13 +86,13 @@ func (p *Package) CurrentToLatestStr() string {
 	}
 	var ret string
 	if p.Version.Current != p.Version.Latest {
-		ret += color.GreenString(p.Version.Current) + " to " + color.YellowString(p.Version.Latest)
+		ret += color.YellowString(p.Version.Current) + " to " + color.GreenString(p.Version.Latest)
 	}
 	if p.GoVersion.Current != p.GoVersion.Latest {
 		if len(ret) != 0 {
 			ret += ", "
 		}
-		ret += color.GreenString(p.GoVersion.Current) + " to " + color.YellowString(p.GoVersion.Latest)
+		ret += color.YellowString(p.GoVersion.Current) + " to " + color.GreenString(p.GoVersion.Latest)
 	}
 	return ret
 }
@@ -103,27 +103,28 @@ func (p *Package) VersionCheckResultStr() string {
 		return "Already up-to-date: " + color.GreenString(p.Version.Current) + " / " + color.GreenString(p.GoVersion.Current)
 	}
 	var ret string
-	// TODO: yellow only if latest > current
 	if p.Version.Current == p.Version.Latest {
 		ret += color.GreenString(p.Version.Current)
 	} else {
-		ret += "current: " + color.GreenString(p.Version.Current) + ", latest: "
+		ret += "current: "
 		if p.IsPackageUpToDate() {
-			ret += color.GreenString(p.Version.Latest)
+			ret += color.GreenString(p.Version.Current)
 		} else {
-			ret += color.YellowString(p.Version.Latest)
+			ret += color.YellowString(p.Version.Current)
 		}
+		ret += ", latest:" + color.GreenString(p.Version.Latest)
 	}
 	ret += " / "
 	if p.GoVersion.Current == p.GoVersion.Latest {
 		ret += color.GreenString(p.GoVersion.Current)
 	} else {
-		ret += "current: " + color.GreenString(p.GoVersion.Current) + ", installed: "
+		ret += "current: "
 		if p.IsGoUpToDate() {
-			ret += color.GreenString(p.GoVersion.Latest)
+			ret += color.GreenString(p.GoVersion.Current)
 		} else {
-			ret += color.YellowString(p.GoVersion.Latest)
+			ret += color.YellowString(p.GoVersion.Current)
 		}
+		ret += ", latest:" + color.GreenString(p.GoVersion.Latest)
 	}
 	return ret
 }


### PR DESCRIPTION
Show outdated versions with the yellow warning color, and up to date ones with green. Previously they were the other way around in some outputs, which seems counterintuitive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced version display colors: current versions now shown in yellow, latest versions in green for improved visual distinction.
  * Refined version output formatting to consistently display both current and latest versions with organized labeling across all version checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->