### PR TITLE
feat(cmd): add per-package timeout for go subprocess operations

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/nao1215/gup/internal/goutil"
 	"github.com/nao1215/gup/internal/print"
@@ -33,6 +34,7 @@ However, do not update`,
 		panic(err)
 	}
 	cmd.Flags().Bool("ignore-go-update", false, "Ignore updates to the Go toolchain")
+	addTimeoutFlag(cmd)
 
 	return cmd
 }
@@ -56,6 +58,12 @@ func check(cmd *cobra.Command, args []string) int {
 		return 1
 	}
 
+	timeout, err := getTimeoutFlag(cmd)
+	if err != nil {
+		print.Err(err)
+		return 1
+	}
+
 	pkgs, err := getPackageInfoByTargets(args)
 	if err != nil {
 		print.Err(err)
@@ -69,10 +77,10 @@ func check(cmd *cobra.Command, args []string) int {
 	}
 	ctx, cancel, signals := newSignalCancelContext()
 	defer stopSignalCancelContext(cancel, signals)
-	return doCheck(ctx, pkgs, cpus, ignoreGoUpdate)
+	return doCheck(ctx, pkgs, cpus, timeout, ignoreGoUpdate)
 }
 
-func doCheck(ctx context.Context, pkgs []goutil.Package, cpus int, ignoreGoUpdate bool) int {
+func doCheck(ctx context.Context, pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpdate bool) int {
 	result := 0
 	countFmt := "[%" + pkgDigit(pkgs) + "d/%" + pkgDigit(pkgs) + "d]"
 	var mu sync.Mutex
@@ -120,7 +128,7 @@ func doCheck(ctx context.Context, pkgs []goutil.Package, cpus int, ignoreGoUpdat
 		}
 	}
 
-	ch := forEachPackage(ctx, pkgs, cpus, checker)
+	ch := forEachPackage(ctx, pkgs, cpus, timeout, checker)
 
 	// print result
 	for i := 0; i < len(pkgs); i++ {

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -443,7 +443,7 @@ func Test_doCheck_modulePathChanged(t *testing.T) {
 			},
 		},
 	}
-	got := doCheck(context.Background(), pkgs, 1, true)
+	got := doCheck(context.Background(), pkgs, 1, 0, true)
 
 	pw.Close()
 	print.Stdout = orgStdout
@@ -493,7 +493,7 @@ func Test_doCheck_customGoBuildTag_noFalsePositiveUpdate(t *testing.T) {
 			},
 		},
 	}
-	got := doCheck(context.Background(), pkgs, 1, false)
+	got := doCheck(context.Background(), pkgs, 1, 0, false)
 
 	if err := pw.Close(); err != nil {
 		t.Fatal(err)
@@ -553,7 +553,7 @@ func Test_doCheck_customGoBuildTag_goVersionDiffColor(t *testing.T) {
 		},
 	}
 
-	got := doCheck(context.Background(), pkgs, 1, false)
+	got := doCheck(context.Background(), pkgs, 1, 0, false)
 	if err := pw.Close(); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -55,5 +55,8 @@ func getTimeoutFlag(cmd *cobra.Command) (time.Duration, error) {
 	if err != nil {
 		return 0, fmt.Errorf("can not parse command line argument (--%s): %w", timeoutFlagName, err)
 	}
+	if v < 0 {
+		return 0, fmt.Errorf("can not parse command line argument (--%s): must be >= 0 (use 0 to disable the timeout)", timeoutFlagName)
+	}
 	return v, nil
 }

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -34,6 +35,25 @@ func getFlagStringSlice(cmd *cobra.Command, name string) ([]string, error) {
 	v, err := cmd.Flags().GetStringSlice(name)
 	if err != nil {
 		return nil, fmt.Errorf("can not parse command line argument (--%s): %w", name, err)
+	}
+	return v, nil
+}
+
+// timeoutFlagName is the name of the shared --timeout flag.
+const timeoutFlagName = "timeout"
+
+// addTimeoutFlag registers the shared --timeout flag used by commands that run
+// go subprocesses (update, check, import, migrate).
+func addTimeoutFlag(cmd *cobra.Command) {
+	cmd.Flags().Duration(timeoutFlagName, defaultGoOpTimeout,
+		"per-package timeout for go operations (e.g. 90s, 5m); 0 disables the timeout")
+}
+
+// getTimeoutFlag reads the shared --timeout flag.
+func getTimeoutFlag(cmd *cobra.Command) (time.Duration, error) {
+	v, err := cmd.Flags().GetDuration(timeoutFlagName)
+	if err != nil {
+		return 0, fmt.Errorf("can not parse command line argument (--%s): %w", timeoutFlagName, err)
 	}
 	return v, nil
 }

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -105,6 +106,75 @@ func TestGetFlagStringSlice(t *testing.T) {
 		cmd := &cobra.Command{}
 		_, err := getFlagStringSlice(cmd, "no-such-flag")
 		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}
+
+func TestGetTimeoutFlag(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default", func(t *testing.T) {
+		t.Parallel()
+		cmd := &cobra.Command{}
+		addTimeoutFlag(cmd)
+		v, err := getTimeoutFlag(cmd)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v != defaultGoOpTimeout {
+			t.Errorf("got %v, want %v", v, defaultGoOpTimeout)
+		}
+	})
+
+	t.Run("zero disables the timeout", func(t *testing.T) {
+		t.Parallel()
+		cmd := &cobra.Command{}
+		addTimeoutFlag(cmd)
+		if err := cmd.Flags().Set(timeoutFlagName, "0"); err != nil {
+			t.Fatal(err)
+		}
+		v, err := getTimeoutFlag(cmd)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v != 0 {
+			t.Errorf("got %v, want 0", v)
+		}
+	})
+
+	t.Run("custom positive value", func(t *testing.T) {
+		t.Parallel()
+		cmd := &cobra.Command{}
+		addTimeoutFlag(cmd)
+		if err := cmd.Flags().Set(timeoutFlagName, "90s"); err != nil {
+			t.Fatal(err)
+		}
+		v, err := getTimeoutFlag(cmd)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v != 90*time.Second {
+			t.Errorf("got %v, want 90s", v)
+		}
+	})
+
+	t.Run("negative value is rejected", func(t *testing.T) {
+		t.Parallel()
+		cmd := &cobra.Command{}
+		addTimeoutFlag(cmd)
+		if err := cmd.Flags().Set(timeoutFlagName, "-1s"); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := getTimeoutFlag(cmd); err == nil {
+			t.Fatal("expected error for negative timeout, got nil")
+		}
+	})
+
+	t.Run("missing flag", func(t *testing.T) {
+		t.Parallel()
+		cmd := &cobra.Command{}
+		if _, err := getTimeoutFlag(cmd); err == nil {
 			t.Fatal("expected error, got nil")
 		}
 	})

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/nao1215/gup/internal/config"
 	"github.com/nao1215/gup/internal/fileutil"
@@ -44,6 +45,7 @@ versions recorded in that gup.json.`,
 	if err := cmd.RegisterFlagCompletionFunc("jobs", completeNCPUs); err != nil {
 		panic(err)
 	}
