### PR TITLE
fix: correct grammar in README installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you are using oh-my-zsh, then gup has an alias set up. The alias is `gup - gi
 
 ## How to install
 ### Use "go install"
-If you does not have the golang development environment installed on your system, please install golang from the [golang official website](https://go.dev/doc/install).
+If you do not have the Go development environment installed on your system, please install it from the [official website](https://go.dev/doc/install).
 ```
 go install github.com/nao1215/gup@latest
 ```


### PR DESCRIPTION
Small grammar fix in the "Use go install" section:

**Before:** "If you does not have the golang development environment installed on your system, please install golang from the golang official website."

**After:** "If you do not have the Go development environment installed on your system, please install it from the official website."

Changes:
- "you does not" → "you do not" (subject-verb agreement)
- "golang" → "Go" (official name per Go project style)
- Simplified phrasing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined installation section in README with improved grammar and terminology for Go development environment setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->