### PR TITLE
Propagate cancellation context to go subprocesses

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -81,14 +81,14 @@ func doCheck(pkgs []goutil.Package, cpus int, ignoreGoUpdate bool) int {
 
 	print.Info("check binary under $GOPATH/bin or $GOBIN")
 
-	checker := func(_ context.Context, p goutil.Package) updateResult {
+	checker := func(ctx context.Context, p goutil.Package) updateResult {
 		var err error
 		if p.ModulePath == "" {
 			err = fmt.Errorf(" %s is not installed by 'go install' (or permission incorrect)", p.Name)
 		} else {
 			var latestVer string
 			modulePathChanged := false
-			latestVer, err = verCache.get(p.ModulePath)
+			latestVer, err = verCache.get(ctx, p.ModulePath)
 			if err != nil {
 				newPkg, changed := resolveModulePathChange(p, err)
 				if !changed {
@@ -96,7 +96,7 @@ func doCheck(pkgs []goutil.Package, cpus int, ignoreGoUpdate bool) int {
 				} else {
 					modulePathChanged = true
 					p = newPkg
-					latestVer, err = verCache.get(p.ModulePath)
+					latestVer, err = verCache.get(ctx, p.ModulePath)
 					if err != nil {
 						err = fmt.Errorf(" %s %w", p.Name, err)
 					}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Added context-aware execution and improved concurrency controls so operations honor cancellation and run more reliably and responsively.

* **Tests**
  * Expanded test coverage for cancellation and context propagation to ensure robust behavior under aborted or concurrent operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->