+	addTimeoutFlag(cmd)
 
 	return cmd
 }
@@ -84,6 +86,12 @@ func runImport(cmd *cobra.Command, _ []string) int {
 	}
 	cpus = clampJobs(cpus)
 
+	timeout, err := getTimeoutFlag(cmd)
+	if err != nil {
+		print.Err(err)
+		return 1
+	}
+
 	if !fileutil.IsFile(confFile) {
 		print.Err(fmt.Errorf("%s is not found", confFile))
 		return 1
@@ -101,10 +109,10 @@ func runImport(cmd *cobra.Command, _ []string) int {
 	}
 
 	print.Info("start import based on " + confFile)
-	return installFromConfig(pkgs, dryRun, notify, cpus)
+	return installFromConfig(pkgs, dryRun, notify, cpus, timeout)
 }
 
-func installFromConfig(pkgs []goutil.Package, dryRun, notification bool, cpus int) int {
+func installFromConfig(pkgs []goutil.Package, dryRun, notification bool, cpus int, timeout time.Duration) int {
 	result := 0
 	countFmt := "[%" + pkgDigit(pkgs) + "d/%" + pkgDigit(pkgs) + "d]"
 	dryRunManager := goutil.NewGoPaths()
@@ -156,7 +164,7 @@ func installFromConfig(pkgs []goutil.Package, dryRun, notification bool, cpus in
 		}
 	}
 
-	ch := forEachPackage(ctx, pkgs, cpus, installer)
+	ch := forEachPackage(ctx, pkgs, cpus, timeout, installer)
 
 	count := 0
 	for v := range ch {

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nao1215/gup/internal/config"
 	"github.com/nao1215/gup/internal/goutil"
@@ -262,7 +263,7 @@ func Test_installFromConfig_UseVersion(t *testing.T) {
 		},
 	}
 
-	if got := installFromConfig(pkgs, false, false, 1); got != 0 {
+	if got := installFromConfig(pkgs, false, false, 1, 0); got != 0 {
 		t.Fatalf("installFromConfig() = %d, want 0", got)
 	}
 
@@ -377,7 +378,7 @@ func Test_installFromConfig_installError(t *testing.T) {
 		},
 	}
 
-	if got := installFromConfig(pkgs, false, false, 1); got != 1 {
+	if got := installFromConfig(pkgs, false, false, 1, 0); got != 1 {
 		t.Fatalf("installFromConfig() = %d, want 1", got)
 	}
 }
@@ -391,7 +392,7 @@ func Test_installFromConfig_emptyImportPath(t *testing.T) {
 		},
 	}
 
-	if got := installFromConfig(pkgs, false, false, 1); got != 1 {
+	if got := installFromConfig(pkgs, false, false, 1, 0); got != 1 {
 		t.Fatalf("installFromConfig() = %d, want 1", got)
 	}
 }
