### PR TITLE
Handle empty GOEXE in remove on Windows

### DIFF
--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -64,7 +64,7 @@ func removeLoop(gobin string, force bool, target []string) int {
 		orig := v
 		// In Windows, $GOEXE is set to the ".exe" extension.
 		// The user-specified command name (arguments) may not have an extension.
-		execSuffix := os.Getenv("GOEXE")
+		execSuffix := normalizeExecSuffix(GOOS, os.Getenv("GOEXE"))
 		if GOOS == goosWindows && !strings.HasSuffix(v, execSuffix) {
 			v += execSuffix
 		}
@@ -95,6 +95,18 @@ func removeLoop(gobin string, force bool, target []string) int {
 		print.Info("removed " + target)
 	}
 	return result
+}
+
+func normalizeExecSuffix(goos, goExe string) string {
+	if goos != goosWindows {
+		return goExe
+	}
+
+	goExe = strings.TrimSpace(goExe)
+	if goExe == "" {
+		return ".exe"
+	}
+	return goExe
 }
 
 func isSafeBinaryName(name string) bool {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the removal command on Windows to correctly handle executable file suffixes, including when the executable suffix environment value is missing or empty, ensuring more reliable deletions.

* **Tests**
  * Added targeted tests covering Windows-specific executable removal and the fallback behavior when the executable suffix is unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->