### PR TITLE
Fix Windows binary rename when GOEXE is unset

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -448,10 +448,17 @@ func removeOldBinaryIfRenamed(oldName, newName string) error {
 }
 
 func binaryNameFromImportPath(importPath string) string {
+	return binaryNameFromImportPathWith(importPath, runtime.GOOS, os.Getenv("GOEXE"))
+}
+
+func binaryNameFromImportPathWith(importPath, goos, goExe string) string {
 	binName := filepath.Base(importPath)
-	if runtime.GOOS == goosWindows {
-		goExe := os.Getenv("GOEXE")
-		if goExe != "" && !strings.HasSuffix(strings.ToLower(binName), strings.ToLower(goExe)) {
+	if goos == goosWindows {
+		goExe = strings.TrimSpace(goExe)
+		if goExe == "" {
+			goExe = ".exe"
+		}
+		if !strings.HasSuffix(strings.ToLower(binName), strings.ToLower(goExe)) {
 			return binName + goExe
 		}
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows binary naming: trims executable-extension input, ensures a safe ".exe" default, and correctly appends the extension when missing.

* **Tests**
  * Expanded test coverage for binary naming across platforms and different executable-extension scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->