@@ -414,7 +415,7 @@ func Test_installFromConfig_dryRun(t *testing.T) {
 		},
 	}
 
-	if got := installFromConfig(pkgs, true, false, 1); got != 0 {
+	if got := installFromConfig(pkgs, true, false, 1, 0); got != 0 {
 		t.Fatalf("installFromConfig() dry-run = %d, want 0", got)
 	}
 }
@@ -510,5 +511,83 @@ func Test_runImport_autoDetectSingleCandidate(t *testing.T) {
 	}
 	if !strings.Contains(out, "start import based on") {
 		t.Errorf("expected import to start from the detected file, got: %s", out)
+	}
+}
+
+func Test_runImport_timeoutPropagation(t *testing.T) {
+	setupXDGBase(t)
+	chdirToTemp(t)
+
+	// Capture the context deadline the install operation receives.
+	org := installByVersionCtx
+	var sawDeadline bool
+	var remaining time.Duration
+	installByVersionCtx = func(ctx context.Context, _, _ string) error {
+		if dl, ok := ctx.Deadline(); ok {
+			sawDeadline = true
+			remaining = time.Until(dl)
+		}
+		return nil
+	}
+	t.Cleanup(func() { installByVersionCtx = org })
+
+	gobinDir := filepath.Join(t.TempDir(), "gobin")
+	t.Setenv("GOBIN", gobinDir)
+	if err := os.MkdirAll(gobinDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(config.LocalFilePath(), []byte(validImportConf), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newImportCmd()
+	if err := cmd.Flags().Set("timeout", "30s"); err != nil {
+		t.Fatal(err)
+	}
+	if got := runImport(cmd, nil); got != 0 {
+		t.Fatalf("runImport() = %d, want 0", got)
+	}
+
+	if !sawDeadline {
+		t.Fatal("install operation did not receive a context deadline from --timeout")
+	}
+	if remaining <= 0 || remaining > 30*time.Second {
+		t.Errorf("unexpected remaining deadline %v, want (0, 30s]", remaining)
+	}
+}
+
+func Test_runImport_timeoutZeroDisablesDeadline(t *testing.T) {
+	setupXDGBase(t)
+	chdirToTemp(t)
+
+	org := installByVersionCtx
+	var sawDeadline bool
+	installByVersionCtx = func(ctx context.Context, _, _ string) error {
+		if _, ok := ctx.Deadline(); ok {
+			sawDeadline = true
+		}
+		return nil
+	}
+	t.Cleanup(func() { installByVersionCtx = org })
+
+	gobinDir := filepath.Join(t.TempDir(), "gobin")
+	t.Setenv("GOBIN", gobinDir)
+	if err := os.MkdirAll(gobinDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(config.LocalFilePath(), []byte(validImportConf), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newImportCmd()
+	if err := cmd.Flags().Set("timeout", "0"); err != nil {
+		t.Fatal(err)
+	}
+	if got := runImport(cmd, nil); got != 0 {
+		t.Fatalf("runImport() = %d, want 0", got)
+	}
+
+	if sawDeadline {
+		t.Error("install operation should not receive a deadline when --timeout is 0")
 	}
 }

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/nao1215/gup/internal/goutil"
 	"github.com/nao1215/gup/internal/print"
@@ -67,6 +68,7 @@ If BINARY arguments are given, only those binaries are migrated.`,
 		panic(err)
 	}
 	cmd.Flags().Bool("force", false, "reinstall even if the binary already exists in AFTER_PATH")
+	addTimeoutFlag(cmd)
 
 	return cmd
 }
@@ -98,6 +100,11 @@ func runMigrate(cmd *cobra.Command, args []string) int {
 		print.Err(err)
 		return 1
 	}
+	timeout, err := getTimeoutFlag(cmd)
+	if err != nil {
+		print.Err(err)
+		return 1
+	}
 
 	beforePath := args[0]
 	afterPath := args[1]
@@ -123,7 +130,7 @@ func runMigrate(cmd *cobra.Command, args []string) int {
 	}
 
 	print.Info(fmt.Sprintf("start migration from %s to %s", beforePath, afterPath))
-	return migratePackages(pkgs, afterPath, dryRun, notify, cpus, force)
+	return migratePackages(pkgs, afterPath, dryRun, notify, cpus, force, timeout)
 }
 
 // validateMigratePaths validates BEFORE_PATH and AFTER_PATH.
@@ -194,7 +201,7 @@ func sameDirPath(a, b string) (bool, error) {
 	return false, nil
 }
 
-func migratePackages(pkgs []goutil.Package, afterPath string, dryRun, notification bool, cpus int, force bool) int {
+func migratePackages(pkgs []goutil.Package, afterPath string, dryRun, notification bool, cpus int, force bool, timeout time.Duration) int {
 	result := 0
 	countFmt := "[%" + pkgDigit(pkgs) + "d/%" + pkgDigit(pkgs) + "d]"
 	ctx, cancel, signals := newSignalCancelContext()
@@ -249,7 +256,7 @@ func migratePackages(pkgs []goutil.Package, afterPath string, dryRun, notificati
 		return updateResult{updated: true, pkg: p}
 	}
 
-	ch := forEachPackage(ctx, pkgs, cpus, migrator)
+	ch := forEachPackage(ctx, pkgs, cpus, timeout, migrator)
 
 	count := 0
 	for v := range ch {

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -250,7 +250,7 @@ func Test_migratePackages_install(t *testing.T) {
 	}
 
 	out := captureMigrateOutput(t, func() {
-		if got := migratePackages(pkgs, after, false, false, 1, false); got != 0 {
+		if got := migratePackages(pkgs, after, false, false, 1, false, 0); got != 0 {
 			t.Fatalf("migratePackages() = %d, want 0", got)
 		}
 	})
@@ -287,7 +287,7 @@ func Test_migratePackages_addOnlySkip(t *testing.T) {
 	}
 
 	out := captureMigrateOutput(t, func() {
-		if got := migratePackages(pkgs, after, false, false, 1, false); got != 0 {
+		if got := migratePackages(pkgs, after, false, false, 1, false, 0); got != 0 {
 			t.Fatalf("migratePackages() = %d, want 0", got)
 		}
 	})
@@ -322,7 +322,7 @@ func Test_migratePackages_force(t *testing.T) {
 	}
 
 	captureMigrateOutput(t, func() {
-		if got := migratePackages(pkgs, after, false, false, 1, true); got != 0 {
+		if got := migratePackages(pkgs, after, false, false, 1, true, 0); got != 0 {
 			t.Fatalf("migratePackages() = %d, want 0", got)
 		}
 	})
@@ -349,7 +349,7 @@ func Test_migratePackages_dryRun(t *testing.T) {
 	}
 
 	captureMigrateOutput(t, func() {
-		if got := migratePackages(pkgs, after, true, false, 1, false); got != 0 {
+		if got := migratePackages(pkgs, after, true, false, 1, false, 0); got != 0 {
 			t.Fatalf("migratePackages() dry-run = %d, want 0", got)
 		}
 	})
@@ -379,7 +379,7 @@ func Test_migratePackages_skipDevelAndUnknown(t *testing.T) {
 	}
 
 	captureMigrateOutput(t, func() {
-		if got := migratePackages(pkgs, after, false, false, 2, false); got != 0 {
+		if got := migratePackages(pkgs, after, false, false, 2, false, 0); got != 0 {
 			t.Fatalf("migratePackages() = %d, want 0", got)
 		}
 	})
@@ -415,7 +415,7 @@ func Test_migratePackages_modulePathMismatchRetry(t *testing.T) {
 	}
 
 	captureMigrateOutput(t, func() {
-		if got := migratePackages(pkgs, after, false, false, 1, false); got != 0 {
+		if got := migratePackages(pkgs, after, false, false, 1, false, 0); got != 0 {
 			t.Fatalf("migratePackages() = %d, want 0", got)
 		}
 	})
@@ -444,7 +444,7 @@ func Test_migratePackages_installError(t *testing.T) {
 	}
 
 	captureMigrateOutput(t, func() {
-		if got := migratePackages(pkgs, after, false, false, 1, false); got != 1 {
+		if got := migratePackages(pkgs, after, false, false, 1, false, 0); got != 1 {
 			t.Fatalf("migratePackages() = %d, want 1 on install error", got)
 		}
 	})
@@ -466,7 +466,7 @@ func Test_migratePackages_jobsBoundary(t *testing.T) {
 
 	for _, jobs := range []int{-1, 0, 1, 100} {
 		captureMigrateOutput(t, func() {
-			if got := migratePackages(pkgs, after, false, false, jobs, false); got != 0 {
+			if got := migratePackages(pkgs, after, false, false, jobs, false, 0); got != 0 {
 				t.Fatalf("migratePackages(jobs=%d) = %d, want 0", jobs, got)
 			}
 		})

--- a/cmd/parallel.go
+++ b/cmd/parallel.go
@@ -3,13 +3,17 @@ package cmd
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/nao1215/gup/internal/goutil"
 )
 
 // forEachPackage runs fn for each package with a fixed-size worker pool.
 // It returns a channel that receives exactly len(pkgs) results.
-func forEachPackage(ctx context.Context, pkgs []goutil.Package, cpus int, fn func(context.Context, goutil.Package) updateResult) <-chan updateResult {
+// When timeout > 0, each package is processed under its own deadline derived
+// from ctx, so a stuck go subprocess fails instead of hanging indefinitely.
+// Signal-based cancellation of ctx still aborts all in-flight work.
+func forEachPackage(ctx context.Context, pkgs []goutil.Package, cpus int, timeout time.Duration, fn func(context.Context, goutil.Package) updateResult) <-chan updateResult {
 	ch := make(chan updateResult, len(pkgs))
 
 	if len(pkgs) == 0 {
@@ -34,7 +38,7 @@ func forEachPackage(ctx context.Context, pkgs []goutil.Package, cpus int, fn fun
 			case <-ctx.Done():
 				ch <- updateResult{pkg: p, err: ctx.Err()}
 			default:
-				ch <- fn(ctx, p)
+				ch <- runWithTimeout(ctx, timeout, p, fn)
 			}
 		}
 	}
@@ -62,4 +66,15 @@ func forEachPackage(ctx context.Context, pkgs []goutil.Package, cpus int, fn fun
 	}()
 
 	return ch
+}
+
+// runWithTimeout invokes fn for p. When timeout > 0, fn runs under a per-package
+// deadline derived from ctx; otherwise it runs under ctx unchanged.
+func runWithTimeout(ctx context.Context, timeout time.Duration, p goutil.Package, fn func(context.Context, goutil.Package) updateResult) updateResult {
+	if timeout <= 0 {
+		return fn(ctx, p)
+	}
+	opCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return fn(opCtx, p)
 }

--- a/cmd/parallel_test.go
+++ b/cmd/parallel_test.go
@@ -61,7 +61,7 @@ func TestForEachPackage(t *testing.T) {
 		}
 	})
 
-	t.Run("returns error when context is cancelled", func(t *testing.T) {
+	t.Run("returns error when context is canceled", func(t *testing.T) {
 		t.Parallel()
 
 		pkgs := []goutil.Package{{Name: "x"}}
@@ -74,7 +74,7 @@ func TestForEachPackage(t *testing.T) {
 
 		r := <-ch
 		if r.err == nil {
-			t.Fatal("expected error from cancelled context, got nil")
+			t.Fatal("expected error from canceled context, got nil")
 		}
 	})
 

--- a/cmd/parallel_test.go
+++ b/cmd/parallel_test.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/nao1215/gup/internal/goutil"
 )
@@ -20,7 +22,7 @@ func TestForEachPackage(t *testing.T) {
 			{Name: "c"},
 		}
 
-		ch := forEachPackage(context.Background(), pkgs, 2, func(_ context.Context, p goutil.Package) updateResult {
+		ch := forEachPackage(context.Background(), pkgs, 2, 0, func(_ context.Context, p goutil.Package) updateResult {
 			return updateResult{pkg: p}
 		})
 
@@ -46,7 +48,7 @@ func TestForEachPackage(t *testing.T) {
 		pkgs := []goutil.Package{{Name: "fail"}}
 		wantErr := fmt.Errorf("test error")
 
-		ch := forEachPackage(context.Background(), pkgs, 1, func(_ context.Context, p goutil.Package) updateResult {
+		ch := forEachPackage(context.Background(), pkgs, 1, 0, func(_ context.Context, p goutil.Package) updateResult {
 			return updateResult{pkg: p, err: wantErr}
 		})
 
@@ -66,13 +68,47 @@ func TestForEachPackage(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel() // cancel immediately
 
-		ch := forEachPackage(ctx, pkgs, 1, func(_ context.Context, p goutil.Package) updateResult {
+		ch := forEachPackage(ctx, pkgs, 1, 0, func(_ context.Context, p goutil.Package) updateResult {
 			return updateResult{pkg: p}
 		})
 
 		r := <-ch
 		if r.err == nil {
 			t.Fatal("expected error from cancelled context, got nil")
+		}
+	})
+
+	t.Run("applies a per-package timeout", func(t *testing.T) {
+		t.Parallel()
+
+		pkgs := []goutil.Package{{Name: "slow"}}
+		ch := forEachPackage(context.Background(), pkgs, 1, 10*time.Millisecond,
+			func(ctx context.Context, p goutil.Package) updateResult {
+				<-ctx.Done()
+				return updateResult{pkg: p, err: ctx.Err()}
+			})
+
+		r := <-ch
+		if !errors.Is(r.err, context.DeadlineExceeded) {
+			t.Fatalf("expected deadline exceeded from per-package timeout, got: %v", r.err)
+		}
+	})
+
+	t.Run("no deadline when timeout is zero", func(t *testing.T) {
+		t.Parallel()
+
+		pkgs := []goutil.Package{{Name: "a"}}
+		ch := forEachPackage(context.Background(), pkgs, 1, 0,
+			func(ctx context.Context, p goutil.Package) updateResult {
+				if _, ok := ctx.Deadline(); ok {
+					return updateResult{pkg: p, err: fmt.Errorf("unexpected deadline with timeout=0")}
+				}
+				return updateResult{pkg: p}
+			})
+
+		r := <-ch
+		if r.err != nil {
+			t.Fatalf("timeout=0 should not set a deadline: %v", r.err)
 		}
 	})
 }

--- a/cmd/precheck.go
+++ b/cmd/precheck.go
@@ -6,9 +6,16 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/nao1215/gup/internal/goutil"
 )
+
+// defaultGoOpTimeout bounds a single package's go operations (version lookup
+// and install). It guards against unbounded hangs caused by bad network,
+// proxy, or registry states. Users can override it with --timeout, and
+// --timeout 0 disables the bound entirely.
+const defaultGoOpTimeout = 5 * time.Minute
 
 func ensureGoCommandAvailable() error {
 	if err := goutil.CanUseGoCmd(); err != nil {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/nao1215/gup/internal/config"
 	"github.com/nao1215/gup/internal/fileutil"
@@ -66,6 +67,7 @@ using the current installed Go toolchain.`,
 		panic(err)
 	}
 	cmd.Flags().Bool("ignore-go-update", false, "Ignore updates to the Go toolchain")
+	addTimeoutFlag(cmd)
 
 	return cmd
 }
@@ -98,6 +100,12 @@ func gup(cmd *cobra.Command, args []string) int {
 	cpus = clampJobs(cpus)
 
 	ignoreGoUpdate, err := getFlagBool(cmd, "ignore-go-update")
+	if err != nil {
+		print.Err(err)
+		return 1
+	}
+
+	timeout, err := getTimeoutFlag(cmd)
 	if err != nil {
 		print.Err(err)
 		return 1
@@ -163,7 +171,7 @@ func gup(cmd *cobra.Command, args []string) int {
 		return 1
 	}
 
-	result, succeededPkgs, renamedPkgs := updateWithChannels(pkgs, dryRun, notify, cpus, ignoreGoUpdate, channelMap)
+	result, succeededPkgs, renamedPkgs := updateWithChannels(pkgs, dryRun, notify, cpus, ignoreGoUpdate, channelMap, timeout)
 
 	if !dryRun && (shouldPersistChannels(mainPkgNames, masterPkgNames, latestPkgNames) || len(renamedPkgs) > 0) {
 		merged := mergeConfigPackages(confPkgs, succeededPkgs, channelMap, renamedPkgs)
@@ -217,7 +225,7 @@ type updateResult struct {
 	skipReason  string // human-readable reason when skipped is true
 }
 
-func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus int, ignoreGoUpdate bool, channelMap map[string]goutil.UpdateChannel) (int, []goutil.Package, map[string]string) {
+func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus int, ignoreGoUpdate bool, channelMap map[string]goutil.UpdateChannel, timeout time.Duration) (int, []goutil.Package, map[string]string) {
 	result := 0
 	countFmt := "[%" + pkgDigit(pkgs) + "d/%" + pkgDigit(pkgs) + "d]"
 	dryRunManager := goutil.NewGoPaths()
@@ -329,7 +337,7 @@ func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus i
 	}
 
 	// update all packages
-	ch := forEachPackage(ctx, pkgs, cpus, updater)
+	ch := forEachPackage(ctx, pkgs, cpus, timeout, updater)
 
 	// print result
 	count := 0

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -865,7 +865,7 @@ func Test_update_modulePathChangedOnGetLatest(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinAir: goutil.UpdateChannelLatest}
-	if got, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap); got != 0 {
+	if got, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0); got != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", got)
 	}
 	if diff := cmp.Diff([]string{oldModule, newModule}, latestCalls); diff != "" {
@@ -934,7 +934,7 @@ func Test_update_modulePathChangedOnInstall(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinAir: goutil.UpdateChannelLatest}
-	if got, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap); got != 0 {
+	if got, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0); got != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", got)
 	}
 	if diff := cmp.Diff([]string{oldImport, newImport}, installCalls); diff != "" {
@@ -1390,7 +1390,7 @@ func Test_updateWithChannels_emptyImportPath(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap)
+	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0)
 	if result != 1 {
 		t.Fatalf("updateWithChannels() = %d, want 1 (empty import path)", result)
 	}
@@ -1412,7 +1412,7 @@ func Test_updateWithChannels_alreadyUpToDate(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, succeeded, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap)
+	result, succeeded, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
@@ -1469,7 +1469,7 @@ func Test_updateWithChannels_alreadyUpToDate_customGoBuildTag(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, succeeded, _ := updateWithChannels(pkgs, false, false, 1, false, channelMap)
+	result, succeeded, _ := updateWithChannels(pkgs, false, false, 1, false, channelMap, 0)
 
 	if err := pw.Close(); err != nil {
 		t.Fatal(err)
@@ -1546,7 +1546,7 @@ func Test_updateWithChannels_customGoBuildTag_goVersionDiffColor(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, false, channelMap)
+	result, _, _ := updateWithChannels(pkgs, false, false, 1, false, channelMap, 0)
 	if err := pw.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -1586,7 +1586,7 @@ func Test_updateWithChannels_emptyModulePath(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap)
+	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
@@ -1610,7 +1610,7 @@ func Test_updateWithChannels_getLatestVerError(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap)
+	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0)
 	if result != 1 {
 		t.Fatalf("updateWithChannels() = %d, want 1", result)
 	}
@@ -1639,7 +1639,7 @@ func Test_updateWithChannels_masterChannel(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelMaster}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap)
+	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
@@ -1712,7 +1712,7 @@ func Test_updateWithChannels_notify(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(pkgs, false, true, 1, true, channelMap)
+	result, _, _ := updateWithChannels(pkgs, false, true, 1, true, channelMap, 0)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() with notify = %d, want 0", result)
 	}
@@ -1740,7 +1740,7 @@ func Test_updateWithChannels_installError(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap)
+	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0)
 	if result != 1 {
 		t.Fatalf("updateWithChannels() = %d, want 1", result)
 	}
