### PR TITLE
test: increase coverage in platform-dependent completion/assets/notify paths

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -8,9 +8,6 @@ coverage:
     - "github.com/nao1215/gup/cmd/root.go"
     - "github.com/nao1215/gup/cmd/man.go"
     - "github.com/nao1215/gup/cmd/bug_report.go"
-    - "github.com/nao1215/gup/internal/assets/asset.go"
-    - "github.com/nao1215/gup/internal/notify/notify.go"
-    - "github.com/nao1215/gup/internal/completion/completion.go"
   badge:
     path: doc/coverage.svg
 diff:

--- a/internal/assets/asset_test.go
+++ b/internal/assets/asset_test.go
@@ -1,0 +1,86 @@
+//nolint:paralleltest // tests mutate the global xdg.ConfigHome and print.Stderr
+package assets
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/adrg/xdg"
+	"github.com/nao1215/gup/internal/config"
+	"github.com/nao1215/gup/internal/fileutil"
+	"github.com/nao1215/gup/internal/print"
+)
+
+// useTempConfigHome points config.DirPath() at a fresh temp directory.
+func useTempConfigHome(t *testing.T) {
+	t.Helper()
+	org := xdg.ConfigHome
+	t.Cleanup(func() { xdg.ConfigHome = org })
+	xdg.ConfigHome = t.TempDir()
+}
+
+func TestIconPaths(t *testing.T) {
+	useTempConfigHome(t)
+
+	assetsDir := filepath.Join(config.DirPath(), "assets")
+	if got, want := InfoIconPath(), filepath.Join(assetsDir, "information.png"); got != want {
+		t.Errorf("InfoIconPath() = %s, want %s", got, want)
+	}
+	if got, want := WarningIconPath(), filepath.Join(assetsDir, "warning.png"); got != want {
+		t.Errorf("WarningIconPath() = %s, want %s", got, want)
+	}
+}
+
+func TestDeployIconIfNeeded(t *testing.T) {
+	useTempConfigHome(t)
+
+	DeployIconIfNeeded()
+
+	if !fileutil.IsFile(InfoIconPath()) {
+		t.Fatalf("info icon was not deployed at %s", InfoIconPath())
+	}
+	if !fileutil.IsFile(WarningIconPath()) {
+		t.Fatalf("warning icon was not deployed at %s", WarningIconPath())
+	}
+
+	got, err := os.ReadFile(InfoIconPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, inforIcon) {
+		t.Error("deployed info icon content does not match the embedded asset")
+	}
+
+	// Calling again must be a no-op and must not error or change the files.
+	DeployIconIfNeeded()
+	if !fileutil.IsFile(InfoIconPath()) || !fileutil.IsFile(WarningIconPath()) {
+		t.Error("icons should still exist after a second DeployIconIfNeeded call")
+	}
+}
+
+func TestDeployIconIfNeeded_MkdirError(t *testing.T) {
+	useTempConfigHome(t)
+
+	// Create a regular file where the gup config directory should be, so
+	// MkdirAll for the assets directory fails.
+	if err := os.WriteFile(config.DirPath(), []byte("not a dir"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := print.Stderr
+	var buf bytes.Buffer
+	print.Stderr = &buf
+	t.Cleanup(func() { print.Stderr = orig })
+
+	DeployIconIfNeeded()
+
+	if !strings.Contains(buf.String(), "can not make assets directory") {
+		t.Errorf("expected assets directory error, got: %s", buf.String())
+	}
+	if fileutil.IsFile(InfoIconPath()) {
+		t.Error("no icon should be created when the assets directory cannot be made")
+	}
+}

--- a/internal/completion/completion_more_test.go
+++ b/internal/completion/completion_more_test.go
@@ -1,13 +1,26 @@
 package completion
 
 import (
+	"bytes"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/nao1215/gup/internal/fileutil"
+	"github.com/nao1215/gup/internal/print"
 )
+
+// capturePrintStderr redirects print.Stderr into a buffer for the test.
+func capturePrintStderr(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	org := print.Stderr
+	buf := &bytes.Buffer{}
+	print.Stderr = buf
+	t.Cleanup(func() { print.Stderr = org })
+	return buf
+}
 
 func TestIsWindows(t *testing.T) {
 	t.Parallel()
@@ -126,6 +139,107 @@ func TestAppendFpathAtZshrcIfNeeded(t *testing.T) {
 	}
 	if got := strings.Count(string(data), "auto generate"); got != 1 {
 		t.Errorf("fpath block appears %d times, want 1 (no duplication)", got)
+	}
+}
+
+func TestMakeBashCompletionFileIfNeeded_MkdirError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if IsWindows() {
+		t.Skip("bash completion is not deployed on Windows")
+	}
+	cmd := testCompletionCmd()
+
+	// Put a regular file where a parent directory must be created, so MkdirAll fails.
+	if err := os.WriteFile(filepath.Join(home, ".local"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	buf := capturePrintStderr(t)
+	makeBashCompletionFileIfNeeded(cmd)
+
+	if !strings.Contains(buf.String(), "can not create bash-completion file") {
+		t.Errorf("expected MkdirAll error, got: %s", buf.String())
+	}
+}
+
+func TestMakeBashCompletionFileIfNeeded_OpenError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if IsWindows() {
+		t.Skip("bash completion is not deployed on Windows")
+	}
+	cmd := testCompletionCmd()
+
+	// Create the completion path itself as a directory so OpenFile fails.
+	if err := os.MkdirAll(bashCompletionFilePath(), 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	buf := capturePrintStderr(t)
+	makeBashCompletionFileIfNeeded(cmd)
+
+	if !strings.Contains(buf.String(), "can not open .bash_completion") {
+		t.Errorf("expected OpenFile error, got: %s", buf.String())
+	}
+}
+
+func TestMakeFishCompletionFileIfNeeded_GenError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if IsWindows() {
+		t.Skip("fish completion is not deployed on Windows")
+	}
+	cmd := testCompletionCmd()
+
+	// Create the completion path as a directory so the file cannot be written.
+	if err := os.MkdirAll(fishCompletionFilePath(), 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	buf := capturePrintStderr(t)
+	makeFishCompletionFileIfNeeded(cmd)
+
+	if !strings.Contains(buf.String(), "can not create fish-completion file") {
+		t.Errorf("expected fish generation error, got: %s", buf.String())
+	}
+}
+
+func TestMakeZshCompletionFileIfNeeded_GenError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if IsWindows() {
+		t.Skip("zsh completion is not deployed on Windows")
+	}
+	cmd := testCompletionCmd()
+
+	// Create the completion path as a directory so the file cannot be written.
+	if err := os.MkdirAll(zshCompletionFilePath(), 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	buf := capturePrintStderr(t)
+	makeZshCompletionFileIfNeeded(cmd)
+
+	if !strings.Contains(buf.String(), "can not create zsh-completion file") {
+		t.Errorf("expected zsh generation error, got: %s", buf.String())
+	}
+}
+
+func TestAppendFpathAtZshrcIfNeeded_OpenError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Make .zshrc a directory so the create-branch OpenFile fails.
+	if err := os.MkdirAll(zshrcPath(), 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	buf := capturePrintStderr(t)
+	appendFpathAtZshrcIfNeeded()
+
+	if !strings.Contains(buf.String(), "can not open .zshrc") {
+		t.Errorf("expected .zshrc open error, got: %s", buf.String())
 	}
 }
 

--- a/internal/completion/completion_more_test.go
+++ b/internal/completion/completion_more_test.go
@@ -1,0 +1,146 @@
+package completion
+
+import (
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/gup/internal/fileutil"
+)
+
+func TestIsWindows(t *testing.T) {
+	t.Parallel()
+	if got, want := IsWindows(), runtime.GOOS == "windows"; got != want {
+		t.Errorf("IsWindows() = %v, want %v", got, want)
+	}
+}
+
+func TestDeployShellCompletionFileIfNeeded(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cmd := testCompletionCmd()
+
+	if IsWindows() {
+		DeployShellCompletionFileIfNeeded(cmd)
+		if fileutil.IsFile(bashCompletionFilePath()) {
+			t.Error("no completion files should be deployed on Windows")
+		}
+		return
+	}
+
+	DeployShellCompletionFileIfNeeded(cmd)
+
+	for _, path := range []string{
+		bashCompletionFilePath(),
+		fishCompletionFilePath(),
+		zshCompletionFilePath(),
+	} {
+		if !fileutil.IsFile(path) {
+			t.Errorf("completion file was not deployed: %s", path)
+		}
+	}
+
+	if !fileutil.IsFile(zshrcPath()) {
+		t.Error("zshrc with fpath setting was not created")
+	}
+
+	// A second run hits the "already up to date" branches and must not error
+	// or duplicate the zshrc fpath block.
+	DeployShellCompletionFileIfNeeded(cmd)
+}
+
+func TestExistSameBashCompletionFile(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cmd := testCompletionCmd()
+
+	if existSameBashCompletionFile(cmd) {
+		t.Fatal("existSameBashCompletionFile() = true, want false when no file exists")
+	}
+
+	writeBashCompletionFile(t, generateBashCompletion(t, cmd))
+
+	if !existSameBashCompletionFile(cmd) {
+		t.Fatal("existSameBashCompletionFile() = false, want true after writing matching content")
+	}
+}
+
+func TestIsSameFishCompletionFile(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if IsWindows() {
+		t.Skip("fish completion is not deployed on Windows")
+	}
+	cmd := testCompletionCmd()
+
+	if isSameFishCompletionFile(cmd) {
+		t.Fatal("isSameFishCompletionFile() = true, want false when no file exists")
+	}
+
+	makeFishCompletionFileIfNeeded(cmd)
+
+	if !isSameFishCompletionFile(cmd) {
+		t.Fatal("isSameFishCompletionFile() = false, want true after generation")
+	}
+}
+
+func TestIsSameZshCompletionFile(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if IsWindows() {
+		t.Skip("zsh completion is not deployed on Windows")
+	}
+	cmd := testCompletionCmd()
+
+	if isSameZshCompletionFile(cmd) {
+		t.Fatal("isSameZshCompletionFile() = true, want false when no file exists")
+	}
+
+	makeZshCompletionFileIfNeeded(cmd)
+
+	if !isSameZshCompletionFile(cmd) {
+		t.Fatal("isSameZshCompletionFile() = false, want true after generation")
+	}
+}
+
+func TestAppendFpathAtZshrcIfNeeded(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// Pre-create .zshrc with unrelated content so the fpath block is appended.
+	if err := os.WriteFile(zshrcPath(), []byte("# existing config\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	appendFpathAtZshrcIfNeeded()
+
+	data, err := os.ReadFile(zshrcPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "fpath=(~/.zsh/completion") {
+		t.Fatalf("fpath block was not appended to .zshrc, got:\n%s", data)
+	}
+
+	// Calling again must not duplicate the block (contains-check branch).
+	appendFpathAtZshrcIfNeeded()
+	data, err = os.ReadFile(zshrcPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(data), "auto generate"); got != 1 {
+		t.Errorf("fpath block appears %d times, want 1 (no duplication)", got)
+	}
+}
+
+func TestCompletionFilePaths(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	for _, path := range []string{
+		bashCompletionFilePath(),
+		fishCompletionFilePath(),
+		zshCompletionFilePath(),
+		zshrcPath(),
+	} {
+		if !strings.HasPrefix(path, home) {
+			t.Errorf("path %s is not rooted at HOME %s", path, home)
+		}
+	}
+}

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -1,0 +1,53 @@
+//go:build !dragonfly
+
+//nolint:paralleltest // tests mutate the global xdg.ConfigHome and print.Stderr
+package notify
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/adrg/xdg"
+	"github.com/nao1215/gup/internal/assets"
+	"github.com/nao1215/gup/internal/fileutil"
+	"github.com/nao1215/gup/internal/print"
+)
+
+// useTempConfigHome points the asset directory at a fresh temp directory and
+// silences print output (beeep may warn when no desktop session is available).
+func useTempConfigHome(t *testing.T) {
+	t.Helper()
+	orgConfig := xdg.ConfigHome
+	orgStderr := print.Stderr
+	orgStdout := print.Stdout
+	t.Cleanup(func() {
+		xdg.ConfigHome = orgConfig
+		print.Stderr = orgStderr
+		print.Stdout = orgStdout
+	})
+	xdg.ConfigHome = t.TempDir()
+	buf := &bytes.Buffer{}
+	print.Stderr = buf
+	print.Stdout = buf
+}
+
+func TestInfo(t *testing.T) {
+	useTempConfigHome(t)
+
+	// Should not panic even when no desktop notification backend is available.
+	Info("gup", "info message")
+
+	if !fileutil.IsFile(assets.InfoIconPath()) {
+		t.Errorf("Info should deploy the info icon at %s", assets.InfoIconPath())
+	}
+}
+
+func TestWarn(t *testing.T) {
+	useTempConfigHome(t)
+
+	Warn("gup", "warning message")
+
+	if !fileutil.IsFile(assets.WarningIconPath()) {
+		t.Errorf("Warn should deploy the warning icon at %s", assets.WarningIconPath())
+	}
+}


### PR DESCRIPTION
## Summary
Coverage was thin in the platform-dependent packages most likely to regress silently (shell completion, asset deployment, desktop notification). This adds focused tests for the main success and failure branches in those packages.

## Coverage (baseline → after)
| Package | Before | After |
|---|---|---|
| `internal/assets` | 0.0% | 86.7% |
| `internal/notify` | 0.0% | 75.0% |
| `internal/completion` | 7.0% | 68.4% |

## Tests added
- **`internal/assets`** (`asset_test.go`): `DeployIconIfNeeded` success + embedded-content check, idempotent second call, and the MkdirAll error branch (config dir is a file); `InfoIconPath`/`WarningIconPath`.
- **`internal/notify`** (`notify_test.go`, `!dragonfly`): smoke tests for `Info`/`Warn` — they don't panic without a desktop backend and deploy the expected icons (output silenced as beeep may warn headless).
- **`internal/completion`** (`completion_more_test.go`): `DeployShellCompletionFileIfNeeded` (deploys bash/fish/zsh + zshrc fpath on non-Windows, no-op on Windows, idempotent second run), `IsWindows`, `existSameBashCompletionFile`, `isSameFishCompletionFile`, `isSameZshCompletionFile`, `appendFpathAtZshrcIfNeeded` (append + no-duplicate), and HOME-rooted path helpers.

Tests isolate state via `t.Setenv("HOME", ...)` and a temporary `xdg.ConfigHome`, and branch on `runtime.GOOS` so they pass on every OS in the CI matrix.

## Verification
- `go test -cover ./...` confirms the coverage increases above.
- `golangci-lint run ./...` → 0 issues (enforced gate); `gofmt`/`go vet` clean; `go test -race ./...` passes on all packages.

Closes #268


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for icon asset path resolution and first-run icon deployment, including idempotent behavior and handling of filesystem setup failures.
  * Added expanded tests for shell completion generation (bash/fish/zsh), including `.zshrc` fpath block correctness and repeated-run idempotency.
  * Added notification tests to ensure Info/Warn calls don’t panic and that the expected icons are available.
* **Chores**
  * Updated OctoCov coverage exclusion settings to refine coverage reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->