### PR TITLE
fix: restore a clean lint baseline and align Go compatibility policy

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,30 @@
+name: golangci-lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  golangci-lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
+
+      - name: Run golangci-lint as an enforced gate
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.12.2

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -2,20 +2,6 @@ name: reviewdog
 on: [pull_request]
 
 jobs:
-  golangci-lint:
-    name: golangci-lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-      - name: golangci-lint
-        uses: reviewdog/action-golangci-lint@v2
-        with:
-          reporter: github-pr-review
-          level: warning
-
   misspell:
     name: misspell
     runs-on: ubuntu-latest

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -86,7 +86,7 @@ func Test_CheckOption(t *testing.T) {
 		stderr []string
 	}{
 		{
-			name: "parser --jobs argument error",
+			name: testParserJobsErr,
 			args: args{
 				cmd:  &cobra.Command{},
 				args: []string{},
@@ -209,8 +209,8 @@ func Test_check_gobin_is_empty(t *testing.T) {
 			want   int
 			stderr []string
 		}{
-			name:  "$GOBIN is empty",
-			gobin: "no_exist_dir",
+			name:  testGobinEmpty,
+			gobin: testNoExistDir,
 			args:  args{},
 			want:  1,
 			stderr: []string{
@@ -226,8 +226,8 @@ func Test_check_gobin_is_empty(t *testing.T) {
 			want   int
 			stderr []string
 		}{
-			name:  "$GOBIN is empty",
-			gobin: "no_exist_dir",
+			name:  testGobinEmpty,
+			gobin: testNoExistDir,
 			args:  args{},
 			want:  1,
 			stderr: []string{
@@ -399,8 +399,8 @@ func Test_check_jobsClamp(t *testing.T) {
 
 func Test_doCheck_modulePathChanged(t *testing.T) {
 	const (
-		oldModule = "github.com/cosmtrek/air"
-		newModule = "github.com/air-verse/air"
+		oldModule = testOldModule
+		newModule = testNewModule
 	)
 
 	origGetLatest := getLatestVer
@@ -415,7 +415,7 @@ func Test_doCheck_modulePathChanged(t *testing.T) {
 				"but was required as: " + oldModule)
 		}
 		if modulePath == newModule {
-			return "v1.2.3", nil
+			return testVersion123, nil
 		}
 		return "", errors.New("unexpected module path")
 	}
@@ -431,15 +431,15 @@ func Test_doCheck_modulePathChanged(t *testing.T) {
 
 	pkgs := []goutil.Package{
 		{
-			Name:       "air",
+			Name:       testBinAir,
 			ImportPath: "github.com/cosmtrek/air/cmd/air",
 			ModulePath: oldModule,
 			Version: &goutil.Version{
-				Current: "v1.2.3",
+				Current: testVersion123,
 			},
 			GoVersion: &goutil.Version{
-				Current: "go1.22.4",
-				Latest:  "go1.22.4",
+				Current: testGoVersion1224,
+				Latest:  testGoVersion1224,
 			},
 		},
 	}
@@ -481,15 +481,15 @@ func Test_doCheck_customGoBuildTag_noFalsePositiveUpdate(t *testing.T) {
 
 	pkgs := []goutil.Package{
 		{
-			Name:       "tool",
-			ImportPath: "github.com/example/tool",
-			ModulePath: "github.com/example/tool",
+			Name:       testBinTool,
+			ImportPath: testImportPathTool,
+			ModulePath: testImportPathTool,
 			Version: &goutil.Version{
 				Current: testVersionOne,
 			},
 			GoVersion: &goutil.Version{
-				Current: "go1.26.0-X:nodwarf5",
-				Latest:  "go1.26.0-X:nodwarf5",
+				Current: testGoVersionNoDwarf5,
+				Latest:  testGoVersionNoDwarf5,
 			},
 		},
 	}
@@ -540,15 +540,15 @@ func Test_doCheck_customGoBuildTag_goVersionDiffColor(t *testing.T) {
 
 	pkgs := []goutil.Package{
 		{
-			Name:       "tool",
-			ImportPath: "github.com/example/tool",
-			ModulePath: "github.com/example/tool",
+			Name:       testBinTool,
+			ImportPath: testImportPathTool,
+			ModulePath: testImportPathTool,
 			Version: &goutil.Version{
 				Current: testVersionOne,
 			},
 			GoVersion: &goutil.Version{
 				Current: "go1.25.0-X:nodwarf5",
-				Latest:  "go1.26.0-X:nodwarf5",
+				Latest:  testGoVersionNoDwarf5,
 			},
 		},
 	}
@@ -572,7 +572,7 @@ func Test_doCheck_customGoBuildTag_goVersionDiffColor(t *testing.T) {
 	if !strings.Contains(buf.String(), color.YellowString("go1.25.0-X:nodwarf5")) {
 		t.Fatalf("expected current go version in yellow, got:\n%s", buf.String())
 	}
-	if !strings.Contains(buf.String(), color.GreenString("go1.26.0-X:nodwarf5")) {
+	if !strings.Contains(buf.String(), color.GreenString(testGoVersionNoDwarf5)) {
 		t.Fatalf("expected latest go version in green, got:\n%s", buf.String())
 	}
 }

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -8,6 +8,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// shellBash is the bash shell name used for completion arguments.
+const shellBash = "bash"
+
 func newCompletionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "completion",
@@ -16,7 +19,7 @@ func newCompletionCmd() *cobra.Command {
 With a shell name as argument, output completion for the shell to standard output.
 Use --install to write bash/fish/zsh completion files to the user shell config paths.`,
 		Args:      cobra.MatchAll(cobra.MaximumNArgs(1), cobra.OnlyValidArgs),
-		ValidArgs: []string{"bash", "fish", "zsh", "powershell"},
+		ValidArgs: []string{shellBash, "fish", "zsh", "powershell"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rootCmd := newRootCmd()
 			install, err := getFlagBool(cmd, "install")
@@ -34,7 +37,7 @@ Use --install to write bash/fish/zsh completion files to the user shell config p
 				return fmt.Errorf("specify shell (bash|fish|zsh|powershell) or use --install to write bash/fish/zsh completion files")
 			}
 			switch args[0] {
-			case "bash":
+			case shellBash:
 				return rootCmd.GenBashCompletionV2(os.Stdout, false)
 			case "fish":
 				return rootCmd.GenFishCompletion(os.Stdout, false)

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -16,7 +16,7 @@ func TestCompletion_InstallWithShellArg(t *testing.T) {
 	t.Parallel()
 
 	cmd := newCompletionCmd()
-	cmd.SetArgs([]string{"--install", "bash"})
+	cmd.SetArgs([]string{testFlagInstall, testShellBash})
 	if err := cmd.Execute(); err == nil {
 		t.Fatal("--install with shell argument should fail")
 	}
@@ -26,7 +26,7 @@ func TestCompletion_Install(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
 	cmd := newCompletionCmd()
-	cmd.SetArgs([]string{"--install"})
+	cmd.SetArgs([]string{testFlagInstall})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("completion --install should succeed: %v", err)
 	}

--- a/cmd/config_file.go
+++ b/cmd/config_file.go
@@ -57,7 +57,6 @@ func writeConfigFile(path string, pkgs []goutil.Package) (err error) {
 }
 
 func renameWithReplace(src, dst string) error {
-	//nolint:gosec // src/dst are created by this process and not user-controlled.
 	if err := os.Rename(src, dst); err != nil {
 		// Windows cannot overwrite an existing file with os.Rename.
 		// Retry via destination backup swap when the destination likely exists.
@@ -78,7 +77,6 @@ func renameWithBackupSwap(src, dst string) error {
 	if err = os.Rename(dst, backupPath); err != nil {
 		return err
 	}
-	//nolint:gosec // src/dst are created by this process and not user-controlled.
 	if err = os.Rename(src, dst); err != nil {
 		if restoreErr := os.Rename(backupPath, dst); restoreErr != nil {
 			return errors.Join(err, fmt.Errorf("can't restore original file %s after failed update: %w", dst, restoreErr))
@@ -97,11 +95,9 @@ func prepareBackupPath(dst string) (string, error) {
 	}
 	backupPath := backupFile.Name()
 	if err := backupFile.Close(); err != nil {
-		//nolint:gosec // backupPath is created by os.CreateTemp in this function.
 		_ = os.Remove(backupPath)
 		return "", err
 	}
-	//nolint:gosec // backupPath is created by os.CreateTemp in this function.
 	if err := os.Remove(backupPath); err != nil {
 		return "", err
 	}

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -108,7 +108,7 @@ func Test_export(t *testing.T) {
 		stderr []string
 	}{
 		{
-			name:   "can not make .config directory",
+			name:   testNoConfigDir,
 			gobin:  "",
 			want:   1,
 			stderr: []string{},
@@ -165,7 +165,7 @@ func Test_export(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("GOBIN", tt.gobin)
 
-			if tt.name == "can not make .config directory" {
+			if tt.name == testNoConfigDir {
 				oldHome := xdg.ConfigHome
 				xdg.ConfigHome = filepath.Join("/", "root")
 				defer func() {
@@ -201,7 +201,7 @@ func Test_export(t *testing.T) {
 			}()
 			got := strings.Split(buf.String(), "\n")
 
-			if tt.name != "can not make .config directory" {
+			if tt.name != testNoConfigDir {
 				if diff := cmp.Diff(tt.stderr, got); diff != "" {
 					t.Errorf("value is mismatch (-want +got):\n%s", diff)
 				}

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -256,9 +256,9 @@ func Test_installFromConfig_UseVersion(t *testing.T) {
 
 	pkgs := []goutil.Package{
 		{
-			Name:       "gup",
+			Name:       testCmdGup,
 			ImportPath: "github.com/nao1215/gup",
-			Version:    &goutil.Version{Current: "v1.0.0"},
+			Version:    &goutil.Version{Current: testVersionOne},
 		},
 	}
 
@@ -287,21 +287,21 @@ func Test_versionFromConfig_NormalizeDevel(t *testing.T) {
 			pkg: goutil.Package{
 				Version: &goutil.Version{Current: "(devel)"},
 			},
-			want: "latest",
+			want: latestKeyword,
 		},
 		{
 			name: "devel without parentheses",
 			pkg: goutil.Package{
 				Version: &goutil.Version{Current: "devel"},
 			},
-			want: "latest",
+			want: latestKeyword,
 		},
 		{
 			name: "regular version",
 			pkg: goutil.Package{
-				Version: &goutil.Version{Current: "v1.2.3"},
+				Version: &goutil.Version{Current: testVersion123},
 			},
-			want: "v1.2.3",
+			want: testVersion123,
 		},
 	}
 
@@ -371,9 +371,9 @@ func Test_installFromConfig_installError(t *testing.T) {
 
 	pkgs := []goutil.Package{
 		{
-			Name:       "tool",
+			Name:       testBinTool,
 			ImportPath: "github.com/example/tool",
-			Version:    &goutil.Version{Current: "v1.0.0"},
+			Version:    &goutil.Version{Current: testVersionOne},
 		},
 	}
 
@@ -385,9 +385,9 @@ func Test_installFromConfig_installError(t *testing.T) {
 func Test_installFromConfig_emptyImportPath(t *testing.T) {
 	pkgs := []goutil.Package{
 		{
-			Name:       "tool",
+			Name:       testBinTool,
 			ImportPath: "",
-			Version:    &goutil.Version{Current: "v1.0.0"},
+			Version:    &goutil.Version{Current: testVersionOne},
 		},
 	}
 
@@ -408,9 +408,9 @@ func Test_installFromConfig_dryRun(t *testing.T) {
 
 	pkgs := []goutil.Package{
 		{
-			Name:       "tool",
+			Name:       testBinTool,
 			ImportPath: "github.com/example/tool",
-			Version:    &goutil.Version{Current: "v1.0.0"},
+			Version:    &goutil.Version{Current: testVersionOne},
 		},
 	}
 

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -91,8 +91,8 @@ func Test_list_gobin_is_empty(t *testing.T) {
 			want   int
 			stderr []string
 		}{
-			name:  "$GOBIN is empty",
-			gobin: "no_exist_dir",
+			name:  testGobinEmpty,
+			gobin: testNoExistDir,
 			args:  args{},
 			want:  1,
 			stderr: []string{
@@ -108,8 +108,8 @@ func Test_list_gobin_is_empty(t *testing.T) {
 			want   int
 			stderr []string
 		}{
-			name:  "$GOBIN is empty",
-			gobin: "no_exist_dir",
+			name:  testGobinEmpty,
+			gobin: testNoExistDir,
 			args:  args{},
 			want:  1,
 			stderr: []string{

--- a/cmd/man.go
+++ b/cmd/man.go
@@ -128,7 +128,6 @@ func copyOneManpage(file, dst string) (err error) {
 		}
 	}()
 
-	//nolint:gosec // destination is chosen by the user and filename comes from filepath.Base.
 	out, err := os.Create(outputPath)
 	if err != nil {
 		return err

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -20,6 +20,45 @@ const (
 	testBinPosixer     = "posixer"
 	testShellBash      = "bash"
 	testCmdCompletion  = "completion"
+
+	testOldModule         = "github.com/cosmtrek/air"
+	testNewModule         = "github.com/air-verse/air"
+	testParserJobsErr     = "parser --jobs argument error"
+	testGobinEmpty        = "$GOBIN is empty"
+	testNoExistDir        = "no_exist_dir"
+	testBinAir            = "air"
+	testGoVersion1224     = "go1.22.4"
+	testGoVersionNoDwarf5 = "go1.26.0-X:nodwarf5"
+	testFlagInstall       = "--install"
+	testCmdGup            = "gup"
+	testCmdList           = "list"
+	testCmdExport         = "export"
+	testCmdImport         = "import"
+	testShellFish         = "fish"
+	testBinMytool         = "mytool"
+	testBinMytoolExe      = "mytool.exe"
+	testPkg1              = "pkg1"
+	testPkg2              = "pkg2"
+	testPkg3              = "pkg3"
+	testPkg2Exe           = "pkg2.exe"
+	testMissing           = "missing"
+	testKeptTool          = "kept-tool"
+	testNewTool           = "new-tool"
+	testDeleteCancel      = "delete cancel"
+	testNoConfigDir       = "can not make .config directory"
+	testVersion123        = "v1.2.3"
+	testVersionTwo        = "v2.0.0"
+	testBinTool           = "tool"
+	testBinPosixerExe     = "posixer.exe"
+	testBinToolA          = "tool-a"
+	testCmdVersion        = "version"
+	testCmdUpdate         = "update"
+	testCmdRemove         = "remove"
+	testShellZsh          = "zsh"
+	testShellPowershell   = "powershell"
+	testNameSuccess       = "success"
+	testNameTest2         = "test2"
+	testUnknown           = "unknown"
 )
 
 // captureMigrateOutput redirects print output into a buffer for the duration of fn.
@@ -139,18 +178,18 @@ func Test_resolveMigrateVersion(t *testing.T) {
 	}{
 		{
 			name:        "regular version",
-			pkg:         goutil.Package{ImportPath: testImportPathXY, Version: &goutil.Version{Current: "v1.2.3"}},
-			wantVersion: "v1.2.3",
+			pkg:         goutil.Package{ImportPath: testImportPathXY, Version: &goutil.Version{Current: testVersion123}},
+			wantVersion: testVersion123,
 			wantSkip:    false,
 		},
 		{
 			name:     "empty import path",
-			pkg:      goutil.Package{ImportPath: "", Version: &goutil.Version{Current: "v1.0.0"}},
+			pkg:      goutil.Package{ImportPath: "", Version: &goutil.Version{Current: testVersionOne}},
 			wantSkip: true,
 		},
 		{
 			name:     commandLineArguments,
-			pkg:      goutil.Package{ImportPath: commandLineArguments, Version: &goutil.Version{Current: "v1.0.0"}},
+			pkg:      goutil.Package{ImportPath: commandLineArguments, Version: &goutil.Version{Current: testVersionOne}},
 			wantSkip: true,
 		},
 		{
@@ -207,7 +246,7 @@ func Test_migratePackages_install(t *testing.T) {
 	}
 
 	pkgs := []goutil.Package{
-		{Name: "tool", ImportPath: testImportPathTool, Version: &goutil.Version{Current: "v1.2.3"}},
+		{Name: testBinTool, ImportPath: testImportPathTool, Version: &goutil.Version{Current: testVersion123}},
 	}
 
 	out := captureMigrateOutput(t, func() {
@@ -219,7 +258,7 @@ func Test_migratePackages_install(t *testing.T) {
 	if len(calls) != 1 {
 		t.Fatalf("installer called %d times, want 1 (output: %s)", len(calls), out)
 	}
-	if calls[0].importPath != testImportPathTool || calls[0].version != "v1.2.3" {
+	if calls[0].importPath != testImportPathTool || calls[0].version != testVersion123 {
 		t.Fatalf("installed %q@%q, want exact reinstall", calls[0].importPath, calls[0].version)
 	}
 }
@@ -244,7 +283,7 @@ func Test_migratePackages_addOnlySkip(t *testing.T) {
 	}
 
 	pkgs := []goutil.Package{
-		{Name: "tool", ImportPath: testImportPathTool, Version: &goutil.Version{Current: "v1.2.3"}},
+		{Name: testBinTool, ImportPath: testImportPathTool, Version: &goutil.Version{Current: testVersion123}},
 	}
 
 	out := captureMigrateOutput(t, func() {
@@ -279,7 +318,7 @@ func Test_migratePackages_force(t *testing.T) {
 	}
 
 	pkgs := []goutil.Package{
-		{Name: "tool", ImportPath: testImportPathTool, Version: &goutil.Version{Current: "v1.2.3"}},
+		{Name: testBinTool, ImportPath: testImportPathTool, Version: &goutil.Version{Current: testVersion123}},
 	}
 
 	captureMigrateOutput(t, func() {
@@ -306,7 +345,7 @@ func Test_migratePackages_dryRun(t *testing.T) {
 	}
 
 	pkgs := []goutil.Package{
-		{Name: "tool", ImportPath: testImportPathTool, Version: &goutil.Version{Current: "v1.2.3"}},
+		{Name: testBinTool, ImportPath: testImportPathTool, Version: &goutil.Version{Current: testVersion123}},
 	}
 
 	captureMigrateOutput(t, func() {
@@ -335,8 +374,8 @@ func Test_migratePackages_skipDevelAndUnknown(t *testing.T) {
 
 	pkgs := []goutil.Package{
 		{Name: "devbin", ImportPath: "github.com/example/dev", Version: &goutil.Version{Current: develVersionParen}},
-		{Name: "noimport", ImportPath: "", Version: &goutil.Version{Current: "v1.0.0"}},
-		{Name: "good", ImportPath: "github.com/example/good", Version: &goutil.Version{Current: "v1.0.0"}},
+		{Name: "noimport", ImportPath: "", Version: &goutil.Version{Current: testVersionOne}},
+		{Name: "good", ImportPath: "github.com/example/good", Version: &goutil.Version{Current: testVersionOne}},
 	}
 
 	captureMigrateOutput(t, func() {
@@ -368,10 +407,10 @@ func Test_migratePackages_modulePathMismatchRetry(t *testing.T) {
 
 	pkgs := []goutil.Package{
 		{
-			Name:       "tool",
+			Name:       testBinTool,
 			ImportPath: "github.com/old/mod/cmd/tool",
 			ModulePath: "github.com/old/mod",
-			Version:    &goutil.Version{Current: "v1.0.0"},
+			Version:    &goutil.Version{Current: testVersionOne},
 		},
 	}
 
@@ -401,7 +440,7 @@ func Test_migratePackages_installError(t *testing.T) {
 	}
 
 	pkgs := []goutil.Package{
-		{Name: "tool", ImportPath: testImportPathTool, Version: &goutil.Version{Current: "v1.0.0"}},
+		{Name: testBinTool, ImportPath: testImportPathTool, Version: &goutil.Version{Current: testVersionOne}},
 	}
 
 	captureMigrateOutput(t, func() {
@@ -421,8 +460,8 @@ func Test_migratePackages_jobsBoundary(t *testing.T) {
 	installByVersionMigrateCtx = func(context.Context, string, string) error { return nil }
 
 	pkgs := []goutil.Package{
-		{Name: "a", ImportPath: "github.com/example/a", Version: &goutil.Version{Current: "v1.0.0"}},
-		{Name: "b", ImportPath: "github.com/example/b", Version: &goutil.Version{Current: "v1.0.0"}},
+		{Name: "a", ImportPath: "github.com/example/a", Version: &goutil.Version{Current: testVersionOne}},
+		{Name: "b", ImportPath: "github.com/example/b", Version: &goutil.Version{Current: testVersionOne}},
 	}
 
 	for _, jobs := range []int{-1, 0, 1, 100} {

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -34,7 +34,7 @@ func Test_removeLoop(t *testing.T) {
 			args: args{
 				gobin:  filepath.Join("testdata", "delete"),
 				force:  false,
-				target: []string{"posixer"},
+				target: []string{testBinPosixer},
 			},
 			input: "y",
 			want:  1,
@@ -47,17 +47,17 @@ func Test_removeLoop(t *testing.T) {
 			args: args{
 				gobin:  filepath.Join("testdata", "delete"),
 				force:  false,
-				target: []string{"posixer.exe"},
+				target: []string{testBinPosixerExe},
 			},
 			input: "y",
 			want:  0,
 		})
 		tests = append(tests, test{
-			name: "delete cancel",
+			name: testDeleteCancel,
 			args: args{
 				gobin:  filepath.Join("testdata", "delete"),
 				force:  false,
-				target: []string{"posixer.exe"},
+				target: []string{testBinPosixerExe},
 			},
 			input: "n",
 			want:  0,
@@ -68,17 +68,17 @@ func Test_removeLoop(t *testing.T) {
 			args: args{
 				gobin:  filepath.Join("testdata", "delete"),
 				force:  false,
-				target: []string{"posixer"},
+				target: []string{testBinPosixer},
 			},
 			input: "y",
 			want:  0,
 		})
 		tests = append(tests, test{
-			name: "delete cancel",
+			name: testDeleteCancel,
 			args: args{
 				gobin:  filepath.Join("testdata", "delete"),
 				force:  false,
-				target: []string{"posixer"},
+				target: []string{testBinPosixer},
 			},
 			input: "n",
 			want:  0,
@@ -94,11 +94,11 @@ func Test_removeLoop(t *testing.T) {
 			src := ""
 			dest := ""
 			if runtime.GOOS == goosWindows {
-				src = filepath.Join("testdata", "check_success_for_windows", "posixer.exe")
-				dest = filepath.Join("testdata", "delete", "posixer.exe")
+				src = filepath.Join("testdata", "check_success_for_windows", testBinPosixerExe)
+				dest = filepath.Join("testdata", "delete", testBinPosixerExe)
 			} else {
-				src = filepath.Join("testdata", "check_success", "posixer")
-				dest = filepath.Join("testdata", "delete", "posixer")
+				src = filepath.Join("testdata", "check_success", testBinPosixer)
+				dest = filepath.Join("testdata", "delete", testBinPosixer)
 			}
 			newFile, err := os.Create(dest)
 			if err != nil {
@@ -136,7 +136,7 @@ func Test_removeLoop(t *testing.T) {
 				t.Errorf("removeLoop() = %v, want %v", got, tt.want)
 			}
 
-			if tt.name == "delete cancel" && !fileutil.IsFile(dest) {
+			if tt.name == testDeleteCancel && !fileutil.IsFile(dest) {
 				t.Errorf("input no, however posixer command is deleted")
 			}
 		})
@@ -169,7 +169,7 @@ func Test_remove_flagError(t *testing.T) {
 	t.Parallel()
 	cmd := &cobra.Command{}
 	// missing "force" flag
-	got := remove(cmd, []string{"tool"})
+	got := remove(cmd, []string{testBinTool})
 	if got != 1 {
 		t.Errorf("remove() = %v, want 1", got)
 	}
@@ -200,12 +200,12 @@ func Test_removeLoop_windowsFallbackGoexe(t *testing.T) {
 	t.Setenv("GOEXE", "")
 
 	gobin := t.TempDir()
-	binaryPath := filepath.Join(gobin, "posixer.exe")
+	binaryPath := filepath.Join(gobin, testBinPosixerExe)
 	if err := os.WriteFile(binaryPath, []byte("dummy"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 
-	if got := removeLoop(gobin, true, []string{"posixer"}); got != 0 {
+	if got := removeLoop(gobin, true, []string{testBinPosixer}); got != 0 {
 		t.Fatalf("removeLoop() = %v, want 0", got)
 	}
 	if fileutil.IsFile(binaryPath) {
@@ -237,7 +237,7 @@ func Test_removeLoop_forceTrimmedName(t *testing.T) {
 	t.Parallel()
 
 	gobin := t.TempDir()
-	binaryName := "posixer"
+	binaryName := testBinPosixer
 	if GOOS == goosWindows {
 		binaryName += normalizeExecSuffix(GOOS, os.Getenv("GOEXE"))
 	}
@@ -261,8 +261,8 @@ func Test_isSafeBinaryName(t *testing.T) {
 		input string
 		want  bool
 	}{
-		{name: "simple name", input: "mytool", want: true},
-		{name: "with extension", input: "mytool.exe", want: true},
+		{name: "simple name", input: testBinMytool, want: true},
+		{name: "with extension", input: testBinMytoolExe, want: true},
 		{name: "empty", input: "", want: false},
 		{name: "whitespace only", input: "   ", want: false},
 		{name: "leading and trailing whitespace", input: " mytool ", want: false},

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -264,7 +264,7 @@ func TestExecute(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "success",
+			name:    testNameSuccess,
 			args:    []string{""},
 			wantErr: false,
 		},
@@ -297,7 +297,7 @@ func TestExecute_Check(t *testing.T) {
 		t.Setenv("GOBIN", gobinDir)
 	}
 
-	got, err := helper_runGup(t, []string{"gup", "check"})
+	got, err := helper_runGup(t, []string{testCmdGup, "check"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -319,8 +319,8 @@ func TestExecute_Version(t *testing.T) {
 		stdout []string
 	}{
 		{
-			name:   "success",
-			args:   []string{"gup", "version"},
+			name:   testNameSuccess,
+			args:   []string{testCmdGup, testCmdVersion},
 			stdout: []string{"gup version (devel) (under Apache License version 2.0)", ""},
 		},
 	}
@@ -351,7 +351,7 @@ func TestExecute_List(t *testing.T) {
 		tests = append(tests, test{
 			name:  "check success in windows",
 			gobin: filepath.Join("testdata", "check_success_for_windows"),
-			args:  []string{"gup", "list"},
+			args:  []string{testCmdGup, testCmdList},
 			stdout: []string{
 				"github.com/nao1215/gal/cmd/gal",
 				"github.com/nao1215/posixer",
@@ -362,7 +362,7 @@ func TestExecute_List(t *testing.T) {
 		tests = append(tests, test{
 			name:  "check success in nix family",
 			gobin: filepath.Join("testdata", "check_success"),
-			args:  []string{"gup", "list"},
+			args:  []string{testCmdGup, testCmdList},
 			stdout: []string{
 				"    gal: github.com/nao1215/gal/cmd/gal@v1.1.1",
 				"posixer: github.com/nao1215/posixer@v0.1.0",
@@ -408,9 +408,9 @@ func TestExecute_Remove_Force(t *testing.T) {
 	dest := ""
 	if runtime.GOOS == goosWindows {
 		tests = append(tests, test{
-			name:   "success",
+			name:   testNameSuccess,
 			gobin:  filepath.Join("testdata", "delete_force"),
-			args:   []string{"gup", "remove", "-f", "posixer.exe"},
+			args:   []string{testCmdGup, testCmdRemove, "-f", testBinPosixerExe},
 			stdout: []string{},
 		})
 		if err := os.MkdirAll(filepath.Join("testdata", "delete_force"), 0750); err != nil {
@@ -422,13 +422,13 @@ func TestExecute_Remove_Force(t *testing.T) {
 				t.Fatal(err)
 			}
 		}()
-		src = filepath.Join("testdata", "check_success_for_windows", "posixer.exe")
-		dest = filepath.Join("testdata", "delete_force", "posixer.exe")
+		src = filepath.Join("testdata", "check_success_for_windows", testBinPosixerExe)
+		dest = filepath.Join("testdata", "delete_force", testBinPosixerExe)
 	} else {
 		tests = append(tests, test{
-			name:   "success",
+			name:   testNameSuccess,
 			gobin:  filepath.Join("testdata", "delete"),
-			args:   []string{"gup", "remove", "-f", "posixer"},
+			args:   []string{testCmdGup, testCmdRemove, "-f", "posixer"},
 			stdout: []string{},
 		})
 		if err := os.MkdirAll(filepath.Join("testdata", "delete"), 0750); err != nil {
@@ -484,9 +484,9 @@ func TestExecute_Export(t *testing.T) {
 			args  []string
 			want  string
 		}{
-			name:  "success",
+			name:  testNameSuccess,
 			gobin: filepath.Join("testdata", "check_success_for_windows"),
-			args:  []string{"gup", "export"},
+			args:  []string{testCmdGup, testCmdExport},
 			want: `{
   "schema_version": 1,
   "packages": [
@@ -513,9 +513,9 @@ func TestExecute_Export(t *testing.T) {
 			args  []string
 			want  string
 		}{
-			name:  "success",
+			name:  testNameSuccess,
 			gobin: filepath.Join("testdata", "check_success"),
-			args:  []string{"gup", "export"},
+			args:  []string{testCmdGup, testCmdExport},
 			want: `{
   "schema_version": 1,
   "packages": [
@@ -602,9 +602,9 @@ func TestExecute_Export_WithOutputOption(t *testing.T) {
 	tests := []test{}
 	if runtime.GOOS == goosWindows {
 		tests = append(tests, test{
-			name:  "success",
+			name:  testNameSuccess,
 			gobin: filepath.Join("testdata", "check_success_for_windows"),
-			args:  []string{"gup", "export", "--output"},
+			args:  []string{testCmdGup, testCmdExport, "--output"},
 			want: []string{
 				"{",
 				`  "schema_version": 1,`,
@@ -616,9 +616,9 @@ func TestExecute_Export_WithOutputOption(t *testing.T) {
 		})
 	} else {
 		tests = append(tests, test{
-			name:  "success",
+			name:  testNameSuccess,
 			gobin: filepath.Join("testdata", "check_success"),
-			args:  []string{"gup", "export", "--output"},
+			args:  []string{testCmdGup, testCmdExport, "--output"},
 			want: []string{
 				"{",
 				`  "schema_version": 1,`,
@@ -679,7 +679,7 @@ func TestExecute_Import_WithInputOption(t *testing.T) {
 		confFile = "testdata/gup_config/windows.json"
 	}
 
-	got, err := helper_runGup(t, []string{"gup", "import", "-f", confFile})
+	got, err := helper_runGup(t, []string{testCmdGup, testCmdImport, "-f", confFile})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -728,7 +728,7 @@ func TestExecute_Import_WithBadInputFile(t *testing.T) {
 				OsExit = os.Exit
 			}()
 
-			got, err := helper_runGup(t, []string{"gup", "import", "-f", tt.inputFile})
+			got, err := helper_runGup(t, []string{testCmdGup, testCmdImport, "-f", tt.inputFile})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -778,7 +778,7 @@ func TestExecute_Update(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := helper_runGup(t, []string{"gup", "update"})
+	got, err := helper_runGup(t, []string{testCmdGup, testCmdUpdate})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -819,7 +819,7 @@ func TestExecute_Update_DryRunAndNotify(t *testing.T) {
 	targetPath := ""
 	binName := ""
 	if runtime.GOOS == goosWindows {
-		binName = "posixer.exe"
+		binName = testBinPosixerExe
 		targetPath = filepath.Join("testdata", "check_success_for_windows", binName)
 	} else {
 		binName = "posixer"
@@ -832,7 +832,7 @@ func TestExecute_Update_DryRunAndNotify(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := helper_runGup(t, []string{"gup", "update", "--dry-run", "--notify"})
+	got, err := helper_runGup(t, []string{testCmdGup, testCmdUpdate, "--dry-run", "--notify"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -858,9 +858,9 @@ func TestExecute_NoAssetsForReadOnlyCommands(t *testing.T) {
 		name string
 		args []string
 	}{
-		{name: "version", args: []string{"gup", "version"}},
-		{name: "help", args: []string{"gup", "help"}},
-		{name: "completion bash", args: []string{"gup", testCmdCompletion, testShellBash}},
+		{name: testCmdVersion, args: []string{testCmdGup, testCmdVersion}},
+		{name: "help", args: []string{testCmdGup, "help"}},
+		{name: "completion bash", args: []string{testCmdGup, testCmdCompletion, testShellBash}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -912,7 +912,7 @@ func TestExecute_AssetsDeployedForNotifyCommand(t *testing.T) {
 		t.Fatalf("assets directory %s should not exist before notify command runs", assetsDirForTest())
 	}
 
-	if _, err := helper_runGup(t, []string{"gup", "update", "--dry-run", "--notify"}); err != nil {
+	if _, err := helper_runGup(t, []string{testCmdGup, testCmdUpdate, "--dry-run", "--notify"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -931,7 +931,7 @@ func TestExecute_Completion(t *testing.T) {
 	setupXDGBase(t)
 
 	t.Run("generate completion file", func(t *testing.T) {
-		os.Args = []string{"gup", "completion", "--install"}
+		os.Args = []string{testCmdGup, testCmdCompletion, testFlagInstall}
 		if err := Execute(); err != nil {
 			t.Error(err)
 		}
@@ -947,7 +947,7 @@ func TestExecute_Completion(t *testing.T) {
 			}
 		}
 
-		fish := filepath.Join(os.Getenv("HOME"), ".config", "fish", "completions", cmdinfo.Name+".fish")
+		fish := filepath.Join(os.Getenv("HOME"), ".config", testShellFish, "completions", cmdinfo.Name+".fish")
 		if runtime.GOOS == goosWindows {
 			if fileutil.IsFile(fish) {
 				t.Errorf("generate %s, however shell completion file is not generated on Windows", fish)
@@ -958,7 +958,7 @@ func TestExecute_Completion(t *testing.T) {
 			}
 		}
 
-		zsh := filepath.Join(os.Getenv("HOME"), ".zsh", "completion", "_"+cmdinfo.Name)
+		zsh := filepath.Join(os.Getenv("HOME"), ".zsh", testCmdCompletion, "_"+cmdinfo.Name)
 		if runtime.GOOS == goosWindows {
 			if fileutil.IsFile(zsh) {
 				t.Errorf("generate %s, however shell completion file is not generated on Windows", zsh)
@@ -986,17 +986,17 @@ func TestExecute_CompletionForShell(t *testing.T) {
 			wantErr:    false,
 		},
 		{
-			shell:      "fish",
+			shell:      testShellFish,
 			wantOutput: true,
 			wantErr:    false,
 		},
 		{
-			shell:      "zsh",
+			shell:      testShellZsh,
 			wantOutput: true,
 			wantErr:    false,
 		},
 		{
-			shell:      "powershell",
+			shell:      testShellPowershell,
 			wantOutput: true,
 			wantErr:    false,
 			wantHeader: "# powershell completion for gup",
@@ -1009,7 +1009,7 @@ func TestExecute_CompletionForShell(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.shell, func(t *testing.T) {
-			got, err := helper_runGupCaptureAllOutput(t, []string{"gup", "completion", tt.shell})
+			got, err := helper_runGupCaptureAllOutput(t, []string{testCmdGup, testCmdCompletion, tt.shell})
 
 			gotErr := err != nil
 			if tt.wantErr != gotErr {

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -90,7 +90,7 @@ func Test_gup(t *testing.T) {
 			},
 		},
 		{
-			name: "parser --jobs argument error",
+			name: testParserJobsErr,
 			args: args{
 				cmd:  &cobra.Command{},
 				args: []string{},
@@ -111,7 +111,7 @@ func Test_gup(t *testing.T) {
 			case "parser --notify argument error":
 				tt.args.cmd.Flags().BoolP("dry-run", "n", false, "perform the trial update with no changes")
 				tt.args.cmd.Flags().BoolP("jobs", "j", false, "Specify the number of CPU cores to use")
-			case "parser --jobs argument error":
+			case testParserJobsErr:
 				tt.args.cmd.Flags().BoolP("dry-run", "n", false, "perform the trial update with no changes")
 				tt.args.cmd.Flags().BoolP("notify", "N", false, "enable desktop notifications")
 			}
@@ -172,17 +172,17 @@ func Test_extractUserSpecifyPkg(t *testing.T) {
 						Name: "test1",
 					},
 					{
-						Name: "test2",
+						Name: testNameTest2,
 					},
 					{
 						Name: "test3",
 					},
 				},
-				targets: []string{"test2"},
+				targets: []string{testNameTest2},
 			},
 			want: []goutil.Package{
 				{
-					Name: "test2",
+					Name: testNameTest2,
 				},
 			},
 		},
@@ -194,7 +194,7 @@ func Test_extractUserSpecifyPkg(t *testing.T) {
 						Name: "test1",
 					},
 					{
-						Name: "test2",
+						Name: testNameTest2,
 					},
 					{
 						Name: "test3",
@@ -247,7 +247,7 @@ func Test_extractUserSpecifyPkg_dedupNotFoundWarnings(t *testing.T) {
 	}
 	print.Stderr = pw
 
-	got := extractUserSpecifyPkg(pkgs, []string{"missing", "missing"})
+	got := extractUserSpecifyPkg(pkgs, []string{testMissing, testMissing})
 	if len(got) != 0 {
 		t.Fatalf("extractUserSpecifyPkg() should return no packages, got: %+v", got)
 	}
@@ -277,10 +277,10 @@ func Test_filterBinaryPathListByTargets(t *testing.T) {
 	binList := []string{
 		filepath.Join("tmp", "gopls"),
 		filepath.Join("tmp", "dlv"),
-		filepath.Join("tmp", "air"),
+		filepath.Join("tmp", testBinAir),
 	}
 
-	got := filterBinaryPathListByTargets(binList, []string{"  dlv  ", "missing"})
+	got := filterBinaryPathListByTargets(binList, []string{"  dlv  ", testMissing})
 	want := []string{filepath.Join("tmp", "dlv")}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatalf("value is mismatch (-want +got):\n%s", diff)
@@ -485,20 +485,20 @@ func Test_excludeUserSpecifiedPkg(t *testing.T) {
 			args: args{
 				pkgs: []goutil.Package{
 					{
-						Name: "pkg1",
+						Name: testPkg1,
 					},
 					{
-						Name: "pkg2",
+						Name: testPkg2,
 					},
 					{
-						Name: "pkg3",
+						Name: testPkg3,
 					},
 				},
-				excludePkgList: []string{"pkg1", "pkg3"},
+				excludePkgList: []string{testPkg1, testPkg3},
 			},
 			want: []goutil.Package{
 				{
-					Name: "pkg2",
+					Name: testPkg2,
 				},
 			},
 		},
@@ -507,16 +507,16 @@ func Test_excludeUserSpecifiedPkg(t *testing.T) {
 			args: args{
 				pkgs: []goutil.Package{
 					{
-						Name: "pkg1",
+						Name: testPkg1,
 					},
 					{
-						Name: "pkg2",
+						Name: testPkg2,
 					},
 					{
-						Name: "pkg3",
+						Name: testPkg3,
 					},
 				},
-				excludePkgList: []string{"pkg1", "pkg2", "pkg3"},
+				excludePkgList: []string{testPkg1, testPkg2, testPkg3},
 			},
 			want: []goutil.Package{},
 		},
@@ -525,26 +525,26 @@ func Test_excludeUserSpecifiedPkg(t *testing.T) {
 			args: args{
 				pkgs: []goutil.Package{
 					{
-						Name: "pkg1",
+						Name: testPkg1,
 					},
 					{
-						Name: "pkg2",
+						Name: testPkg2,
 					},
 					{
-						Name: "pkg3",
+						Name: testPkg3,
 					},
 				},
 				excludePkgList: []string{"pkg4"},
 			},
 			want: []goutil.Package{
 				{
-					Name: "pkg1",
+					Name: testPkg1,
 				},
 				{
-					Name: "pkg2",
+					Name: testPkg2,
 				},
 				{
-					Name: "pkg3",
+					Name: testPkg3,
 				},
 			},
 		},
@@ -553,20 +553,20 @@ func Test_excludeUserSpecifiedPkg(t *testing.T) {
 			args: args{
 				pkgs: []goutil.Package{
 					{
-						Name: "pkg1",
+						Name: testPkg1,
 					},
 					{
-						Name: "pkg2",
+						Name: testPkg2,
 					},
 					{
-						Name: "pkg3",
+						Name: testPkg3,
 					},
 				},
 				excludePkgList: []string{" pkg1", "pkg3 "},
 			},
 			want: []goutil.Package{
 				{
-					Name: "pkg2",
+					Name: testPkg2,
 				},
 			},
 		},
@@ -660,18 +660,18 @@ func Test_desktopNotifyIfNeeded(t *testing.T) {
 
 func TestExtractUserSpecifyPkg(t *testing.T) {
 	pkgs := []goutil.Package{
-		{Name: "pkg1"},
-		{Name: "pkg2.exe"},
-		{Name: "pkg3"},
+		{Name: testPkg1},
+		{Name: testPkg2Exe},
+		{Name: testPkg3},
 	}
-	targets := []string{"pkg1", "pkg2.exe"}
+	targets := []string{testPkg1, testPkg2Exe}
 	if runtime.GOOS == goosWindows {
-		targets = []string{"pkg1", "pkg2"}
+		targets = []string{testPkg1, testPkg2}
 	}
 
 	expected := []goutil.Package{
-		{Name: "pkg1"},
-		{Name: "pkg2.exe"},
+		{Name: testPkg1},
+		{Name: testPkg2Exe},
 	}
 	actual := extractUserSpecifyPkg(pkgs, targets)
 
@@ -738,31 +738,31 @@ func Test_replaceImportPathPrefix(t *testing.T) {
 	}{
 		{
 			name:       "same as module root",
-			importPath: "github.com/cosmtrek/air",
-			oldModule:  "github.com/cosmtrek/air",
-			newModule:  "github.com/air-verse/air",
-			wantImport: "github.com/air-verse/air",
+			importPath: testOldModule,
+			oldModule:  testOldModule,
+			newModule:  testNewModule,
+			wantImport: testNewModule,
 		},
 		{
 			name:       "subdir path",
 			importPath: "github.com/cosmtrek/air/cmd/air",
-			oldModule:  "github.com/cosmtrek/air",
-			newModule:  "github.com/air-verse/air",
+			oldModule:  testOldModule,
+			newModule:  testNewModule,
 			wantImport: "github.com/air-verse/air/cmd/air",
 		},
 		{
 			name:       "empty import path",
 			importPath: "",
-			oldModule:  "github.com/cosmtrek/air",
-			newModule:  "github.com/air-verse/air",
-			wantImport: "github.com/air-verse/air",
+			oldModule:  testOldModule,
+			newModule:  testNewModule,
+			wantImport: testNewModule,
 		},
 		{
 			name:       "no prefix match keeps original import path",
-			importPath: "github.com/example/tool",
-			oldModule:  "github.com/cosmtrek/air",
-			newModule:  "github.com/air-verse/air",
-			wantImport: "github.com/example/tool",
+			importPath: testImportPathTool,
+			oldModule:  testOldModule,
+			newModule:  testNewModule,
+			wantImport: testImportPathTool,
 		},
 	}
 
@@ -785,7 +785,7 @@ func Test_removeOldBinaryIfRenamed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := removeOldBinaryIfRenamed("old-tool", "new-tool"); err != nil {
+	if err := removeOldBinaryIfRenamed("old-tool", testNewTool); err != nil {
 		t.Fatalf("removeOldBinaryIfRenamed() error = %v", err)
 	}
 	if _, err := os.Stat(oldBinaryPath); !errors.Is(err, os.ErrNotExist) {
@@ -806,8 +806,8 @@ func Test_removeOldBinaryIfRenamed(t *testing.T) {
 
 func Test_update_modulePathChangedOnGetLatest(t *testing.T) {
 	const (
-		oldModule = "github.com/cosmtrek/air"
-		newModule = "github.com/air-verse/air"
+		oldModule = testOldModule
+		newModule = testNewModule
 		oldImport = "github.com/cosmtrek/air/cmd/air"
 		newImport = "github.com/air-verse/air/cmd/air"
 	)
@@ -830,7 +830,7 @@ func Test_update_modulePathChangedOnGetLatest(t *testing.T) {
 			return "", modulePathMismatchErr(oldModule, newModule)
 		}
 		if modulePath == newModule {
-			return "v1.2.3", nil
+			return testVersion123, nil
 		}
 		return "", errors.New("unexpected module path")
 	}
@@ -851,20 +851,20 @@ func Test_update_modulePathChangedOnGetLatest(t *testing.T) {
 
 	pkgs := []goutil.Package{
 		{
-			Name:       "air",
+			Name:       testBinAir,
 			ImportPath: oldImport,
 			ModulePath: oldModule,
 			Version: &goutil.Version{
-				Current: "v1.2.3",
+				Current: testVersion123,
 			},
 			GoVersion: &goutil.Version{
-				Current: "go1.22.4",
-				Latest:  "go1.22.4",
+				Current: testGoVersion1224,
+				Latest:  testGoVersion1224,
 			},
 		},
 	}
 
-	channelMap := map[string]goutil.UpdateChannel{"air": goutil.UpdateChannelLatest}
+	channelMap := map[string]goutil.UpdateChannel{testBinAir: goutil.UpdateChannelLatest}
 	if got, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap); got != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", got)
 	}
@@ -878,10 +878,10 @@ func Test_update_modulePathChangedOnGetLatest(t *testing.T) {
 
 func Test_update_modulePathChangedOnInstall(t *testing.T) {
 	const (
-		oldModule = "github.com/cosmtrek/air"
-		newModule = "github.com/air-verse/air"
-		oldImport = "github.com/cosmtrek/air"
-		newImport = "github.com/air-verse/air"
+		oldModule = testOldModule
+		newModule = testNewModule
+		oldImport = testOldModule
+		newImport = testNewModule
 	)
 
 	origGetLatest := getLatestVer
@@ -920,20 +920,20 @@ func Test_update_modulePathChangedOnInstall(t *testing.T) {
 
 	pkgs := []goutil.Package{
 		{
-			Name:       "air",
+			Name:       testBinAir,
 			ImportPath: oldImport,
 			ModulePath: newModule,
 			Version: &goutil.Version{
 				Current: testVersionOne,
 			},
 			GoVersion: &goutil.Version{
-				Current: "go1.22.4",
-				Latest:  "go1.22.4",
+				Current: testGoVersion1224,
+				Latest:  testGoVersion1224,
 			},
 		},
 	}
 
-	channelMap := map[string]goutil.UpdateChannel{"air": goutil.UpdateChannelLatest}
+	channelMap := map[string]goutil.UpdateChannel{testBinAir: goutil.UpdateChannelLatest}
 	if got, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap); got != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", got)
 	}
@@ -957,7 +957,7 @@ func Test_mergeConfigPackages(t *testing.T) {
 			UpdateChannel: goutil.UpdateChannelLatest,
 		},
 		{
-			Name:          "kept-tool",
+			Name:          testKeptTool,
 			ImportPath:    "github.com/example/kept-tool",
 			Version:       &goutil.Version{Current: "v0.5.0"},
 			UpdateChannel: goutil.UpdateChannelLatest,
@@ -965,19 +965,19 @@ func Test_mergeConfigPackages(t *testing.T) {
 	}
 	succeededPkgs := []goutil.Package{
 		{
-			Name:       "new-tool",
+			Name:       testNewTool,
 			ImportPath: "github.com/example/new-tool",
-			Version:    &goutil.Version{Current: testVersionOne, Latest: "v2.0.0"},
+			Version:    &goutil.Version{Current: testVersionOne, Latest: testVersionTwo},
 		},
 		// empty name/import should be skipped
 		{Name: "", ImportPath: ""},
 	}
 	channelMap := map[string]goutil.UpdateChannel{
-		"new-tool":  goutil.UpdateChannelMain,
-		"kept-tool": goutil.UpdateChannelLatest,
+		testNewTool:  goutil.UpdateChannelMain,
+		testKeptTool: goutil.UpdateChannelLatest,
 	}
 	renamedPkgs := map[string]string{
-		"old-tool": "new-tool",
+		"old-tool": testNewTool,
 	}
 
 	got := mergeConfigPackages(confPkgs, succeededPkgs, channelMap, renamedPkgs)
@@ -987,10 +987,10 @@ func Test_mergeConfigPackages(t *testing.T) {
 		t.Fatalf("mergeConfigPackages() returned %d packages, want 2", len(got))
 	}
 	// sorted by name
-	if got[0].Name != "kept-tool" {
+	if got[0].Name != testKeptTool {
 		t.Errorf("first package = %q, want kept-tool", got[0].Name)
 	}
-	if got[1].Name != "new-tool" {
+	if got[1].Name != testNewTool {
 		t.Errorf("second package = %q, want new-tool", got[1].Name)
 	}
 	if got[1].UpdateChannel != goutil.UpdateChannelMain {
@@ -1007,19 +1007,19 @@ func Test_sanitizeConfigPackage(t *testing.T) {
 		{
 			name: "nil version defaults to latest",
 			pkg: goutil.Package{
-				Name:       "tool",
-				ImportPath: "github.com/example/tool",
+				Name:       testBinTool,
+				ImportPath: testImportPathTool,
 			},
-			wantVer: "latest",
+			wantVer: latestKeyword,
 		},
 		{
 			name: "empty version defaults to latest",
 			pkg: goutil.Package{
-				Name:       "tool",
-				ImportPath: "github.com/example/tool",
+				Name:       testBinTool,
+				ImportPath: testImportPathTool,
 				Version:    &goutil.Version{Current: "  "},
 			},
-			wantVer: "latest",
+			wantVer: latestKeyword,
 		},
 		{
 			name: "preserves valid version",
@@ -1028,7 +1028,7 @@ func Test_sanitizeConfigPackage(t *testing.T) {
 				ImportPath: " github.com/example/tool ",
 				Version:    &goutil.Version{Current: " v1.2.3 "},
 			},
-			wantVer: "v1.2.3",
+			wantVer: testVersion123,
 		},
 	}
 	for _, tt := range tests {
@@ -1053,19 +1053,19 @@ func Test_persistedVersion(t *testing.T) {
 		{
 			name: "nil version",
 			pkg:  goutil.Package{},
-			want: "latest",
+			want: latestKeyword,
 		},
 		{
 			name: "prefers latest over current",
 			pkg: goutil.Package{
-				Version: &goutil.Version{Current: testVersionOne, Latest: "v2.0.0"},
+				Version: &goutil.Version{Current: testVersionOne, Latest: testVersionTwo},
 			},
-			want: "v2.0.0",
+			want: testVersionTwo,
 		},
 		{
 			name: "falls back to current when latest is unknown",
 			pkg: goutil.Package{
-				Version: &goutil.Version{Current: testVersionOne, Latest: "unknown"},
+				Version: &goutil.Version{Current: testVersionOne, Latest: testUnknown},
 			},
 			want: testVersionOne,
 		},
@@ -1081,7 +1081,7 @@ func Test_persistedVersion(t *testing.T) {
 			pkg: goutil.Package{
 				Version: &goutil.Version{Current: "", Latest: ""},
 			},
-			want: "latest",
+			want: latestKeyword,
 		},
 	}
 	for _, tt := range tests {
@@ -1096,18 +1096,18 @@ func Test_persistedVersion(t *testing.T) {
 
 func Test_resolveUpdateChannels(t *testing.T) {
 	pkgs := []goutil.Package{
-		{Name: "tool-a"},
+		{Name: testBinToolA},
 		{Name: "tool-b"},
 		{Name: "tool-c"},
 	}
 
 	t.Run("assigns channels from flags", func(t *testing.T) {
-		got, err := resolveUpdateChannels(pkgs, nil, []string{"tool-a"}, []string{"tool-b"}, nil)
+		got, err := resolveUpdateChannels(pkgs, nil, []string{testBinToolA}, []string{"tool-b"}, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if got["tool-a"] != goutil.UpdateChannelMain {
-			t.Errorf("tool-a channel = %q, want main", got["tool-a"])
+		if got[testBinToolA] != goutil.UpdateChannelMain {
+			t.Errorf("tool-a channel = %q, want main", got[testBinToolA])
 		}
 		if got["tool-b"] != goutil.UpdateChannelMaster {
 			t.Errorf("tool-b channel = %q, want master", got["tool-b"])
@@ -1118,7 +1118,7 @@ func Test_resolveUpdateChannels(t *testing.T) {
 	})
 
 	t.Run("error on conflicting flags", func(t *testing.T) {
-		_, err := resolveUpdateChannels(pkgs, nil, []string{"tool-a"}, []string{"tool-a"}, nil)
+		_, err := resolveUpdateChannels(pkgs, nil, []string{testBinToolA}, []string{testBinToolA}, nil)
 		if err == nil {
 			t.Fatal("expected error for conflicting flags")
 		}
@@ -1165,7 +1165,7 @@ func Test_installWithSelectedVersion(t *testing.T) {
 	}()
 
 	var called string
-	installLatest = func(string) error { called = "latest"; return nil }
+	installLatest = func(string) error { called = latestKeyword; return nil }
 	installMainOrMaster = func(string) error { called = "main"; return nil }
 	installByVersionUpd = func(_, v string) error { called = "version:" + v; return nil }
 
@@ -1173,10 +1173,10 @@ func Test_installWithSelectedVersion(t *testing.T) {
 		channel goutil.UpdateChannel
 		want    string
 	}{
-		{goutil.UpdateChannelLatest, "latest"},
+		{goutil.UpdateChannelLatest, latestKeyword},
 		{goutil.UpdateChannelMain, "main"},
 		{goutil.UpdateChannelMaster, "version:master"},
-		{"unknown", "latest"}, // default case
+		{testUnknown, latestKeyword}, // default case
 	}
 	for _, tt := range tests {
 		called = ""
@@ -1248,10 +1248,10 @@ func Test_latestVerCache_get_contextCanceled(t *testing.T) {
 
 func Test_packageUpdateChannel(t *testing.T) {
 	channelMap := map[string]goutil.UpdateChannel{
-		"tool-a": goutil.UpdateChannelMain,
+		testBinToolA: goutil.UpdateChannelMain,
 	}
 
-	if got := packageUpdateChannel("tool-a", goutil.UpdateChannelLatest, channelMap); got != goutil.UpdateChannelMain {
+	if got := packageUpdateChannel(testBinToolA, goutil.UpdateChannelLatest, channelMap); got != goutil.UpdateChannelMain {
 		t.Errorf("found in map: got %q, want main", got)
 	}
 	if got := packageUpdateChannel("tool-b", goutil.UpdateChannelMaster, channelMap); got != goutil.UpdateChannelMaster {
@@ -1263,9 +1263,9 @@ func Test_binaryNameFromImportPath(t *testing.T) {
 	t.Setenv("GOEXE", "")
 
 	got := binaryNameFromImportPath("github.com/example/tool/cmd/mytool")
-	want := "mytool"
+	want := testBinMytool
 	if runtime.GOOS == goosWindows {
-		want = "mytool.exe"
+		want = testBinMytoolExe
 	}
 	if got != want {
 		t.Errorf("binaryNameFromImportPath() = %q, want %q", got, want)
@@ -1285,11 +1285,11 @@ func Test_binaryNameFromImportPathWith(t *testing.T) {
 			importPath: "github.com/example/tool/cmd/mytool",
 			goos:       "linux",
 			goexe:      "",
-			want:       "mytool",
+			want:       testBinMytool,
 		},
 		{
 			name:       "windows adds .exe when GOEXE is empty",
-			importPath: "github.com/air-verse/air",
+			importPath: testNewModule,
 			goos:       goosWindows,
 			goexe:      "",
 			want:       "air.exe",
@@ -1299,7 +1299,7 @@ func Test_binaryNameFromImportPathWith(t *testing.T) {
 			importPath: "github.com/example/tool/cmd/mytool.exe",
 			goos:       goosWindows,
 			goexe:      "",
-			want:       "mytool.exe",
+			want:       testBinMytoolExe,
 		},
 		{
 			name:       "windows respects GOEXE when provided",
@@ -1326,8 +1326,8 @@ func Test_normalizeBinaryNameForMatch(t *testing.T) {
 		input string
 		want  string
 	}{
-		{name: "plain name", input: "tool", want: "tool"},
-		{name: "whitespace trimmed", input: "  tool  ", want: "tool"},
+		{name: "plain name", input: testBinTool, want: testBinTool},
+		{name: "whitespace trimmed", input: "  tool  ", want: testBinTool},
 		{name: "empty", input: "", want: ""},
 	}
 	for _, tt := range tests {
@@ -1341,7 +1341,7 @@ func Test_normalizeBinaryNameForMatch(t *testing.T) {
 }
 
 func Test_removeOldBinaryIfRenamed_unsafeName(t *testing.T) {
-	err := removeOldBinaryIfRenamed("../escape", "new-tool")
+	err := removeOldBinaryIfRenamed("../escape", testNewTool)
 	if err == nil {
 		t.Fatal("expected error for unsafe binary name")
 	}
@@ -1351,7 +1351,7 @@ func Test_removeOldBinaryIfRenamed_unsafeName(t *testing.T) {
 }
 
 func Test_removeOldBinaryIfRenamed_emptyNames(t *testing.T) {
-	if err := removeOldBinaryIfRenamed("", "new-tool"); err != nil {
+	if err := removeOldBinaryIfRenamed("", testNewTool); err != nil {
 		t.Errorf("empty oldName should return nil, got: %v", err)
 	}
 	if err := removeOldBinaryIfRenamed("old-tool", ""); err != nil {
@@ -1381,15 +1381,15 @@ func Test_updateWithChannels_emptyImportPath(t *testing.T) {
 
 	pkgs := []goutil.Package{
 		{
-			Name:       "tool",
+			Name:       testBinTool,
 			ImportPath: "",
-			ModulePath: "github.com/example/tool",
+			ModulePath: testImportPathTool,
 			Version:    &goutil.Version{Current: testVersionOne},
-			GoVersion:  &goutil.Version{Current: "go1.22.4", Latest: "go1.22.4"},
+			GoVersion:  &goutil.Version{Current: testGoVersion1224, Latest: testGoVersion1224},
 		},
 	}
 
-	channelMap := map[string]goutil.UpdateChannel{"tool": goutil.UpdateChannelLatest}
+	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
 	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap)
 	if result != 1 {
 		t.Fatalf("updateWithChannels() = %d, want 1 (empty import path)", result)
@@ -1403,15 +1403,15 @@ func Test_updateWithChannels_alreadyUpToDate(t *testing.T) {
 
 	pkgs := []goutil.Package{
 		{
-			Name:       "tool",
-			ImportPath: "github.com/example/tool",
-			ModulePath: "github.com/example/tool",
+			Name:       testBinTool,
+			ImportPath: testImportPathTool,
+			ModulePath: testImportPathTool,
 			Version:    &goutil.Version{Current: testVersionOne},
-			GoVersion:  &goutil.Version{Current: "go1.22.4", Latest: "go1.22.4"},
+			GoVersion:  &goutil.Version{Current: testGoVersion1224, Latest: testGoVersion1224},
 		},
 	}
 
-	channelMap := map[string]goutil.UpdateChannel{"tool": goutil.UpdateChannelLatest}
+	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
 	result, succeeded, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
@@ -1460,15 +1460,15 @@ func Test_updateWithChannels_alreadyUpToDate_customGoBuildTag(t *testing.T) {
 
 	pkgs := []goutil.Package{
 		{
-			Name:       "tool",
-			ImportPath: "github.com/example/tool",
-			ModulePath: "github.com/example/tool",
+			Name:       testBinTool,
+			ImportPath: testImportPathTool,
+			ModulePath: testImportPathTool,
 			Version:    &goutil.Version{Current: testVersionOne},
-			GoVersion:  &goutil.Version{Current: "go1.26.0-X:nodwarf5", Latest: "go1.26.0-X:nodwarf5"},
+			GoVersion:  &goutil.Version{Current: testGoVersionNoDwarf5, Latest: testGoVersionNoDwarf5},
 		},
 	}
 
-	channelMap := map[string]goutil.UpdateChannel{"tool": goutil.UpdateChannelLatest}
+	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
 	result, succeeded, _ := updateWithChannels(pkgs, false, false, 1, false, channelMap)
 
 	if err := pw.Close(); err != nil {
@@ -1537,15 +1537,15 @@ func Test_updateWithChannels_customGoBuildTag_goVersionDiffColor(t *testing.T) {
 
 	pkgs := []goutil.Package{
 		{
-			Name:       "tool",
-			ImportPath: "github.com/example/tool",
-			ModulePath: "github.com/example/tool",
+			Name:       testBinTool,
+			ImportPath: testImportPathTool,
+			ModulePath: testImportPathTool,
 			Version:    &goutil.Version{Current: testVersionOne},
-			GoVersion:  &goutil.Version{Current: "go1.25.0-X:nodwarf5", Latest: "go1.26.0-X:nodwarf5"},
+			GoVersion:  &goutil.Version{Current: "go1.25.0-X:nodwarf5", Latest: testGoVersionNoDwarf5},
 		},
 	}
 
-	channelMap := map[string]goutil.UpdateChannel{"tool": goutil.UpdateChannelLatest}
+	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
 	result, _, _ := updateWithChannels(pkgs, false, false, 1, false, channelMap)
 	if err := pw.Close(); err != nil {
 		t.Fatal(err)
@@ -1565,7 +1565,7 @@ func Test_updateWithChannels_customGoBuildTag_goVersionDiffColor(t *testing.T) {
 	if !strings.Contains(buf.String(), color.YellowString("go1.25.0-X:nodwarf5")) {
 		t.Fatalf("expected current go version in yellow, got:\n%s", buf.String())
 	}
-	if !strings.Contains(buf.String(), color.GreenString("go1.26.0-X:nodwarf5")) {
+	if !strings.Contains(buf.String(), color.GreenString(testGoVersionNoDwarf5)) {
 		t.Fatalf("expected latest go version in green, got:\n%s", buf.String())
 	}
 }
@@ -1577,15 +1577,15 @@ func Test_updateWithChannels_emptyModulePath(t *testing.T) {
 
 	pkgs := []goutil.Package{
 		{
-			Name:       "tool",
-			ImportPath: "github.com/example/tool",
+			Name:       testBinTool,
+			ImportPath: testImportPathTool,
 			ModulePath: "",
 			Version:    &goutil.Version{Current: testVersionOne},
-			GoVersion:  &goutil.Version{Current: "go1.22.4", Latest: "go1.22.4"},
+			GoVersion:  &goutil.Version{Current: testGoVersion1224, Latest: testGoVersion1224},
 		},
 	}
 
-	channelMap := map[string]goutil.UpdateChannel{"tool": goutil.UpdateChannelLatest}
+	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
 	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
@@ -1601,15 +1601,15 @@ func Test_updateWithChannels_getLatestVerError(t *testing.T) {
 
 	pkgs := []goutil.Package{
 		{
-			Name:       "tool",
-			ImportPath: "github.com/example/tool",
-			ModulePath: "github.com/example/tool",
+			Name:       testBinTool,
+			ImportPath: testImportPathTool,
+			ModulePath: testImportPathTool,
 			Version:    &goutil.Version{Current: testVersionOne},
-			GoVersion:  &goutil.Version{Current: "go1.22.4", Latest: "go1.22.4"},
+			GoVersion:  &goutil.Version{Current: testGoVersion1224, Latest: testGoVersion1224},
 		},
 	}
 
-	channelMap := map[string]goutil.UpdateChannel{"tool": goutil.UpdateChannelLatest}
+	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
 	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap)
 	if result != 1 {
 		t.Fatalf("updateWithChannels() = %d, want 1", result)
@@ -1630,15 +1630,15 @@ func Test_updateWithChannels_masterChannel(t *testing.T) {
 
 	pkgs := []goutil.Package{
 		{
-			Name:       "tool",
-			ImportPath: "github.com/example/tool",
-			ModulePath: "github.com/example/tool",
+			Name:       testBinTool,
+			ImportPath: testImportPathTool,
+			ModulePath: testImportPathTool,
 			Version:    &goutil.Version{Current: testVersionOne},
-			GoVersion:  &goutil.Version{Current: "go1.22.4", Latest: "go1.22.4"},
+			GoVersion:  &goutil.Version{Current: testGoVersion1224, Latest: testGoVersion1224},
 		},
 	}
 
-	channelMap := map[string]goutil.UpdateChannel{"tool": goutil.UpdateChannelMaster}
+	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelMaster}
 	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
@@ -1685,7 +1685,7 @@ func Test_removeOldBinaryIfRenamed_notExist(t *testing.T) {
 	t.Setenv("GOBIN", gobin)
 
 	// old binary doesn't exist — should succeed silently
-	if err := removeOldBinaryIfRenamed("nonexistent-tool", "new-tool"); err != nil {
+	if err := removeOldBinaryIfRenamed("nonexistent-tool", testNewTool); err != nil {
 		t.Fatalf("removeOldBinaryIfRenamed() should succeed for non-existent: %v", err)
 	}
 }
@@ -1703,15 +1703,15 @@ func Test_updateWithChannels_notify(t *testing.T) {
 
 	pkgs := []goutil.Package{
 		{
-			Name:       "tool",
-			ImportPath: "github.com/example/tool",
-			ModulePath: "github.com/example/tool",
+			Name:       testBinTool,
+			ImportPath: testImportPathTool,
+			ModulePath: testImportPathTool,
 			Version:    &goutil.Version{Current: testVersionOne},
-			GoVersion:  &goutil.Version{Current: "go1.22.4", Latest: "go1.22.4"},
+			GoVersion:  &goutil.Version{Current: testGoVersion1224, Latest: testGoVersion1224},
 		},
 	}
 
-	channelMap := map[string]goutil.UpdateChannel{"tool": goutil.UpdateChannelLatest}
+	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
 	result, _, _ := updateWithChannels(pkgs, false, true, 1, true, channelMap)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() with notify = %d, want 0", result)
@@ -1731,15 +1731,15 @@ func Test_updateWithChannels_installError(t *testing.T) {
 
 	pkgs := []goutil.Package{
 		{
-			Name:       "tool",
-			ImportPath: "github.com/example/tool",
-			ModulePath: "github.com/example/tool",
+			Name:       testBinTool,
+			ImportPath: testImportPathTool,
+			ModulePath: testImportPathTool,
 			Version:    &goutil.Version{Current: testVersionOne},
-			GoVersion:  &goutil.Version{Current: "go1.22.4", Latest: "go1.22.4"},
+			GoVersion:  &goutil.Version{Current: testGoVersion1224, Latest: testGoVersion1224},
 		},
 	}
 
-	channelMap := map[string]goutil.UpdateChannel{"tool": goutil.UpdateChannelLatest}
+	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
 	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap)
 	if result != 1 {
 		t.Fatalf("updateWithChannels() = %d, want 1", result)
@@ -1768,15 +1768,15 @@ func Test_updateWithChannels_mainChannel(t *testing.T) {
 
 	pkgs := []goutil.Package{
 		{
-			Name:       "tool",
-			ImportPath: "github.com/example/tool",
-			ModulePath: "github.com/example/tool",
+			Name:       testBinTool,
+			ImportPath: testImportPathTool,
+			ModulePath: testImportPathTool,
 			Version:    &goutil.Version{Current: testVersionOne},
-			GoVersion:  &goutil.Version{Current: "go1.22.4", Latest: "go1.22.4"},
+			GoVersion:  &goutil.Version{Current: testGoVersion1224, Latest: testGoVersion1224},
 		},
 	}
 
-	channelMap := map[string]goutil.UpdateChannel{"tool": goutil.UpdateChannelMain}
+	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelMain}
 	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/hashicorp/go-version v1.9.0
 	github.com/mattn/go-colorable v0.1.15
 	github.com/pkg/errors v0.9.1
-	github.com/shogo82148/pointer v1.4.0
 	github.com/spf13/cobra v1.10.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,6 @@ github.com/sergeymakinen/go-bmp v1.0.0 h1:SdGTzp9WvCV0A1V0mBeaS7kQAwNLdVJbmHlqNW
 github.com/sergeymakinen/go-bmp v1.0.0/go.mod h1:/mxlAQZRLxSvJFNIEGGLBE/m40f3ZnUifpgVDlcUIEY=
 github.com/sergeymakinen/go-ico v1.0.0-beta.0 h1:m5qKH7uPKLdrygMWxbamVn+tl2HfiA3K6MFJw4GfZvQ=
 github.com/sergeymakinen/go-ico v1.0.0-beta.0/go.mod h1:wQ47mTczswBO5F0NoDt7O0IXgnV4Xy3ojrroMQzyhUk=
-github.com/shogo82148/pointer v1.4.0 h1:mEpe+gtEWGP4cX8o5YJdmKAbSsYBCqfMQ70RarPJKGE=
-github.com/shogo82148/pointer v1.4.0/go.mod h1:agZ5JFpavFPXznbWonIvbG78NDfvDTFppe+7o53up5w=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,8 +14,13 @@ import (
 	"github.com/nao1215/gup/internal/cmdinfo"
 	"github.com/nao1215/gup/internal/fileutil"
 	"github.com/nao1215/gup/internal/goutil"
-	"github.com/shogo82148/pointer"
 )
+
+// ptr returns a pointer to v. It replaces the external pointer.Ptr helper,
+// whose go1.26 build constraint conflicts with this module's go1.25.0 policy.
+func ptr[T any](v T) *T {
+	return &v
+}
 
 // ConfigFileName is gup command configuration file
 const ConfigFileName = "gup.json"
@@ -123,8 +128,8 @@ func ReadConfFile(path string) ([]goutil.Package, error) {
 		pkgs = append(pkgs, goutil.Package{
 			Name:          name,
 			ImportPath:    importPath,
-			Version:       pointer.Ptr(binVer),
-			GoVersion:     pointer.Ptr(goVer),
+			Version:       ptr(binVer),
+			GoVersion:     ptr(goVer),
 			UpdateChannel: goutil.NormalizeUpdateChannel(v.Channel),
 		})
 	}

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -17,14 +17,12 @@ const (
 
 // IsFile reports whether the path exists and is a file.
 func IsFile(path string) bool {
-	//nolint:gosec // The caller controls the path; helper intentionally accepts relative paths.
 	stat, err := os.Stat(path)
 	return (err == nil) && (!stat.IsDir())
 }
 
 // IsDir reports whether the path exists and is a directory.
 func IsDir(path string) bool {
-	//nolint:gosec // The caller controls the path; helper intentionally accepts relative paths.
 	stat, err := os.Stat(path)
 	return (err == nil) && (stat.IsDir())
 }

--- a/internal/print/print_test.go
+++ b/internal/print/print_test.go
@@ -15,6 +15,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+const (
+	testPrintMessage = "Print message"
+	testMessage      = "test message"
+	testNoCheck      = "no check"
+)
+
 func TestInfo(t *testing.T) {
 	type args struct {
 		msg string
@@ -25,11 +31,11 @@ func TestInfo(t *testing.T) {
 		want []string
 	}{
 		{
-			name: "Print message",
+			name: testPrintMessage,
 			args: args{
-				msg: "test message",
+				msg: testMessage,
 			},
-			want: []string{"test message", ""},
+			want: []string{testMessage, ""},
 		},
 	}
 	for _, tt := range tests {
@@ -74,9 +80,9 @@ func TestWarn(t *testing.T) {
 		want []string
 	}{
 		{
-			name: "Print message",
+			name: testPrintMessage,
 			args: args{
-				msg: "test message",
+				msg: testMessage,
 			},
 			want: []string{"gup:WARN : test message", ""},
 		},
@@ -123,9 +129,9 @@ func TestErr(t *testing.T) {
 		want []string
 	}{
 		{
-			name: "Print message",
+			name: testPrintMessage,
 			args: args{
-				msg: "test message",
+				msg: testMessage,
 			},
 			want: []string{"gup:ERROR: test message", ""},
 		},
@@ -172,9 +178,9 @@ func TestFatal(t *testing.T) {
 		exitcode int
 	}{
 		{
-			name: "Print message",
+			name: testPrintMessage,
 			args: args{
-				msg: "test message",
+				msg: testMessage,
 			},
 			want:     []string{"gup:FATAL: test message", ""},
 			exitcode: 1,
@@ -234,37 +240,37 @@ func TestQuestion(t *testing.T) {
 	}{
 		{
 			name:  "user input 'y'",
-			args:  args{"no check"},
+			args:  args{testNoCheck},
 			input: "y",
 			want:  true,
 		},
 		{
 			name:  "user input 'yes'",
-			args:  args{"no check"},
+			args:  args{testNoCheck},
 			input: "yes",
 			want:  true,
 		},
 		{
 			name:  "user input 'n'",
-			args:  args{"no check"},
+			args:  args{testNoCheck},
 			input: "n",
 			want:  false,
 		},
 		{
 			name:  "user input 'no'",
-			args:  args{"no check"},
+			args:  args{testNoCheck},
 			input: "no",
 			want:  false,
 		},
 		{
 			name:  "user input 'yes' after 'a'",
-			args:  args{"no check"},
+			args:  args{testNoCheck},
 			input: "a\nyes",
 			want:  true,
 		},
 		{
 			name:  "user only input enter",
-			args:  args{"no check"},
+			args:  args{testNoCheck},
 			input: "\nyes",
 			want:  true,
 		},
@@ -292,7 +298,7 @@ func TestQuestion_FmtScanlnErr(t *testing.T) {
 		}
 		defer func() { FmtScanln = orgFmtScanln }()
 
-		if got := Question("no check"); got != false {
+		if got := Question(testNoCheck); got != false {
 			t.Errorf("Question() = %v, want %v", got, false)
 		}
 	})

--- a/internal/print/print_test.go
+++ b/internal/print/print_test.go
@@ -332,7 +332,6 @@ func mockStdin(t *testing.T, dummyInput string) (funcDefer func(), err error) {
 	return func() {
 		// clean up
 		os.Stdin = oldOsStdin
-		//nolint:gosec // tmpFile is created by os.CreateTemp in this test helper.
 		_ = os.Remove(tmpFile.Name())
 	}, nil
 }


### PR DESCRIPTION
## Summary
Restores a clean `golangci-lint` baseline and aligns the module with its declared `go 1.25.0` policy, then makes CI enforce the lint bar as a hard gate.

Before this change, `golangci-lint run ./...` reported 60 issues (50 `goconst`, 8 `nolintlint`, 2 `govet`); now it reports **0 issues**.

## Changes

### Go compatibility (`govet`)
- `internal/config/config.go`: replaced `pointer.Ptr` (from `github.com/shogo82148/pointer`, whose helper carries a `go1.26` build constraint and could not be inlined into a `go1.25.0` module) with a tiny local generic `ptr` helper.
- Dropped the now-unused `github.com/shogo82148/pointer` dependency (`go mod tidy`). The module now builds consistently on its declared `go 1.25.0` (and the CI matrix 1.25 / 1.26 / latest).

### Stale `nolint` directives (`nolintlint`)
- Removed 8 `//nolint:gosec` comments that `gosec` no longer triggers (`cmd/config_file.go`, `cmd/man.go`, `internal/fileutil/fileutil.go`, `internal/print/print_test.go`).

### Repeated strings (`goconst`)
- Replaced repeated string literals with named constants, reusing existing ones (`testImportPathTool`, `testBinPosixer`, `testShellBash`, `testCmdCompletion`, `latestKeyword`, `testVersion*`) and consolidating duplicated function-local `oldModule`/`newModule` declarations into single package-level constants.
- One minimal production constant (`shellBash` in `cmd/completion.go`); all other production `Use:`/`ValidArgs` literals fell below the goconst threshold once test occurrences were constantized, so production code is otherwise untouched.
- Raw-string `gup.json` fixtures were intentionally left as literal JSON.

### CI enforcement
- Added `.github/workflows/golangci-lint.yml`: runs `golangci-lint run` (golangci-lint v2.12.2) over the whole repo as an **enforced gate** that fails the build on any finding.
- Removed the old non-blocking `reviewdog/action-golangci-lint` job (`level: warning`) from `.github/workflows/reviewdog.yml`; `misspell` and `actionlint` reviewdog jobs are unchanged.

## Verification
- `golangci-lint run ./...` → `0 issues.`
- `go build ./...`, `go vet ./...`, `gofmt -l .` clean.
- `go test -race ./...` passes on all packages.

Closes #269


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added golangci-lint as an enforced CI gate on push and pull requests to the main branch
  * Removed external pointer dependency in favor of a local generic implementation

* **Refactor**
  * Standardized internal test suites to use shared constants instead of hardcoded strings
  * Removed linting suppression comments from the codebase

<!-- end of auto-generated comment: release notes by coderabbit.ai -->