@@ -1777,7 +1777,7 @@ func Test_updateWithChannels_mainChannel(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelMain}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap)
+	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}

--- a/internal/goutil/goutil.go
+++ b/internal/goutil/goutil.go
@@ -399,6 +399,9 @@ func InstallWithContext(ctx context.Context, importPath, version string) error {
 	err := cmd.Run()
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
+			if errors.Is(ctxErr, context.DeadlineExceeded) {
+				return fmt.Errorf("install of %s timed out: %w", importPath, ctxErr)
+			}
 			return fmt.Errorf("install of %s cancelled: %w", importPath, ctxErr)
 		}
 		return fmt.Errorf("can't install %s:\n%s", importPath, stderr.String())
@@ -423,6 +426,9 @@ func GetLatestVerWithContext(ctx context.Context, modulePath string) (string, er
 	out, err := cmd.Output()
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
+			if errors.Is(ctxErr, context.DeadlineExceeded) {
+				return "", fmt.Errorf("version check of %s timed out: %w", modulePath, ctxErr)
+			}
 			return "", fmt.Errorf("version check of %s cancelled: %w", modulePath, ctxErr)
 		}
 		return "", fmt.Errorf("can't check %s:\n%s", modulePath, stderr.String())

--- a/internal/goutil/goutil.go
+++ b/internal/goutil/goutil.go
@@ -402,7 +402,7 @@ func InstallWithContext(ctx context.Context, importPath, version string) error {
 			if errors.Is(ctxErr, context.DeadlineExceeded) {
 				return fmt.Errorf("install of %s timed out: %w", importPath, ctxErr)
 			}
-			return fmt.Errorf("install of %s cancelled: %w", importPath, ctxErr)
+			return fmt.Errorf("install of %s canceled: %w", importPath, ctxErr)
 		}
 		return fmt.Errorf("can't install %s:\n%s", importPath, stderr.String())
 	}
