### PR TITLE
fix: bug fixes and CI improvements

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,13 +28,6 @@ jobs:
       - name: Run tests with coverage report output
         run: go test -cover -coverpkg=./... -coverprofile=cover.out ./...
 
-      - name: Debug coverage input
-        run: |
-          pwd
-          ls -l cover.out
-          go tool cover -func=cover.out | tail -1
-          cat .octocov.yml
-
       - uses: k1LoW/octocov-action@v1
         with:
           config: .octocov.yml

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -12,7 +12,7 @@ coverage:
     - "github.com/nao1215/gup/internal/notify/notify.go"
     - "github.com/nao1215/gup/internal/completion/completion.go"
   badge:
-    path: docs/coverage.svg
+    path: doc/coverage.svg
 diff:
   datastores:
     - artifact://${GITHUB_REPOSITORY}
@@ -24,7 +24,7 @@ report:
     - artifact://${GITHUB_REPOSITORY}
 codeToTestRatio:
   badge:
-    path: docs/ratio.svg
+    path: doc/ratio.svg
 testExecutionTime:
   badge:
-    path: docs/time.svg
+    path: doc/time.svg

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -83,6 +83,7 @@ func removeLoop(gobin string, force bool, target []string) int {
 
 		if err := os.Remove(target); err != nil {
 			print.Err(err)
+			result = 1
 			continue
 		}
 		print.Info("removed " + target)

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -234,7 +234,8 @@ func update(pkgs []goutil.Package, dryRun, notification bool, cpus int, ignoreGo
 			print.Err(fmt.Errorf("can not change dry run mode to normal mode: %w", err))
 			return 1
 		}
-		close(signals)
+		signal.Stop(signals) // stop signal delivery before closing the channel
+		close(signals)       // unblock catchSignal goroutine
 	}
 
 	desktopNotifyIfNeeded(result, notification)

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -41,7 +41,7 @@ func makeBashCompletionFileIfNeeded(cmd *cobra.Command) {
 		return
 	}
 
-	if !fileutil.IsDir(path) {
+	if !fileutil.IsDir(filepath.Dir(path)) {
 		if err := os.MkdirAll(filepath.Dir(path), fileutil.FileModeCreatingDir); err != nil {
 			print.Err(fmt.Errorf("can not create bash-completion file: %w", err))
 			return


### PR DESCRIPTION
- remove: set result=1 when os.Remove fails so exit code reflects the error
- update: call signal.Stop before close(signals) to avoid send-on-closed-channel race
- completion: check filepath.Dir(path) instead of path in IsDir to correctly detect parent directory
- octocov: fix badge paths from non-existent docs/ to doc/
- coverage CI: remove debug step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting during file removal operations
  * Fixed bash completion file creation in directory scenarios
  * Improved signal handling cleanup during dry-run operations

* **Chores**
  * Removed debug output from CI workflow
  * Updated documentation badge paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->