### PR TITLE
refactor(cmd): extract a shared package-operation engine

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -75,14 +75,10 @@ func check(cmd *cobra.Command, args []string) int {
 		print.Err("unable to check package: no package information")
 		return 1
 	}
-	ctx, cancel, signals := newSignalCancelContext()
-	defer stopSignalCancelContext(cancel, signals)
-	return doCheck(ctx, pkgs, cpus, timeout, ignoreGoUpdate)
+	return doCheck(pkgs, cpus, timeout, ignoreGoUpdate)
 }
 
-func doCheck(ctx context.Context, pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpdate bool) int {
-	result := 0
-	countFmt := "[%" + pkgDigit(pkgs) + "d/%" + pkgDigit(pkgs) + "d]"
+func doCheck(pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpdate bool) int {
 	var mu sync.Mutex
 	needUpdatePkgs := []goutil.Package{}
 	verCache := newLatestVerCache()
@@ -92,7 +88,7 @@ func doCheck(ctx context.Context, pkgs []goutil.Package, cpus int, timeout time.
 	checker := func(ctx context.Context, p goutil.Package) updateResult {
 		var err error
 		if p.ModulePath == "" {
-			err = fmt.Errorf(" %s is not installed by 'go install' (or permission incorrect)", p.Name)
+			err = fmt.Errorf("%s is not installed by 'go install' (or permission incorrect)", p.Name)
 		} else {
 			var latestVer string
 			modulePathChanged := false
@@ -100,13 +96,13 @@ func doCheck(ctx context.Context, pkgs []goutil.Package, cpus int, timeout time.
 			if err != nil {
 				newPkg, changed := resolveModulePathChange(p, err)
 				if !changed {
-					err = fmt.Errorf(" %s %w", p.Name, err)
+					err = fmt.Errorf("%s %w", p.Name, err)
 				} else {
 					modulePathChanged = true
 					p = newPkg
 					latestVer, err = verCache.get(ctx, p.ModulePath)
 					if err != nil {
-						err = fmt.Errorf(" %s %w", p.Name, err)
+						err = fmt.Errorf("%s %w", p.Name, err)
 					}
 				}
 			}
@@ -128,19 +124,9 @@ func doCheck(ctx context.Context, pkgs []goutil.Package, cpus int, timeout time.
 		}
 	}
 
-	ch := forEachPackage(ctx, pkgs, cpus, timeout, checker)
-
-	// print result
-	for i := 0; i < len(pkgs); i++ {
-		v := <-ch
-		if v.err == nil {
-			print.Info(fmt.Sprintf(countFmt+" %s (%s)",
-				i+1, len(pkgs), v.pkg.ImportPath, v.pkg.VersionCheckResultStr()))
-		} else {
-			result = 1
-			print.Err(fmt.Errorf(countFmt+"%s", i+1, len(pkgs), v.err.Error()))
-		}
-	}
+	result := executePackages(pkgs, cpus, timeout, checker, func(prefix string, v updateResult) {
+		print.Info(fmt.Sprintf("%s %s (%s)", prefix, v.pkg.ImportPath, v.pkg.VersionCheckResultStr()))
+	})
 
 	printUpdatablePkgInfo(needUpdatePkgs)
 	return result

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -3,7 +3,6 @@ package cmd
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"io"
 	"os"
@@ -443,7 +442,7 @@ func Test_doCheck_modulePathChanged(t *testing.T) {
 			},
 		},
 	}
-	got := doCheck(context.Background(), pkgs, 1, 0, true)
+	got := doCheck(pkgs, 1, 0, true)
 
 	pw.Close()
 	print.Stdout = orgStdout
@@ -493,7 +492,7 @@ func Test_doCheck_customGoBuildTag_noFalsePositiveUpdate(t *testing.T) {
 			},
 		},
 	}
-	got := doCheck(context.Background(), pkgs, 1, 0, false)
+	got := doCheck(pkgs, 1, 0, false)
 
 	if err := pw.Close(); err != nil {
 		t.Fatal(err)
@@ -553,7 +552,7 @@ func Test_doCheck_customGoBuildTag_goVersionDiffColor(t *testing.T) {
 		},
 	}
 
-	got := doCheck(context.Background(), pkgs, 1, 0, false)
+	got := doCheck(pkgs, 1, 0, false)
 	if err := pw.Close(); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -113,11 +113,7 @@ func runImport(cmd *cobra.Command, _ []string) int {
 }
 
 func installFromConfig(pkgs []goutil.Package, dryRun, notification bool, cpus int, timeout time.Duration) int {
-	result := 0
-	countFmt := "[%" + pkgDigit(pkgs) + "d/%" + pkgDigit(pkgs) + "d]"
 	dryRunManager := goutil.NewGoPaths()
-	ctx, cancel, signals := newSignalCancelContext()
-	defer stopSignalCancelContext(cancel, signals)
 
 	if dryRun {
 		if err := dryRunManager.StartDryRunMode(); err != nil {
@@ -164,21 +160,9 @@ func installFromConfig(pkgs []goutil.Package, dryRun, notification bool, cpus in
 		}
 	}
 
-	ch := forEachPackage(ctx, pkgs, cpus, timeout, installer)
-
-	count := 0
-	for v := range ch {
-		if v.err == nil {
-			print.Info(fmt.Sprintf(countFmt+" %s@%s", count+1, len(pkgs), v.pkg.ImportPath, v.pkg.Version.Current))
-		} else {
-			result = 1
-			print.Err(fmt.Errorf(countFmt+" %s", count+1, len(pkgs), v.err.Error()))
-		}
-		count++
-		if count == len(pkgs) {
-			break
-		}
-	}
+	result := executePackages(pkgs, cpus, timeout, installer, func(prefix string, v updateResult) {
+		print.Info(fmt.Sprintf("%s %s@%s", prefix, v.pkg.ImportPath, v.pkg.Version.Current))
+	})
 
 	if dryRun {
 		if err := dryRunManager.EndDryRunMode(); err != nil {

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -202,11 +202,6 @@ func sameDirPath(a, b string) (bool, error) {
 }
 
 func migratePackages(pkgs []goutil.Package, afterPath string, dryRun, notification bool, cpus int, force bool, timeout time.Duration) int {
-	result := 0
-	countFmt := "[%" + pkgDigit(pkgs) + "d/%" + pkgDigit(pkgs) + "d]"
-	ctx, cancel, signals := newSignalCancelContext()
-	defer stopSignalCancelContext(cancel, signals)
-
 	// Point GOBIN at AFTER_PATH so the existing 'go install' path reinstalls
 	// into the target directory. Restore the environment afterward. Dry-run
 	// never installs, so the environment is left untouched.
@@ -256,24 +251,13 @@ func migratePackages(pkgs []goutil.Package, afterPath string, dryRun, notificati
 		return updateResult{updated: true, pkg: p}
 	}
 
-	ch := forEachPackage(ctx, pkgs, cpus, timeout, migrator)
-
-	count := 0
-	for v := range ch {
-		switch {
-		case v.err != nil:
-			result = 1
-			print.Err(fmt.Errorf(countFmt+" %s", count+1, len(pkgs), v.err.Error()))
-		case v.skipped:
-			print.Info(fmt.Sprintf(countFmt+" skip %s: %s", count+1, len(pkgs), v.pkg.Name, v.skipReason))
-		default:
-			print.Info(fmt.Sprintf(countFmt+" %s@%s", count+1, len(pkgs), v.pkg.ImportPath, v.pkg.Version.Current))
+	result := executePackages(pkgs, cpus, timeout, migrator, func(prefix string, v updateResult) {
+		if v.skipped {
+			print.Info(fmt.Sprintf("%s skip %s: %s", prefix, v.pkg.Name, v.skipReason))
+			return
 		}
-		count++
-		if count == len(pkgs) {
-			break
-		}
-	}
+		print.Info(fmt.Sprintf("%s %s@%s", prefix, v.pkg.ImportPath, v.pkg.Version.Current))
+	})
 
 	desktopNotifyIfNeeded(result, notification)
 	return result

--- a/cmd/parallel.go
+++ b/cmd/parallel.go
@@ -2,11 +2,56 @@ package cmd
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
 	"github.com/nao1215/gup/internal/goutil"
+	"github.com/nao1215/gup/internal/print"
 )
+
+// countFormat returns the "[%Nd/%Nd]" progress format string for total
+// packages, where N is the digit width of total (e.g. "[%2d/%2d]" for 10).
+func countFormat(total int) string {
+	digit := strconv.Itoa(len(strconv.Itoa(total)))
+	return "[%" + digit + "d/%" + digit + "d]"
+}
+
+// collectResults consumes one result per package from ch in completion order
+// and returns 1 if any package failed, otherwise 0. Failed results print the
+// shared "[i/n] <error>" line; every non-error result is passed to onResult
+// with the formatted "[i/n]" prefix so callers can render command-specific
+// success/skip output and collect data.
+func collectResults(ch <-chan updateResult, total int, onResult func(prefix string, v updateResult)) int {
+	countFmt := countFormat(total)
+	result := 0
+	count := 0
+	for v := range ch {
+		prefix := fmt.Sprintf(countFmt, count+1, total)
+		if v.err != nil {
+			result = 1
+			print.Err(fmt.Errorf("%s %s", prefix, v.err.Error()))
+		} else {
+			onResult(prefix, v)
+		}
+		count++
+	}
+	return result
+}
+
+// executePackages runs worker over each package with signal-based cancellation
+// and a per-package timeout, then reports results via collectResults. It is the
+// shared operation engine used by update, check, import, and migrate.
+func executePackages(pkgs []goutil.Package, cpus int, timeout time.Duration,
+	worker func(context.Context, goutil.Package) updateResult,
+	onResult func(prefix string, v updateResult)) int {
+	ctx, cancel, signals := newSignalCancelContext()
+	defer stopSignalCancelContext(cancel, signals)
+
+	ch := forEachPackage(ctx, pkgs, cpus, timeout, worker)
+	return collectResults(ch, len(pkgs), onResult)
+}
 
 // forEachPackage runs fn for each package with a fixed-size worker pool.
 // It returns a channel that receives exactly len(pkgs) results.

--- a/cmd/parallel_test.go
+++ b/cmd/parallel_test.go
@@ -1,13 +1,16 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/nao1215/gup/internal/goutil"
+	"github.com/nao1215/gup/internal/print"
 )
 
 func TestForEachPackage(t *testing.T) {
@@ -111,4 +114,74 @@ func TestForEachPackage(t *testing.T) {
 			t.Fatalf("timeout=0 should not set a deadline: %v", r.err)
 		}
 	})
+}
+
+func TestCountFormat(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		total int
+		want  string
+	}{
+		{1, "[%1d/%1d]"},
+		{9, "[%1d/%1d]"},
+		{10, "[%2d/%2d]"},
+		{100, "[%3d/%3d]"},
+	}
+	for _, c := range cases {
+		if got := countFormat(c.total); got != c.want {
+			t.Errorf("countFormat(%d) = %q, want %q", c.total, got, c.want)
+		}
+	}
+}
+
+func TestCollectResults_AllSuccess(t *testing.T) {
+	t.Parallel()
+
+	pkgs := []goutil.Package{{Name: "a"}, {Name: "b"}, {Name: "c"}}
+	ch := make(chan updateResult, len(pkgs))
+	for _, p := range pkgs {
+		ch <- updateResult{pkg: p}
+	}
+	close(ch)
+
+	var prefixes []string
+	code := collectResults(ch, len(pkgs), func(prefix string, _ updateResult) {
+		prefixes = append(prefixes, prefix)
+	})
+
+	if code != 0 {
+		t.Errorf("collectResults() = %d, want 0", code)
+	}
+	if got := strings.Join(prefixes, ","); got != "[1/3],[2/3],[3/3]" {
+		t.Errorf("prefixes = %q, want [1/3],[2/3],[3/3]", got)
+	}
+}
+
+//nolint:paralleltest // captures the global print.Stderr
+func TestCollectResults_WithError(t *testing.T) {
+	orgStderr := print.Stderr
+	var buf bytes.Buffer
+	print.Stderr = &buf
+	t.Cleanup(func() { print.Stderr = orgStderr })
+
+	ch := make(chan updateResult, 2)
+	ch <- updateResult{pkg: goutil.Package{Name: "ok"}}
+	ch <- updateResult{pkg: goutil.Package{Name: "bad"}, err: errors.New("boom")}
+	close(ch)
+
+	onResultCalls := 0
+	code := collectResults(ch, 2, func(_ string, _ updateResult) {
+		onResultCalls++
+	})
+
+	if code != 1 {
+		t.Errorf("collectResults() = %d, want 1 when a result has an error", code)
+	}
+	if onResultCalls != 1 {
+		t.Errorf("onResult called %d times, want 1 (only the successful result)", onResultCalls)
+	}
+	if !strings.Contains(buf.String(), "[2/2] boom") {
+		t.Errorf("error output = %q, want it to contain %q", buf.String(), "[2/2] boom")
+	}
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -226,13 +225,9 @@ type updateResult struct {
 }
 
 func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus int, ignoreGoUpdate bool, channelMap map[string]goutil.UpdateChannel, timeout time.Duration) (int, []goutil.Package, map[string]string) {
-	result := 0
-	countFmt := "[%" + pkgDigit(pkgs) + "d/%" + pkgDigit(pkgs) + "d]"
 	dryRunManager := goutil.NewGoPaths()
 	succeededPkgs := make([]goutil.Package, 0, len(pkgs))
 	renamedPkgs := map[string]string{} // oldName -> newName
-	ctx, cancel, signals := newSignalCancelContext()
-	defer stopSignalCancelContext(cancel, signals)
 
 	verCache := newLatestVerCache()
 
@@ -337,27 +332,13 @@ func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus i
 	}
 
 	// update all packages
-	ch := forEachPackage(ctx, pkgs, cpus, timeout, updater)
-
-	// print result
-	count := 0
-	for v := range ch {
-		if v.err == nil {
-			print.Info(fmt.Sprintf(countFmt+" %s (%s)",
-				count+1, len(pkgs), v.pkg.ImportPath, v.pkg.CurrentToLatestStr()))
-			succeededPkgs = append(succeededPkgs, v.pkg)
-			if v.renamedFrom != "" {
-				renamedPkgs[v.renamedFrom] = v.pkg.Name
-			}
-		} else {
-			result = 1
-			print.Err(fmt.Errorf(countFmt+" %s", count+1, len(pkgs), v.err.Error()))
+	result := executePackages(pkgs, cpus, timeout, updater, func(prefix string, v updateResult) {
+		print.Info(fmt.Sprintf("%s %s (%s)", prefix, v.pkg.ImportPath, v.pkg.CurrentToLatestStr()))
+		succeededPkgs = append(succeededPkgs, v.pkg)
+		if v.renamedFrom != "" {
+			renamedPkgs[v.renamedFrom] = v.pkg.Name
 		}
-		count++
-		if count == len(pkgs) {
-			break
-		}
-	}
+	})
 
 	if dryRun {
 		if err := dryRunManager.EndDryRunMode(); err != nil {
@@ -610,10 +591,6 @@ func persistedVersion(p goutil.Package) string {
 		return current
 	}
 	return latestKeyword
-}
-
-func pkgDigit(pkgs []goutil.Package) string {
-	return strconv.Itoa(len(strconv.Itoa(len(pkgs))))
 }
 
 func getBinaryPathList() ([]string, error) {


### PR DESCRIPTION
## Summary
Package-operation orchestration was duplicated across `update`, `check`, `import`, and `migrate`: each repeated the signal-context setup, `[i/n]` count formatting, worker-pool invocation, result loop, and error reporting. This extracts a shared operation engine so commands keep only their command-specific worker and reporting.

## Changes
- **`cmd/parallel.go`** — new shared layer:
  - `countFormat(total)` — the `[%Nd/%Nd]` progress format (replaces the per-command `pkgDigit` construction).
  - `collectResults(ch, total, onResult)` — consumes one result per package, prints the shared `[i/n] <error>` line for failures, and calls `onResult(prefix, v)` for every non-error result; returns the exit code. Pure and unit-testable.
  - `executePackages(pkgs, cpus, timeout, worker, onResult)` — owns signal-based cancellation + per-package timeout (via `forEachPackage`) and delegates to `collectResults`.
- **`update`/`check`/`import`/`migrate`** — replaced their ctx setup + count format + result loop with a single `executePackages(...)` call plus a small success/skip reporter closure. Command-specific collection (succeeded/renamed packages, needs-update list, dry-run, GOBIN redirect, notifications) stays in each command.
- Removed now-unused `pkgDigit`.

## Behavior preservation
- CLI output is byte-for-byte identical. `check` error messages carried a leading space and used a no-space format (`countFmt+"%s"`); the others used `countFmt+" %s"`. The shared formatter standardizes on a single space, and `check`'s error strings were normalized to drop the leading space — net output unchanged.
- Net: the four command files shrink by ~69 lines; the shared engine adds ~45.

## Tests
- New unit tests for the extracted layer: `TestCountFormat`, `TestCollectResults_AllSuccess`, `TestCollectResults_WithError`.
- All existing command-level regression tests for update/check/import/migrate remain green (`doCheck` signature updated to drop the now-engine-owned context).

## Verification
- `go test -race ./...` passes; `golangci-lint run ./...` → 0 issues; `gofmt`/`go vet` clean.
- Manual smoke: `gup check` → `[1/3] <importPath> (...)`, `gup import -f ... --dry-run` → `[1/1] <importPath>@<version>` — unchanged.

Closes #270


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated package execution and result reporting logic across commands for improved maintainability and consistency.
  
* **Tests**
  * Added test coverage for new execution and formatting utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->