@@ -429,7 +429,7 @@ func GetLatestVerWithContext(ctx context.Context, modulePath string) (string, er
 			if errors.Is(ctxErr, context.DeadlineExceeded) {
 				return "", fmt.Errorf("version check of %s timed out: %w", modulePath, ctxErr)
 			}
-			return "", fmt.Errorf("version check of %s cancelled: %w", modulePath, ctxErr)
+			return "", fmt.Errorf("version check of %s canceled: %w", modulePath, ctxErr)
 		}
 		return "", fmt.Errorf("can't check %s:\n%s", modulePath, stderr.String())
 	}

--- a/internal/goutil/goutil_test.go
+++ b/internal/goutil/goutil_test.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/google/go-cmp/cmp"
@@ -1224,5 +1225,63 @@ func TestGetPackageInformation_emptyList(t *testing.T) {
 	result := GetPackageInformation([]string{})
 	if result != nil {
 		t.Errorf("expected nil for empty list, got %v", result)
+	}
+}
+
+const timeoutTestImportPath = "github.com/nao1215/posixer"
+
+// expiredContext returns a context whose deadline is already in the past.
+func expiredContext(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Hour))
+	t.Cleanup(cancel)
+	return ctx
+}
+
+// cancelledContext returns a context that has already been cancelled.
+func cancelledContext(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return ctx
+}
+
+func TestInstallWithContext_Timeout(t *testing.T) {
+	err := InstallWithContext(expiredContext(t), timeoutTestImportPath, "latest")
+	if err == nil {
+		t.Fatal("InstallWithContext should fail when the context deadline is exceeded")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("error should report a timeout, got: %v", err)
+	}
+}
+
+func TestInstallWithContext_Cancel(t *testing.T) {
+	err := InstallWithContext(cancelledContext(t), timeoutTestImportPath, "latest")
+	if err == nil {
+		t.Fatal("InstallWithContext should fail when the context is cancelled")
+	}
+	if !strings.Contains(err.Error(), "cancelled") {
+		t.Errorf("error should report a cancellation, got: %v", err)
+	}
+}
+
+func TestGetLatestVerWithContext_Timeout(t *testing.T) {
+	_, err := GetLatestVerWithContext(expiredContext(t), timeoutTestImportPath)
+	if err == nil {
+		t.Fatal("GetLatestVerWithContext should fail when the context deadline is exceeded")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("error should report a timeout, got: %v", err)
+	}
+}
+
+func TestGetLatestVerWithContext_Cancel(t *testing.T) {
+	_, err := GetLatestVerWithContext(cancelledContext(t), timeoutTestImportPath)
+	if err == nil {
+		t.Fatal("GetLatestVerWithContext should fail when the context is cancelled")
+	}
+	if !strings.Contains(err.Error(), "cancelled") {
+		t.Errorf("error should report a cancellation, got: %v", err)
 	}
 }

