### PR TITLE
Harden completion checks and speed up generation script

### DIFF
--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -168,7 +168,7 @@ func hasSameBashCompletionContent(cmd *cobra.Command) bool {
 	if err := cmd.GenBashCompletionV2(currentBashCompletion, false); err != nil {
 		return false
 	}
-	if !strings.Contains(string(bashCompletionFileInLocal), currentBashCompletion.String()) {
+	if !bytes.Equal(currentBashCompletion.Bytes(), bashCompletionFileInLocal) {
 		return false
 	}
 	return true

--- a/internal/completion/completion_test.go
+++ b/internal/completion/completion_test.go
@@ -1,0 +1,71 @@
+package completion
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestHasSameBashCompletionContent_ExactMatch(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cmd := testCompletionCmd()
+
+	content := generateBashCompletion(t, cmd)
+	writeBashCompletionFile(t, content)
+
+	if !hasSameBashCompletionContent(cmd) {
+		t.Fatal("hasSameBashCompletionContent() = false, want true")
+	}
+}
+
+func TestHasSameBashCompletionContent_DifferentButContains(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cmd := testCompletionCmd()
+
+	content := generateBashCompletion(t, cmd)
+	writeBashCompletionFile(t, append([]byte("# stale header\n"), content...))
+
+	if hasSameBashCompletionContent(cmd) {
+		t.Fatal("hasSameBashCompletionContent() = true, want false")
+	}
+}
+
+func testCompletionCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "gup"}
+	cmd.PersistentFlags().Bool("verbose", false, "verbose output")
+
+	updateCmd := &cobra.Command{
+		Use:   "update",
+		Short: "update tools",
+		Annotations: map[string]string{
+			"group": "maintenance",
+		},
+	}
+	updateCmd.Flags().String("channel", "latest", "update channel")
+
+	cmd.AddCommand(updateCmd)
+	return cmd
+}
+
+func generateBashCompletion(t *testing.T, cmd *cobra.Command) []byte {
+	t.Helper()
+	buf := new(bytes.Buffer)
+	if err := cmd.GenBashCompletionV2(buf, false); err != nil {
+		t.Fatalf("GenBashCompletionV2() error = %v", err)
+	}
+	return buf.Bytes()
+}
+
+func writeBashCompletionFile(t *testing.T, content []byte) {
+	t.Helper()
+	path := bashCompletionFilePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+}

--- a/scripts/completions.sh
+++ b/scripts/completions.sh
@@ -2,13 +2,23 @@
 # scripts/completions.sh
 set -eux
 
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
 rm -rf completions
-mkdir completions
+mkdir -p completions
+
+tmp_bin="$(mktemp "${TMPDIR:-/tmp}/gup-completion.XXXXXX")"
+trap 'rm -f "$tmp_bin"' EXIT
+
+go build -o "$tmp_bin" .
+chmod +x "$tmp_bin"
 
 for sh in bash zsh fish powershell; do
     ext="$sh"
     if [ "$sh" = "powershell" ]; then
         ext="ps1"
     fi
-    go run main.go completion "$sh" >"completions/gup.$ext"
+    "$tmp_bin" completion "$sh" >"completions/gup.$ext"
 done


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bash completion validation now requires exact content equality instead of substring matching, avoiding false positives and stale overwrites.

* **Tests**
  * Added tests to confirm exact bash completion matches and to detect outdated/stale completion content.

* **Chores**
  * Improved completion-generation script for reliable startup, idempotent output directory creation, use of a temporary binary, and assured cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->