### PR TITLE
fix(check): respect saved update channels in gup check

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/nao1215/gup/internal/config"
 	"github.com/nao1215/gup/internal/goutil"
 	"github.com/nao1215/gup/internal/print"
 	"github.com/spf13/cobra"
@@ -75,7 +76,32 @@ func check(cmd *cobra.Command, args []string) int {
 		print.Err("unable to check package: no package information")
 		return 1
 	}
+
+	pkgs = applyCheckChannels(pkgs)
 	return doCheck(pkgs, cpus, timeout, ignoreGoUpdate)
+}
+
+// applyCheckChannels resolves the saved per-package update channel from
+// gup.json so that 'gup check' compares each binary against the same source
+// 'gup update' would install from. The config is located with the same
+// resolution rules used by import/update; when no config exists every package
+// keeps the default @latest behavior.
+func applyCheckChannels(pkgs []goutil.Package) []goutil.Package {
+	confReadPath, resolveErr := config.ResolveImportFilePath("")
+	if resolveErr != nil {
+		// check only reads the config for channel hints and is not the command
+		// targeted by the ambiguity check, so fall back to the user-level config
+		// instead of failing.
+		confReadPath = config.FilePath()
+	}
+
+	confPkgs, err := readConfFileIfExists(confReadPath)
+	if err != nil {
+		print.Warn(fmt.Sprintf("failed to read %s: %s (continuing without config)", confReadPath, err))
+		confPkgs = []goutil.Package{}
+	}
+
+	return applySavedChannels(pkgs, confPkgs)
 }
 
 func doCheck(pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpdate bool) int {
@@ -92,7 +118,7 @@ func doCheck(pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpd
 		} else {
 			var latestVer string
 			modulePathChanged := false
-			latestVer, err = verCache.get(ctx, p.ModulePath)
+			latestVer, err = verCache.getByChannel(ctx, p.ModulePath, p.UpdateChannel)
 			if err != nil {
 				newPkg, changed := resolveModulePathChange(p, err)
 				if !changed {
@@ -100,7 +126,7 @@ func doCheck(pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpd
 				} else {
 					modulePathChanged = true
 					p = newPkg
-					latestVer, err = verCache.get(ctx, p.ModulePath)
+					latestVer, err = verCache.getByChannel(ctx, p.ModulePath, p.UpdateChannel)
 					if err != nil {
 						err = fmt.Errorf("%s %w", p.Name, err)
 					}

--- a/cmd/check_channel_test.go
+++ b/cmd/check_channel_test.go
@@ -1,0 +1,214 @@
+//nolint:paralleltest // tests mutate global function variables for stubbing
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/gup/internal/goutil"
+	"github.com/nao1215/gup/internal/print"
+)
+
+const (
+	testBinMainTool   = "maintool"
+	testBinMasterTool = "mastertool"
+	testBinLatestTool = "latesttool"
+	testVerMaster     = "v0.0.0-master"
+
+	// refMain and refMaster are the go toolchain version selectors
+	// fetchVerForChannel passes to "go list" for the @main and @master channels.
+	refMain   = string(goutil.UpdateChannelMain)
+	refMaster = string(goutil.UpdateChannelMaster)
+)
+
+// newCheckPkg builds a package fixture for doCheck channel tests. The Go
+// toolchain version is pinned equal to itself so only the package version drives
+// the "needs update" decision.
+func newCheckPkg(name, current string, channel goutil.UpdateChannel) goutil.Package {
+	return goutil.Package{
+		Name:          name,
+		ImportPath:    "example.com/" + name + "/cmd/" + name,
+		ModulePath:    "example.com/" + name,
+		Version:       &goutil.Version{Current: current},
+		GoVersion:     &goutil.Version{Current: testGoVersion1224, Latest: testGoVersion1224},
+		UpdateChannel: channel,
+	}
+}
+
+// captureCheckOutput runs fn while capturing everything printed to stdout/stderr.
+func captureCheckOutput(t *testing.T, fn func() int) string {
+	t.Helper()
+	orgStdout := print.Stdout
+	orgStderr := print.Stderr
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	print.Stdout = pw
+	print.Stderr = pw
+
+	fn()
+
+	_ = pw.Close()
+	print.Stdout = orgStdout
+	print.Stderr = orgStderr
+
+	buf := bytes.Buffer{}
+	if _, err := io.Copy(&buf, pr); err != nil {
+		t.Fatal(err)
+	}
+	_ = pr.Close()
+	return buf.String()
+}
+
+func Test_fetchVerForChannel(t *testing.T) {
+	origLatest := getLatestVerCtx
+	origRef := getVerByRefCtx
+	t.Cleanup(func() {
+		getLatestVerCtx = origLatest
+		getVerByRefCtx = origRef
+	})
+
+	getLatestVerCtx = func(_ context.Context, _ string) (string, error) {
+		return "v1.0.0-latest", nil
+	}
+	getVerByRefCtx = func(_ context.Context, _ string, ref string) (string, error) {
+		switch ref {
+		case refMain:
+			return "", errors.New("unknown revision main")
+		case refMaster:
+			return testVerMaster, nil
+		default:
+			return "", fmt.Errorf("unexpected ref %q", ref)
+		}
+	}
+
+	tests := []struct {
+		name    string
+		channel goutil.UpdateChannel
+		want    string
+	}{
+		{"latest channel uses go list @latest", goutil.UpdateChannelLatest, "v1.0.0-latest"},
+		{"master channel uses go list @master", goutil.UpdateChannelMaster, testVerMaster},
+		{"main channel falls back to @master when @main is missing", goutil.UpdateChannelMain, testVerMaster},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := fetchVerForChannel(context.Background(), "example.com/mod", tt.channel)
+			if err != nil {
+				t.Fatalf("fetchVerForChannel() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("fetchVerForChannel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_fetchVerForChannel_mainNoFallbackOnContextError(t *testing.T) {
+	origRef := getVerByRefCtx
+	t.Cleanup(func() { getVerByRefCtx = origRef })
+
+	var refCalls []string
+	getVerByRefCtx = func(_ context.Context, _ string, ref string) (string, error) {
+		refCalls = append(refCalls, ref)
+		return "", context.Canceled
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := fetchVerForChannel(ctx, "example.com/mod", goutil.UpdateChannelMain); err == nil {
+		t.Fatal("fetchVerForChannel() should return error on context cancellation")
+	}
+	if len(refCalls) != 1 || refCalls[0] != refMain {
+		t.Fatalf("expected only the @main attempt on context cancellation, got %v", refCalls)
+	}
+}
+
+func Test_doCheck_respectsSavedChannels(t *testing.T) {
+	origLatest := getLatestVerCtx
+	origRef := getVerByRefCtx
+	t.Cleanup(func() {
+		getLatestVerCtx = origLatest
+		getVerByRefCtx = origRef
+	})
+
+	// @latest always reports v1.0.0 so a main/master binary would look
+	// up-to-date if check wrongly ignored the saved channel.
+	getLatestVerCtx = func(_ context.Context, _ string) (string, error) {
+		return "v1.0.0", nil
+	}
+	getVerByRefCtx = func(_ context.Context, _ string, ref string) (string, error) {
+		switch ref {
+		case refMain:
+			return "v1.5.0", nil
+		case refMaster:
+			return "v2.0.0", nil
+		default:
+			return "", fmt.Errorf("unexpected ref %q", ref)
+		}
+	}
+
+	pkgs := []goutil.Package{
+		// v1.0.0 == @latest v1.0.0 -> up to date
+		newCheckPkg(testBinLatestTool, "v1.0.0", goutil.UpdateChannelLatest),
+		// v1.0.0 < @main v1.5.0 -> needs update
+		newCheckPkg(testBinMainTool, "v1.0.0", goutil.UpdateChannelMain),
+		// v2.0.0 == @master v2.0.0 -> up to date
+		newCheckPkg(testBinMasterTool, "v2.0.0", goutil.UpdateChannelMaster),
+	}
+
+	out := captureCheckOutput(t, func() int {
+		return doCheck(pkgs, 1, 0, true)
+	})
+
+	idx := strings.Index(out, "$ gup update ")
+	if idx < 0 {
+		t.Fatalf("expected an update hint, got:\n%s", out)
+	}
+	hint := out[idx:]
+	if !strings.Contains(hint, testBinMainTool) {
+		t.Fatalf("expected %s in update hint (outdated against @main), got:\n%s", testBinMainTool, hint)
+	}
+	if strings.Contains(hint, testBinLatestTool) {
+		t.Fatalf("%s should be up-to-date against @latest, got hint:\n%s", testBinLatestTool, hint)
+	}
+	if strings.Contains(hint, testBinMasterTool) {
+		t.Fatalf("%s should be up-to-date against @master, got hint:\n%s", testBinMasterTool, hint)
+	}
+}
+
+func Test_applySavedChannels(t *testing.T) {
+	confPkgs := []goutil.Package{
+		{Name: testBinMainTool, UpdateChannel: goutil.UpdateChannelMain},
+		{Name: testBinMasterTool, UpdateChannel: goutil.UpdateChannelMaster},
+		{Name: testBinLatestTool, UpdateChannel: goutil.UpdateChannelLatest},
+	}
+	pkgs := []goutil.Package{
+		{Name: testBinMainTool},
+		{Name: testBinMasterTool},
+		{Name: testBinLatestTool},
+		{Name: "unconfigured"}, // not present in config -> defaults to latest
+	}
+
+	got := applySavedChannels(pkgs, confPkgs)
+
+	want := map[string]goutil.UpdateChannel{
+		testBinMainTool:   goutil.UpdateChannelMain,
+		testBinMasterTool: goutil.UpdateChannelMaster,
+		testBinLatestTool: goutil.UpdateChannelLatest,
+		"unconfigured":    goutil.UpdateChannelLatest,
+	}
+	for _, p := range got {
+		if p.UpdateChannel != want[p.Name] {
+			t.Errorf("applySavedChannels() %s channel = %q, want %q", p.Name, p.UpdateChannel, want[p.Name])
+		}
+	}
+}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -21,6 +21,7 @@ import (
 
 var (
 	getLatestVerCtx        = goutil.GetLatestVerWithContext        //nolint:gochecknoglobals // swapped in tests
+	getVerByRefCtx         = goutil.GetVerWithContext              //nolint:gochecknoglobals // swapped in tests
 	installLatestCtx       = goutil.InstallLatestWithContext       //nolint:gochecknoglobals // swapped in tests
 	installMainOrMasterCtx = goutil.InstallMainOrMasterWithContext //nolint:gochecknoglobals // swapped in tests
 	installByVersionUpdCtx = goutil.InstallWithContext             //nolint:gochecknoglobals // swapped in tests

--- a/cmd/version_cache.go
+++ b/cmd/version_cache.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"sync"
+
+	"github.com/nao1215/gup/internal/goutil"
 )
 
 // latestVerCache deduplicates concurrent getLatestVer calls for the same module path.
@@ -27,14 +29,25 @@ func newLatestVerCache() *latestVerCache {
 	return &latestVerCache{entries: make(map[string]*latestVerEntry)}
 }
 
-// get returns the latest version for the given module path,
-// calling getLatestVer at most once per unique module path.
+// get returns the latest version for the given module path on the @latest
+// channel, calling the fetcher at most once per unique module path.
 func (c *latestVerCache) get(ctx context.Context, modulePath string) (string, error) {
+	return c.getByChannel(ctx, modulePath, goutil.UpdateChannelLatest)
+}
+
+// getByChannel returns the resolved version for the given module path on the
+// requested update channel. Results are cached per (module path, channel) pair
+// so that, for example, a package tracked on @main is not confused with the
+// same module queried on @latest.
+func (c *latestVerCache) getByChannel(ctx context.Context, modulePath string, channel goutil.UpdateChannel) (string, error) {
+	channel = goutil.NormalizeUpdateChannel(string(channel))
+	key := modulePath + "@" + string(channel)
+
 	c.mu.Lock()
-	entry, ok := c.entries[modulePath]
+	entry, ok := c.entries[key]
 	if !ok {
 		entry = &latestVerEntry{}
-		c.entries[modulePath] = entry
+		c.entries[key] = entry
 	}
 	c.mu.Unlock()
 
@@ -61,7 +74,7 @@ func (c *latestVerCache) get(ctx context.Context, modulePath string) (string, er
 		entry.waitCh = make(chan struct{})
 		entry.mu.Unlock()
 
-		version, err := getLatestVerCtx(ctx, modulePath)
+		version, err := fetchVerForChannel(ctx, modulePath, channel)
 
 		entry.mu.Lock()
 		entry.fetching = false
@@ -87,5 +100,33 @@ func (c *latestVerCache) get(ctx context.Context, modulePath string) (string, er
 		close(waitCh)
 
 		return version, err
+	}
+}
+
+// fetchVerForChannel resolves the version that the given update channel would
+// install, mirroring the install-time policy used by 'gup update':
+//   - latest: "$ go list -m ... <module>@latest"
+//   - main:   "$ go list -m ... <module>@main", falling back to @master
+//     (the same @main-with-@master-fallback policy update applies on install)
+//   - master: "$ go list -m ... <module>@master"
+func fetchVerForChannel(ctx context.Context, modulePath string, channel goutil.UpdateChannel) (string, error) {
+	switch goutil.NormalizeUpdateChannel(string(channel)) {
+	case goutil.UpdateChannelMain:
+		ver, err := getVerByRefCtx(ctx, modulePath, string(goutil.UpdateChannelMain))
+		if err == nil {
+			return ver, nil
+		}
+		// Do not fall back when the failure is a cancelled/expired context;
+		// the same cancellation would just hit @master too.
+		if ctx != nil && ctx.Err() != nil {
+			return "", err
+		}
+		return getVerByRefCtx(ctx, modulePath, string(goutil.UpdateChannelMaster))
+	case goutil.UpdateChannelMaster:
+		return getVerByRefCtx(ctx, modulePath, string(goutil.UpdateChannelMaster))
+	case goutil.UpdateChannelLatest:
+		return getLatestVerCtx(ctx, modulePath)
+	default:
+		return getLatestVerCtx(ctx, modulePath)
 	}
 }

--- a/internal/goutil/goutil.go
+++ b/internal/goutil/goutil.go
@@ -417,11 +417,18 @@ func GetLatestVer(modulePath string) (string, error) {
 // GetLatestVerWithContext execute "$ go list -m -f {{.Version}} <importPath>@latest"
 // with context cancellation support.
 func GetLatestVerWithContext(ctx context.Context, modulePath string) (string, error) {
+	return GetVerWithContext(ctx, modulePath, "latest")
+}
+
+// GetVerWithContext execute "$ go list -m -f {{.Version}} <modulePath>@<ref>"
+// with context cancellation support. ref is the version selector understood by
+// the go toolchain, such as "latest", "main", "master" or a concrete version.
+func GetVerWithContext(ctx context.Context, modulePath, ref string) (string, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	var stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, goExe, "list", "-m", "-f", "{{.Version}}", modulePath+"@latest") //#nosec
+	cmd := exec.CommandContext(ctx, goExe, "list", "-m", "-f", "{{.Version}}", modulePath+"@"+ref) //#nosec
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/goutil/goutil_test.go
+++ b/internal/goutil/goutil_test.go
@@ -75,6 +75,40 @@ func TestGetLatestVer_unknown_module(t *testing.T) {
 	}
 }
 
+func TestGetVerWithContext_unknown_module(t *testing.T) {
+	out, err := GetVerWithContext(context.Background(), ".", "master")
+
+	// Require to be error
+	if err == nil {
+		t.Fatalf("GetVerWithContext() should return error. got: nil")
+	}
+
+	// Assert to be empty
+	if out != "" {
+		t.Errorf("GetVerWithContext() should return empty string on error. got: %v", out)
+	}
+}
+
+func TestGetVerWithContext_golden(t *testing.T) {
+	// Backup and defer restore
+	oldGoExe := goExe
+	defer func() {
+		goExe = oldGoExe
+	}()
+
+	// Mock the `go` to `echo` command so that the command succeeds and the
+	// requested ref is echoed back as the resolved version.
+	goExe = "echo"
+
+	out, err := GetVerWithContext(context.Background(), "github.com/nao1215/gup", "master")
+	if err != nil {
+		t.Fatalf("GetVerWithContext() should not return error. got: %v", err)
+	}
+	if !strings.Contains(out, "github.com/nao1215/gup@master") {
+		t.Errorf("GetVerWithContext() should query the @master ref. got: %v", out)
+	}
+}
+
 func TestDetectModulePathMismatch(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
## Summary

Fixes #281.

`gup check` compared every package against `@latest`, ignoring the per-package update channel saved in `gup.json`. This made the result misleading for binaries that intentionally track `@main` or `@master` — `check` could report them as outdated or up-to-date against the wrong source, while `gup update` would install from the saved channel. This is a correctness issue: `check` and `update` must agree on the comparison source.

## Changes

- `gup check` now loads the saved channel using the **same config resolution rules** as `import`/`update` (`config.ResolveImportFilePath` with a user-level fallback). When no config exists, every package keeps the default `@latest` behavior.
- The expected version is resolved per channel, mirroring `update`'s install-time policy:
  - `latest`: `go list -m <module>@latest` (unchanged)
  - `main`: `go list -m <module>@main`, falling back to `@master`
  - `master`: `go list -m <module>@master`
- `goutil`: added `GetVerWithContext(ctx, modulePath, ref)`; `GetLatestVerWithContext` is now a thin wrapper over it.
- The version cache is keyed per `(module, channel)` so the same module queried on different channels is not conflated.

## Acceptance Criteria

- [x] `gup check` respects the saved channel in `gup.json`.
- [x] `main` follows the same `@main` with `@master` fallback policy as `update`.
- [x] `master` checks against `@master`.
- [x] `latest` keeps the current behavior.
- [x] Tests cover mixed-channel results and config resolution edge cases.

## Test

- `Test_fetchVerForChannel` / `Test_fetchVerForChannel_mainNoFallbackOnContextError` — channel dispatch and `@main`→`@master` fallback (no fallback on context cancellation).
- `Test_doCheck_respectsSavedChannels` — mixed-channel installation; a `@main` binary that would look up-to-date against `@latest` is correctly flagged.
- `Test_applySavedChannels` — config mapping and unconfigured-package defaulting to `latest`.
- `goutil` golden/error tests for `GetVerWithContext`.

All tests and `golangci-lint` pass (developed TDD-style: tests written first).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-package update channel configuration, allowing each tool to be checked against specific channels (latest, master, or main) based on saved user preferences.

* **Tests**
  * Introduced comprehensive test coverage for channel-based version resolution logic, including fallback behavior between channels and correct application of saved configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->