### PR TITLE
fix(import): fail explicitly when multiple gup.json candidates exist

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -65,7 +65,11 @@ func runImport(cmd *cobra.Command, _ []string) int {
 		print.Err(err)
 		return 1
 	}
-	confFile = config.ResolveImportFilePath(confFile)
+	confFile, err = config.ResolveImportFilePath(confFile)
+	if err != nil {
+		print.Err(err)
+		return 1
+	}
 
 	notify, err := getFlagBool(cmd, "notify")
 	if err != nil {

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -11,10 +11,40 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nao1215/gup/internal/config"
 	"github.com/nao1215/gup/internal/goutil"
 	"github.com/nao1215/gup/internal/print"
 	"github.com/spf13/cobra"
 )
+
+// validImportConf is a minimal gup.json with a single package entry.
+const validImportConf = `{
+  "schema_version": 1,
+  "packages": [
+    {
+      "name": "posixer",
+      "import_path": "github.com/nao1215/posixer",
+      "version": "v0.1.0",
+      "channel": "latest"
+    }
+  ]
+}`
+
+// chdirToTemp switches the working directory to a fresh temp dir and restores
+// it on cleanup, so that config.LocalFilePath() ("./gup.json") is isolated.
+func chdirToTemp(t *testing.T) {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(wd)
+	})
+	if err := os.Chdir(t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+}
 
 func Test_runImport_flagErrors(t *testing.T) {
 	tests := []struct {
@@ -392,5 +422,99 @@ func Test_installFromConfig_dryRun(t *testing.T) {
 
 	if got := installFromConfig(pkgs, true, false, 1); got != 0 {
 		t.Fatalf("installFromConfig() dry-run = %d, want 0", got)
+	}
+}
+
+func Test_runImport_ambiguousConfig(t *testing.T) {
+	setupXDGBase(t)
+	chdirToTemp(t)
+
+	// Create the user-level config.
+	if err := os.MkdirAll(config.DirPath(), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(config.FilePath(), []byte(validImportConf), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Create ./gup.json as well, making auto-detection ambiguous.
+	if err := os.WriteFile(config.LocalFilePath(), []byte(validImportConf), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newImportCmd()
+
+	orgStdout := print.Stdout
+	orgStderr := print.Stderr
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	print.Stdout = pw
+	print.Stderr = pw
+
+	got := runImport(cmd, nil)
+	pw.Close()
+	print.Stdout = orgStdout
+	print.Stderr = orgStderr
+
+	if got != 1 {
+		t.Errorf("runImport() = %v, want 1", got)
+	}
+
+	buf := bytes.Buffer{}
+	_, _ = io.Copy(&buf, pr)
+	pr.Close()
+
+	out := buf.String()
+	if !strings.Contains(out, "multiple gup.json") {
+		t.Errorf("expected ambiguity error, got: %s", out)
+	}
+	if !strings.Contains(out, "--file") {
+		t.Errorf("expected error to mention --file, got: %s", out)
+	}
+}
+
+func Test_runImport_autoDetectSingleCandidate(t *testing.T) {
+	setupXDGBase(t)
+	helper_stubImportInstaller(t)
+	chdirToTemp(t)
+
+	gobinDir := filepath.Join(t.TempDir(), "gobin")
+	t.Setenv("GOBIN", gobinDir)
+	if err := os.MkdirAll(gobinDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	// Only ./gup.json exists: it is the sole auto-detected candidate.
+	if err := os.WriteFile(config.LocalFilePath(), []byte(validImportConf), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newImportCmd()
+
+	orgStdout := print.Stdout
+	orgStderr := print.Stderr
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	print.Stdout = pw
+	print.Stderr = pw
+
+	got := runImport(cmd, nil)
+	pw.Close()
+	print.Stdout = orgStdout
+	print.Stderr = orgStderr
+
+	buf := bytes.Buffer{}
+	_, _ = io.Copy(&buf, pr)
+	pr.Close()
+
+	out := buf.String()
+	if got != 0 {
+		t.Errorf("runImport() = %v, want 0; output: %s", got, out)
+	}
+	if !strings.Contains(out, "start import based on") {
+		t.Errorf("expected import to start from the detected file, got: %s", out)
 	}
 }

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -32,18 +32,12 @@ const validImportConf = `{
 
 // chdirToTemp switches the working directory to a fresh temp dir and restores
 // it on cleanup, so that config.LocalFilePath() ("./gup.json") is isolated.
+// t.Chdir restores the directory before t.TempDir's RemoveAll runs, which
+// avoids a Windows cleanup failure where the current directory cannot be
+// removed while still in use.
 func chdirToTemp(t *testing.T) {
 	t.Helper()
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		_ = os.Chdir(wd)
-	})
-	if err := os.Chdir(t.TempDir()); err != nil {
-		t.Fatal(err)
-	}
+	t.Chdir(t.TempDir())
 }
 
 func Test_runImport_flagErrors(t *testing.T) {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -139,7 +139,13 @@ func gup(cmd *cobra.Command, args []string) int {
 		return 1
 	}
 
-	confReadPath := config.ResolveImportFilePath("")
+	confReadPath, resolveErr := config.ResolveImportFilePath("")
+	if resolveErr != nil {
+		// update only reads the config for channel hints and is not the
+		// command targeted by the ambiguity check, so fall back to the
+		// user-level config instead of failing.
+		confReadPath = config.FilePath()
+	}
 	confWritePath := config.FilePath()
 	if fileutil.IsFile(confReadPath) {
 		confWritePath = confReadPath

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,24 +49,36 @@ func DirPath() string {
 	return filepath.Join(xdg.ConfigHome, cmdinfo.Name)
 }
 
-// ResolveImportFilePath resolves config file path for import.
-// Priority: explicit path > default config path (if exists) > ./gup.json (if exists) > default config path.
-func ResolveImportFilePath(explicitPath string) string {
+// ResolveImportFilePath resolves the gup.json path used by import.
+// Priority:
+//   - an explicit path always wins.
+//   - if exactly one auto-detected candidate (the user-level config or
+//     ./gup.json) exists, that candidate is used.
+//   - if both candidates exist and no explicit path is given, the choice is
+//     ambiguous and an error is returned so the caller can ask the user to
+//     rerun with --file.
+//   - if neither candidate exists, the user-level config path is returned so
+//     the caller can report it as "not found".
+func ResolveImportFilePath(explicitPath string) (string, error) {
 	explicitPath = strings.TrimSpace(explicitPath)
 	if explicitPath != "" {
-		return explicitPath
+		return explicitPath, nil
 	}
 
 	defaultPath := FilePath()
-	if fileutil.IsFile(defaultPath) {
-		return defaultPath
-	}
-
 	local := LocalFilePath()
-	if fileutil.IsFile(local) {
-		return local
+	defaultExists := fileutil.IsFile(defaultPath)
+	localExists := fileutil.IsFile(local)
+
+	if defaultExists && localExists {
+		return "", fmt.Errorf(
+			"multiple gup.json candidates found (%s and %s); rerun with --file to choose one",
+			defaultPath, local)
 	}
-	return defaultPath
+	if localExists {
+		return local, nil
+	}
+	return defaultPath, nil
 }
 
 // ResolveExportFilePath resolves config file path for export.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/adrg/xdg"
@@ -239,22 +240,26 @@ func TestResolveImportFilePath(t *testing.T) { //nolint:paralleltest // changes 
 	}
 
 	custom := filepath.Join(t.TempDir(), "custom.json")
-	if got := ResolveImportFilePath(custom); got != custom {
-		t.Fatalf("ResolveImportFilePath(explicit) = %s, want %s", got, custom)
+	if got, err := ResolveImportFilePath(custom); err != nil || got != custom {
+		t.Fatalf("ResolveImportFilePath(explicit) = (%s, %v), want (%s, nil)", got, err, custom)
 	}
 
-	if got := ResolveImportFilePath(""); got != FilePath() {
-		t.Fatalf("ResolveImportFilePath(default) = %s, want %s", got, FilePath())
+	// Neither candidate exists: returns the user-level path so the caller can
+	// report it as "not found".
+	if got, err := ResolveImportFilePath(""); err != nil || got != FilePath() {
+		t.Fatalf("ResolveImportFilePath(none) = (%s, %v), want (%s, nil)", got, err, FilePath())
 	}
 
+	// Only ./gup.json exists: it is used.
 	local := filepath.Join(tmpDir, ConfigFileName)
 	if err := os.WriteFile(local, []byte(""), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if got := ResolveImportFilePath(""); got != LocalFilePath() {
-		t.Fatalf("ResolveImportFilePath(local) = %s, want %s", got, LocalFilePath())
+	if got, err := ResolveImportFilePath(""); err != nil || got != LocalFilePath() {
+		t.Fatalf("ResolveImportFilePath(local) = (%s, %v), want (%s, nil)", got, err, LocalFilePath())
 	}
 
+	// Both candidates exist: ambiguous, must return an error mentioning --file.
 	xdgFile := FilePath()
 	if err := os.MkdirAll(filepath.Dir(xdgFile), 0o750); err != nil {
 		t.Fatal(err)
@@ -262,8 +267,20 @@ func TestResolveImportFilePath(t *testing.T) { //nolint:paralleltest // changes 
 	if err := os.WriteFile(xdgFile, []byte(""), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if got := ResolveImportFilePath(""); got != FilePath() {
-		t.Fatalf("ResolveImportFilePath(xdg-priority) = %s, want %s", got, FilePath())
+	got, err := ResolveImportFilePath("")
+	if err == nil {
+		t.Fatalf("ResolveImportFilePath(ambiguous) = (%s, nil), want error", got)
+	}
+	if got != "" {
+		t.Fatalf("ResolveImportFilePath(ambiguous) path = %s, want empty", got)
+	}
+	if !strings.Contains(err.Error(), "--file") {
+		t.Fatalf("ResolveImportFilePath(ambiguous) error = %q, want it to mention --file", err.Error())
+	}
+
+	// An explicit path still wins even when both candidates exist.
+	if got, err := ResolveImportFilePath(custom); err != nil || got != custom {
+		t.Fatalf("ResolveImportFilePath(explicit over ambiguous) = (%s, %v), want (%s, nil)", got, err, custom)
 	}
 }
 


### PR DESCRIPTION
## Summary
`gup import` previously picked a config file silently when more than one candidate existed (the user-level `$XDG_CONFIG_HOME/gup/gup.json` and `./gup.json`). The import result then depended on hidden local state rather than an explicit user choice. This change makes the ambiguous case fail loudly.

## Changes
- `internal/config/config.go`: `ResolveImportFilePath` now returns `(string, error)`.
  - An explicit path always wins.
  - Exactly one auto-detected candidate is used.
  - When both candidates exist and `--file` is omitted, it returns an error telling the user to rerun with `--file`.
  - When neither exists, it returns the user-level path so the caller reports it as "not found" (unchanged).
- `cmd/import.go`: surfaces the resolver error and exits non-zero.
- `cmd/update.go`: `gup update` is not the targeted command and only reads the config for channel hints, so on the ambiguous case it falls back to the user-level config (preserving historical behavior) instead of failing.

## Tests
- `internal/config/config_test.go`: extends `TestResolveImportFilePath` to cover the full matrix — explicit path, none, local-only, both-present (error mentioning `--file`), and explicit-over-ambiguous.
- `cmd/import_test.go`: adds `Test_runImport_ambiguousConfig` (both candidates present → exit 1, error mentions `--file`) and `Test_runImport_autoDetectSingleCandidate` (sole `./gup.json` is used and import succeeds).

## Verification
- `go build ./...`, `gofmt`, `go vet ./...`, `go test ./...` all pass.
- Manually confirmed with isolated `HOME`/`XDG_CONFIG_HOME`:
  - both candidates + no `--file` → `gup:ERROR: multiple gup.json candidates found (...); rerun with --file to choose one`, exit 1.
  - explicit `--file` still imports the specified file.

Closes #266


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration file detection and error handling during import and update operations.
  * If multiple matching `gup.json` files are found, the command now fails with guidance to rerun using `--file`.
  * If detection fails, the app now falls back to the user-level configuration location.
* **Tests**
  * Added coverage for auto-detection behavior, single-candidate success, and ambiguous-candidate failure messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->