--- a/internal/goutil/goutil_test.go
+++ b/internal/goutil/goutil_test.go
@@ -1238,8 +1238,8 @@ func expiredContext(t *testing.T) context.Context {
 	return ctx
 }
 
-// cancelledContext returns a context that has already been cancelled.
-func cancelledContext(t *testing.T) context.Context {
+// canceledContext returns a context that has already been canceled.
+func canceledContext(t *testing.T) context.Context {
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -1257,11 +1257,11 @@ func TestInstallWithContext_Timeout(t *testing.T) {
 }
 
 func TestInstallWithContext_Cancel(t *testing.T) {
-	err := InstallWithContext(cancelledContext(t), timeoutTestImportPath, "latest")
+	err := InstallWithContext(canceledContext(t), timeoutTestImportPath, "latest")
 	if err == nil {
-		t.Fatal("InstallWithContext should fail when the context is cancelled")
+		t.Fatal("InstallWithContext should fail when the context is canceled")
 	}
-	if !strings.Contains(err.Error(), "cancelled") {
+	if !strings.Contains(err.Error(), "canceled") {
 		t.Errorf("error should report a cancellation, got: %v", err)
 	}
 }
@@ -1277,11 +1277,11 @@ func TestGetLatestVerWithContext_Timeout(t *testing.T) {
 }
 
 func TestGetLatestVerWithContext_Cancel(t *testing.T) {
-	_, err := GetLatestVerWithContext(cancelledContext(t), timeoutTestImportPath)
+	_, err := GetLatestVerWithContext(canceledContext(t), timeoutTestImportPath)
 	if err == nil {
-		t.Fatal("GetLatestVerWithContext should fail when the context is cancelled")
+		t.Fatal("GetLatestVerWithContext should fail when the context is canceled")
 	}
-	if !strings.Contains(err.Error(), "cancelled") {
+	if !strings.Contains(err.Error(), "canceled") {
 		t.Errorf("error should report a cancellation, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
The `go` subprocesses used by `update`, `check`, `import`, and `migrate` ran under a cancelable context but were effectively unbounded — in bad network/proxy/registry states `gup` could appear hung. This adds a configurable per-package timeout while preserving signal-based cancellation.

## Changes
- **Default + configurable timeout**: a new `--timeout` flag (default `5m`, `0` disables) on `update`, `check`, `import`, and `migrate`, registered via a shared `addTimeoutFlag`/`getTimeoutFlag` helper.
- **Per-package enforcement**: `forEachPackage` now derives a per-package deadline from the signal-cancelable context (`runWithTimeout`). Because every command routes its go operations through `forEachPackage`, the timeout is honored consistently across all four commands. Signal-based cancellation of the parent context still aborts in-flight work.
- **Clear errors**: `goutil.InstallWithContext` / `GetLatestVerWithContext` now distinguish `context.DeadlineExceeded` ("... timed out") from cancellation ("... cancelled"), so timeout failures are easy to understand.

## Design notes
- The timeout is applied **per package** (the unit `forEachPackage` schedules), not per whole batch, so it scales correctly regardless of how many binaries are processed in parallel.
- `--timeout 0` preserves the previous unbounded behavior for users who need it.

## Tests
- `internal/goutil` (in `goutil_test.go`): `TestInstallWithContext_Timeout`/`_Cancel` and `TestGetLatestVerWithContext_Timeout`/`_Cancel` assert the timeout vs. cancellation error paths.
- `cmd/parallel_test.go`: `forEachPackage` applies a per-package timeout (DeadlineExceeded) and sets no deadline when `timeout == 0`.
- `cmd/import_test.go`: `Test_runImport_timeoutPropagation` and `Test_runImport_timeoutZeroDisablesDeadline` verify the flag propagates from the CLI layer into the package operation's context.
- Existing call sites pass `0` (unbounded) to preserve prior behavior.

## Verification
- `golangci-lint run ./...` → 0 issues (enforced gate); `go build`, `go vet`, `gofmt` clean; `go test -race ./...` passes.
- Manual: `gup check --timeout 1ns` → `gup:ERROR: [1/1] gal version check of github.com/nao1215/gal timed out: context deadline exceeded`.

Closes #267


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable `--timeout` flag to check, import, migrate, and update commands (default: 5 minutes).
  * Package operations now run with an optional per-package timeout during parallel processing.
  * Set `--timeout 0` to disable timeout enforcement.
* **Bug Fixes**
  * More specific timeout error messages for install and version checks.
* **Tests**
  * Expanded test coverage for timeout propagation, deadline behavior, and timeout=0 handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->