### PR TITLE
fix(cmd): deploy notification icons lazily to avoid startup filesystem writes

### DIFF
--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -18,6 +18,8 @@ const (
 	testImportPathXY   = "github.com/x/y"
 	testImportPathTool = "github.com/example/tool"
 	testBinPosixer     = "posixer"
+	testShellBash      = "bash"
+	testCmdCompletion  = "completion"
 )
 
 // captureMigrateOutput redirects print output into a buffer for the duration of fn.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,7 +6,6 @@ import (
 	"runtime"
 	"strconv"
 
-	"github.com/nao1215/gup/internal/assets"
 	"github.com/nao1215/gup/internal/completion"
 	"github.com/spf13/cobra"
 )
@@ -57,7 +56,6 @@ If you find gup useful, please consider sponsoring the project:
 
 // Execute run gup process.
 func Execute() error {
-	assets.DeployIconIfNeeded()
 	rootCmd := newRootCmd()
 	return rootCmd.Execute()
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -860,7 +860,7 @@ func TestExecute_NoAssetsForReadOnlyCommands(t *testing.T) {
 	}{
 		{name: "version", args: []string{"gup", "version"}},
 		{name: "help", args: []string{"gup", "help"}},
-		{name: "completion bash", args: []string{"gup", "completion", "bash"}},
+		{name: "completion bash", args: []string{"gup", testCmdCompletion, testShellBash}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -981,7 +981,7 @@ func TestExecute_CompletionForShell(t *testing.T) {
 		wantHeader string
 	}{
 		{
-			shell:      "bash",
+			shell:      testShellBash,
 			wantOutput: true,
 			wantErr:    false,
 		},

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/adrg/xdg"
 	"github.com/google/go-cmp/cmp"
+	"github.com/nao1215/gup/internal/assets"
 	"github.com/nao1215/gup/internal/cmdinfo"
 	"github.com/nao1215/gup/internal/config"
 	"github.com/nao1215/gup/internal/fileutil"
@@ -844,6 +845,85 @@ func TestExecute_Update_DryRunAndNotify(t *testing.T) {
 	}
 	if !contain {
 		t.Errorf("failed to update posixer command")
+	}
+}
+
+// assetsDirForTest returns the directory where notification icons are deployed.
+func assetsDirForTest() string {
+	return filepath.Join(config.DirPath(), "assets")
+}
+
+func TestExecute_NoAssetsForReadOnlyCommands(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "version", args: []string{"gup", "version"}},
+		{name: "help", args: []string{"gup", "help"}},
+		{name: "completion bash", args: []string{"gup", "completion", "bash"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupXDGBase(t)
+
+			if _, err := helper_runGupCaptureAllOutput(t, tt.args); err != nil {
+				t.Fatal(err)
+			}
+
+			if fileutil.IsDir(assetsDirForTest()) {
+				t.Errorf("read-only command %q created assets directory %s", tt.name, assetsDirForTest())
+			}
+		})
+	}
+}
+
+func TestExecute_AssetsDeployedForNotifyCommand(t *testing.T) {
+	setupXDGBase(t)
+	helper_stubUpdateOps(t)
+	helper_setupFakeGoBin(t)
+	OsExit = func(code int) {}
+	defer func() {
+		OsExit = os.Exit
+	}()
+
+	gobin, err := goutil.GoBin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(gobin); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(gobin, 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	binName := testBinPosixer
+	targetPath := filepath.Join("testdata", "check_success", binName)
+	if runtime.GOOS == goosWindows {
+		binName = testBinPosixer + ".exe"
+		targetPath = filepath.Join("testdata", "check_success_for_windows", binName)
+	}
+	helper_CopyFile(t, targetPath, filepath.Join(gobin, binName))
+	if err = os.Chmod(filepath.Join(gobin, binName), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if fileutil.IsDir(assetsDirForTest()) {
+		t.Fatalf("assets directory %s should not exist before notify command runs", assetsDirForTest())
+	}
+
+	if _, err := helper_runGup(t, []string{"gup", "update", "--dry-run", "--notify"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if !fileutil.IsDir(assetsDirForTest()) {
+		t.Errorf("notify command did not deploy assets directory %s", assetsDirForTest())
+	}
+	if !fileutil.IsFile(assets.InfoIconPath()) {
+		t.Errorf("notify command did not deploy info icon %s", assets.InfoIconPath())
+	}
+	if !fileutil.IsFile(assets.WarningIconPath()) {
+		t.Errorf("notify command did not deploy warning icon %s", assets.WarningIconPath())
 	}
 }
 

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -10,6 +10,7 @@ import (
 
 // Info notify information message at desktop
 func Info(title, message string) {
+	assets.DeployIconIfNeeded()
 	err := beeep.Notify(title, message, assets.InfoIconPath())
 	if err != nil {
 		print.Warn(err)
@@ -18,6 +19,7 @@ func Info(title, message string) {
 
 // Warn notify warning message at desktop
 func Warn(title, message string) {
+	assets.DeployIconIfNeeded()
 	err := beeep.Notify(title, message, assets.WarningIconPath())
 	if err != nil {
 		print.Warn(err)


### PR DESCRIPTION
## Summary
`gup` deployed notification icon assets during command startup, even for commands that never use desktop notifications. `cmd.Execute()` always called `assets.DeployIconIfNeeded()`, so read-only commands such as `gup version`, `gup help`, and `gup completion bash` created config directories and files under the user profile.

This change defers asset deployment so that only notification-enabled flows touch the filesystem.

## Changes
- `cmd/root.go`: remove the unconditional `assets.DeployIconIfNeeded()` call (and its now-unused import) from `Execute()`.
- `internal/notify/notify.go`: deploy icons lazily inside `Info`/`Warn`, the only consumers of the icons. The dragonfly stub sends no notification, so it performs no writes.

## Why
CLIs should avoid surprising filesystem writes during read-only operations — important for scripted usage, sandboxed environments, and debugging.

## Tests
- `TestExecute_NoAssetsForReadOnlyCommands`: asserts `version`, `help`, and `completion bash` do not create the assets directory under an isolated temporary config root.
- `TestExecute_AssetsDeployedForNotifyCommand`: asserts `update --dry-run --notify` lazily deploys the assets directory and both icons.

## Verification
- `go build ./...`, `gofmt`, `go vet ./...`, `go test ./...` all pass.
- Manually confirmed with an isolated `HOME`/`XDG_CONFIG_HOME` that `version`, `help`, and `completion bash` create no assets directory.

Closes #264


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notification info/warning icons are now guaranteed to be deployed before sending desktop notifications.
  * Read-only commands no longer trigger notification asset deployment during startup.
* **Tests**
  * Added coverage to confirm assets are not created for read-only commands, while they are created and deployed for notification-enabled updates.
  * Updated completion-related test expectations for the Bash shell.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->