### PR TITLE
fix(completion): return explicit error for --install on Windows

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -11,6 +11,10 @@ import (
 // shellBash is the bash shell name used for completion arguments.
 const shellBash = "bash"
 
+// isWindows reports whether gup is running on Windows. It is a package
+// variable so tests can exercise the Windows-specific --install path on any OS.
+var isWindows = completion.IsWindows //nolint:gochecknoglobals // test seam
+
 func newCompletionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "completion",
@@ -29,6 +33,9 @@ Use --install to write bash/fish/zsh completion files to the user shell config p
 			if install {
 				if len(args) != 0 {
 					return fmt.Errorf("--install cannot be used with shell argument")
+				}
+				if isWindows() {
+					return fmt.Errorf("--install is not supported on Windows; run 'gup completion powershell' to output PowerShell completion to stdout")
 				}
 				completion.DeployShellCompletionFileIfNeeded(rootCmd)
 				return nil

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -1,6 +1,20 @@
+//nolint:paralleltest // tests that stub the package-level isWindows seam must not run in parallel
 package cmd
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+// stubIsWindows overrides the isWindows seam for the duration of a test.
+func stubIsWindows(t *testing.T, v bool) {
+	t.Helper()
+	org := isWindows
+	isWindows = func() bool { return v }
+	t.Cleanup(func() {
+		isWindows = org
+	})
+}
 
 func TestCompletion_NoArgsRequiresExplicitMode(t *testing.T) {
 	t.Parallel()
@@ -23,11 +37,39 @@ func TestCompletion_InstallWithShellArg(t *testing.T) {
 }
 
 func TestCompletion_Install(t *testing.T) {
+	stubIsWindows(t, false)
 	t.Setenv("HOME", t.TempDir())
 
 	cmd := newCompletionCmd()
 	cmd.SetArgs([]string{testFlagInstall})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("completion --install should succeed: %v", err)
+	}
+}
+
+func TestCompletion_InstallWindowsReturnsError(t *testing.T) {
+	stubIsWindows(t, true)
+
+	cmd := newCompletionCmd()
+	cmd.SetArgs([]string{testFlagInstall})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("completion --install should return an error on Windows")
+	}
+	if !strings.Contains(err.Error(), "Windows") {
+		t.Errorf("error should explain Windows is unsupported, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "powershell") {
+		t.Errorf("error should point to 'gup completion powershell', got: %v", err)
+	}
+}
+
+func TestCompletion_PowerShellStdoutWorksOnWindows(t *testing.T) {
+	stubIsWindows(t, true)
+
+	cmd := newCompletionCmd()
+	cmd.SetArgs([]string{testShellPowershell})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("completion powershell stdout generation should work on Windows: %v", err)
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -932,7 +932,13 @@ func TestExecute_Completion(t *testing.T) {
 
 	t.Run("generate completion file", func(t *testing.T) {
 		os.Args = []string{testCmdGup, testCmdCompletion, testFlagInstall}
-		if err := Execute(); err != nil {
+		err := Execute()
+		if runtime.GOOS == goosWindows {
+			// --install is explicitly unsupported on Windows.
+			if err == nil {
+				t.Error("completion --install should return an error on Windows")
+			}
+		} else if err != nil {
 			t.Error(err)
 		}
 


### PR DESCRIPTION
## Summary
`gup completion --install` previously succeeded on Windows even though `internal/completion.DeployShellCompletionFileIfNeeded` is a no-op there. Users were told nothing while no completion was installed — a silent UX failure. The command now fails explicitly on Windows.

## Decision
Of the two options in #265, this implements the **explicit-error** behavior (rather than PowerShell profile integration), which keeps the cross-platform CLI simple and is the lower-risk, maintainable choice. PowerShell completion is still fully available via stdout generation.

## Changes
- `cmd/completion.go`: when `--install` is used on Windows, return a clear error:
  `--install is not supported on Windows; run 'gup completion powershell' to output PowerShell completion to stdout`.
  Introduced a small `isWindows` package-variable seam (matching gup's existing var-stub testing pattern) so both branches can be tested deterministically on any OS.
- Non-Windows `--install` behavior is unchanged; `gup completion powershell` stdout output is unchanged.

## Tests (`cmd/completion_test.go`, `cmd/root_test.go`)
- `TestCompletion_InstallWindowsReturnsError`: stubs Windows → asserts the exact error path (mentions "Windows" and "powershell").
- `TestCompletion_PowerShellStdoutWorksOnWindows`: stubs Windows → `completion powershell` stdout still works.
- `TestCompletion_Install`: stubs non-Windows → `--install` still succeeds (deterministic across OSes).
- `TestExecute_Completion`: updated so the Windows branch expects an error instead of a silent success.

## Verification
- `golangci-lint run ./...` → 0 issues (enforced gate).
- `go build ./...`, `go vet ./...`, `gofmt -l` clean.
- `go test -race ./...` passes on all packages.

Closes #265


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shell completion installation via the `--install` flag now explicitly detects Windows platforms and returns an informative error message that directs users to use the PowerShell completion subcommand as an alternative method.

* **Tests**
  * Added Windows-specific test coverage for shell completion installation, verifying proper error handling on Windows and confirming the PowerShell completion subcommand works correctly on Windows platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->