### PR TITLE
feat(cmd): add machine-readable JSON output to list, check, and update

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,20 @@ If you want to update binaries, the following command.
 `list`, `check`, and `update` accept `--json`, printing a JSON array instead of the human-readable output (which stays the default).
 
 ```shell
-$ gup check --json | jq -r '.[] | select(.status == "update-available") | .name'
-lazygit
-mimixbox
+$ gup check --json
+[
+  {
+    "name": "gup",
+    "import_path": "github.com/nao1215/gup",
+    "module_path": "github.com/nao1215/gup",
+    "channel": "latest",
+    "current_version": "v1.0.0",
+    "latest_version": "v1.1.0",
+    "current_go_version": "go1.22.4",
+    "installed_go_version": "go1.22.4",
+    "status": "update-available"
+  }
+]
 ```
 
 Each element has these fields: `name`, `import_path`, `module_path`, `channel` (`latest`/`main`/`master`), `current_version`, `latest_version` (empty for `list`), `current_go_version`, `installed_go_version`, `status`, and `error` (omitted when absent). `status` is `installed` (list), `up-to-date`, `update-available` (check), `updated` (update), or `error`.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ If you want to update binaries, the following command.
 
 ```shell
 $ gup check --json | jq -r '.[] | select(.status == "update-available") | .name'
+lazygit
+mimixbox
 ```
 
 Each element has these fields: `name`, `import_path`, `module_path`, `channel` (`latest`/`main`/`master`), `current_version`, `latest_version` (empty for `list`), `current_go_version`, `installed_go_version`, `status`, and `error` (omitted when absent). `status` is `installed` (list), `up-to-date`, `update-available` (check), `updated` (update), or `error`.

--- a/README.md
+++ b/README.md
@@ -151,54 +151,15 @@ If you want to update binaries, the following command.
 ```
 
 ### Machine-readable JSON output (for scripting / CI)
-`list`, `check`, and `update` accept a `--json` flag that prints a JSON array
-instead of the human-readable output, so the result can be consumed by scripts
-and CI. The human-readable output remains the default.
+`list`, `check`, and `update` accept `--json`, printing a JSON array instead of the human-readable output (which stays the default).
 
 ```shell
-$ gup check --json
-[
-  {
-    "name": "gup",
-    "import_path": "github.com/nao1215/gup",
-    "module_path": "github.com/nao1215/gup",
-    "channel": "latest",
-    "current_version": "v1.0.0",
-    "latest_version": "v1.1.0",
-    "current_go_version": "go1.22.4",
-    "installed_go_version": "go1.22.4",
-    "status": "update-available"
-  }
-]
-```
-
-Each element has the following stable fields:
-
-| Field | Description |
-| ----- | ----------- |
-| `name` | Binary name under `$GOBIN`/`$GOPATH/bin`. |
-| `import_path` | Package import path used by `go install`. |
-| `module_path` | Module path (where `go.mod` lives); may be empty if it cannot be determined. |
-| `channel` | Update channel resolved from `gup.json`: `latest`, `main`, or `master`. |
-| `current_version` | Currently installed version. |
-| `latest_version` | Version available on the channel (empty for `list`, which does not query it). |
-| `current_go_version` | Go toolchain version the binary was built with. |
-| `installed_go_version` | Go toolchain version currently installed. |
-| `status` | One of `installed` (list), `up-to-date`, `update-available` (check), `updated` (update), or `error`. |
-| `error` | Error message for the package; omitted when there is no error. |
-
-Notes:
-
-- The array is always valid JSON, including the partial-failure case where some
-  packages have `"status": "error"`. Error details are also printed to STDERR,
-  so STDOUT stays pure JSON.
-- Exit codes are unchanged: the command exits non-zero when any package fails.
-  `check` reporting `update-available` is not an error and exits `0`.
-
-```shell
-# Example: list only the binaries that have an update available.
 $ gup check --json | jq -r '.[] | select(.status == "update-available") | .name'
 ```
+
+Each element has these fields: `name`, `import_path`, `module_path`, `channel` (`latest`/`main`/`master`), `current_version`, `latest_version` (empty for `list`), `current_go_version`, `installed_go_version`, `status`, and `error` (omitted when absent). `status` is `installed` (list), `up-to-date`, `update-available` (check), `updated` (update), or `error`.
+
+The array is always valid JSON, including partial failures (those packages get `"status": "error"`; error detail also goes to STDERR so STDOUT stays pure JSON). Exit codes are unchanged—`check` reporting `update-available` still exits `0`.
 
 ### Export／Import subcommand
 Use export/import when you want to install the same Go binaries across multiple systems.

--- a/README.md
+++ b/README.md
@@ -149,6 +149,57 @@ check binary under $GOPATH/bin or $GOBIN
 If you want to update binaries, the following command.
            $ gup update mimixbox
 ```
+
+### Machine-readable JSON output (for scripting / CI)
+`list`, `check`, and `update` accept a `--json` flag that prints a JSON array
+instead of the human-readable output, so the result can be consumed by scripts
+and CI. The human-readable output remains the default.
+
+```shell
+$ gup check --json
+[
+  {
+    "name": "gup",
+    "import_path": "github.com/nao1215/gup",
+    "module_path": "github.com/nao1215/gup",
+    "channel": "latest",
+    "current_version": "v1.0.0",
+    "latest_version": "v1.1.0",
+    "current_go_version": "go1.22.4",
+    "installed_go_version": "go1.22.4",
+    "status": "update-available"
+  }
+]
+```
+
+Each element has the following stable fields:
+
+| Field | Description |
+| ----- | ----------- |
+| `name` | Binary name under `$GOBIN`/`$GOPATH/bin`. |
+| `import_path` | Package import path used by `go install`. |
+| `module_path` | Module path (where `go.mod` lives); may be empty if it cannot be determined. |
+| `channel` | Update channel resolved from `gup.json`: `latest`, `main`, or `master`. |
+| `current_version` | Currently installed version. |
+| `latest_version` | Version available on the channel (empty for `list`, which does not query it). |
+| `current_go_version` | Go toolchain version the binary was built with. |
+| `installed_go_version` | Go toolchain version currently installed. |
+| `status` | One of `installed` (list), `up-to-date`, `update-available` (check), `updated` (update), or `error`. |
+| `error` | Error message for the package; omitted when there is no error. |
+
+Notes:
+
+- The array is always valid JSON, including the partial-failure case where some
+  packages have `"status": "error"`. Error details are also printed to STDERR,
+  so STDOUT stays pure JSON.
+- Exit codes are unchanged: the command exits non-zero when any package fails.
+  `check` reporting `update-available` is not an error and exits `0`.
+
+```shell
+# Example: list only the binaries that have an update available.
+$ gup check --json | jq -r '.[] | select(.status == "update-available") | .name'
+```
+
 ### Export／Import subcommand
 Use export/import when you want to install the same Go binaries across multiple systems.
 `gup.json` stores import path, binary version, and update channel (`latest` / `main` / `master`).

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/nao1215/gup/internal/config"
@@ -35,6 +34,7 @@ It does not update them.`,
 		panic(err)
 	}
 	cmd.Flags().Bool("ignore-go-update", false, "Ignore updates to the Go toolchain")
+	cmd.Flags().Bool("json", false, "output result as machine-readable JSON")
 	addTimeoutFlag(cmd)
 
 	return cmd
@@ -59,6 +59,12 @@ func check(cmd *cobra.Command, args []string) int {
 		return 1
 	}
 
+	jsonOut, err := getFlagBool(cmd, "json")
+	if err != nil {
+		print.Err(err)
+		return 1
+	}
+
 	timeout, err := getTimeoutFlag(cmd)
 	if err != nil {
 		print.Err(err)
@@ -78,6 +84,9 @@ func check(cmd *cobra.Command, args []string) int {
 	}
 
 	pkgs = applyCheckChannels(pkgs)
+	if jsonOut {
+		return doCheckJSON(pkgs, cpus, timeout, ignoreGoUpdate)
+	}
 	return doCheck(pkgs, cpus, timeout, ignoreGoUpdate)
 }
 
@@ -105,14 +114,25 @@ func applyCheckChannels(pkgs []goutil.Package) []goutil.Package {
 }
 
 func doCheck(pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpdate bool) int {
-	var mu sync.Mutex
-	needUpdatePkgs := []goutil.Package{}
+	return doCheckWith(pkgs, cpus, timeout, ignoreGoUpdate, false)
+}
+
+// doCheckJSON runs the same check as doCheck but emits a JSON array of package
+// records to STDOUT instead of human-readable progress lines.
+func doCheckJSON(pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpdate bool) int {
+	return doCheckWith(pkgs, cpus, timeout, ignoreGoUpdate, true)
+}
+
+func doCheckWith(pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpdate, jsonOut bool) int {
 	verCache := newLatestVerCache()
 
-	print.Info("check binary under $GOPATH/bin or $GOBIN")
+	if !jsonOut {
+		print.Info("check binary under $GOPATH/bin or $GOBIN")
+	}
 
 	checker := func(ctx context.Context, p goutil.Package) updateResult {
 		var err error
+		status := statusUpToDate
 		if p.ModulePath == "" {
 			err = fmt.Errorf("%s is not installed by 'go install' (or permission incorrect)", p.Name)
 		} else {
@@ -137,25 +157,49 @@ func doCheck(pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpd
 
 				shouldUpdate := modulePathChanged || !p.IsPackageUpToDate() || (!ignoreGoUpdate && !p.IsGoUpToDate())
 				if shouldUpdate {
-					mu.Lock()
-					needUpdatePkgs = append(needUpdatePkgs, p)
-					mu.Unlock()
+					status = statusUpdateAvailable
 				}
 			}
 		}
 
 		return updateResult{
-			pkg: p,
-			err: err,
+			pkg:    p,
+			err:    err,
+			status: status,
 		}
 	}
 
-	result := executePackages(pkgs, cpus, timeout, checker, func(prefix string, v updateResult) {
-		print.Info(fmt.Sprintf("%s %s (%s)", prefix, v.pkg.ImportPath, v.pkg.VersionCheckResultStr()))
-	})
+	var onResult func(prefix string, v updateResult)
+	if !jsonOut {
+		onResult = func(prefix string, v updateResult) {
+			print.Info(fmt.Sprintf("%s %s (%s)", prefix, v.pkg.ImportPath, v.pkg.VersionCheckResultStr()))
+		}
+	}
 
-	printUpdatablePkgInfo(needUpdatePkgs)
+	result, results := executePackages(pkgs, cpus, timeout, checker, onResult)
+
+	if jsonOut {
+		if err := encodeJSONPackages(resultsToJSONPackages(results)); err != nil {
+			print.Err(err)
+			return 1
+		}
+		return result
+	}
+
+	printUpdatablePkgInfo(collectNeedUpdatePkgs(results))
 	return result
+}
+
+// collectNeedUpdatePkgs returns the packages from successful results whose
+// status indicates an available update, preserving completion order.
+func collectNeedUpdatePkgs(results []updateResult) []goutil.Package {
+	needUpdate := make([]goutil.Package, 0, len(results))
+	for _, v := range results {
+		if v.err == nil && v.status == statusUpdateAvailable {
+			needUpdate = append(needUpdate, v.pkg)
+		}
+	}
+	return needUpdate
 }
 
 func printUpdatablePkgInfo(pkgs []goutil.Package) {

--- a/cmd/check_channel_test.go
+++ b/cmd/check_channel_test.go
@@ -143,14 +143,14 @@ func Test_doCheck_respectsSavedChannels(t *testing.T) {
 	// @latest always reports v1.0.0 so a main/master binary would look
 	// up-to-date if check wrongly ignored the saved channel.
 	getLatestVerCtx = func(_ context.Context, _ string) (string, error) {
-		return "v1.0.0", nil
+		return testVersionOne, nil
 	}
 	getVerByRefCtx = func(_ context.Context, _ string, ref string) (string, error) {
 		switch ref {
 		case refMain:
 			return "v1.5.0", nil
 		case refMaster:
-			return "v2.0.0", nil
+			return testVersionTwo, nil
 		default:
 			return "", fmt.Errorf("unexpected ref %q", ref)
 		}
@@ -158,11 +158,11 @@ func Test_doCheck_respectsSavedChannels(t *testing.T) {
 
 	pkgs := []goutil.Package{
 		// v1.0.0 == @latest v1.0.0 -> up to date
-		newCheckPkg(testBinLatestTool, "v1.0.0", goutil.UpdateChannelLatest),
+		newCheckPkg(testBinLatestTool, testVersionOne, goutil.UpdateChannelLatest),
 		// v1.0.0 < @main v1.5.0 -> needs update
-		newCheckPkg(testBinMainTool, "v1.0.0", goutil.UpdateChannelMain),
+		newCheckPkg(testBinMainTool, testVersionOne, goutil.UpdateChannelMain),
 		// v2.0.0 == @master v2.0.0 -> up to date
-		newCheckPkg(testBinMasterTool, "v2.0.0", goutil.UpdateChannelMaster),
+		newCheckPkg(testBinMasterTool, testVersionTwo, goutil.UpdateChannelMaster),
 	}
 
 	out := captureCheckOutput(t, func() int {

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -160,7 +160,7 @@ func installFromConfig(pkgs []goutil.Package, dryRun, notification bool, cpus in
 		}
 	}
 
-	result := executePackages(pkgs, cpus, timeout, installer, func(prefix string, v updateResult) {
+	result, _ := executePackages(pkgs, cpus, timeout, installer, func(prefix string, v updateResult) {
 		print.Info(fmt.Sprintf("%s %s@%s", prefix, v.pkg.ImportPath, v.pkg.Version.Current))
 	})
 

--- a/cmd/jsonout.go
+++ b/cmd/jsonout.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"encoding/json"
+
+	"github.com/nao1215/gup/internal/goutil"
+	"github.com/nao1215/gup/internal/print"
+)
+
+// Status values reported in the machine-readable (--json) output. They form a
+// stable contract for scripting and CI use, so existing values must not change.
+const (
+	// statusInstalled is reported by 'list' for every installed binary.
+	statusInstalled = "installed"
+	// statusUpToDate means the binary already matches its update channel.
+	statusUpToDate = "up-to-date"
+	// statusUpdateAvailable means 'check' found a newer version on the channel.
+	statusUpdateAvailable = "update-available"
+	// statusUpdated means 'update' successfully updated the binary.
+	statusUpdated = "updated"
+	// statusError means the package could not be processed; see the error field.
+	statusError = "error"
+)
+
+// jsonPackage is the stable, machine-readable record emitted by --json. The
+// field names are part of the public contract documented in the README.
+type jsonPackage struct {
+	Name               string `json:"name"`
+	ImportPath         string `json:"import_path"`
+	ModulePath         string `json:"module_path"`
+	Channel            string `json:"channel"`
+	CurrentVersion     string `json:"current_version"`
+	LatestVersion      string `json:"latest_version"`
+	CurrentGoVersion   string `json:"current_go_version"`
+	InstalledGoVersion string `json:"installed_go_version"`
+	Status             string `json:"status"`
+	Error              string `json:"error,omitempty"`
+}
+
+// newJSONPackage builds a jsonPackage from package information, the resolved
+// status, and an optional per-package error. Nil Version/GoVersion pointers are
+// tolerated so partial-failure records can still be emitted.
+func newJSONPackage(p goutil.Package, status string, err error) jsonPackage {
+	rec := jsonPackage{
+		Name:       p.Name,
+		ImportPath: p.ImportPath,
+		ModulePath: p.ModulePath,
+		Channel:    string(goutil.NormalizeUpdateChannel(string(p.UpdateChannel))),
+		Status:     status,
+	}
+	if p.Version != nil {
+		rec.CurrentVersion = p.Version.Current
+		rec.LatestVersion = p.Version.Latest
+	}
+	if p.GoVersion != nil {
+		rec.CurrentGoVersion = p.GoVersion.Current
+		rec.InstalledGoVersion = p.GoVersion.Latest
+	}
+	if err != nil {
+		rec.Status = statusError
+		rec.Error = err.Error()
+	}
+	return rec
+}
+
+// resultToJSONPackage converts an execution result into a JSON record. Error
+// results are always reported with statusError regardless of the worker status.
+func resultToJSONPackage(v updateResult) jsonPackage {
+	return newJSONPackage(v.pkg, v.status, v.err)
+}
+
+// resultsToJSONPackages converts execution results into JSON records, preserving
+// completion order.
+func resultsToJSONPackages(results []updateResult) []jsonPackage {
+	recs := make([]jsonPackage, 0, len(results))
+	for _, v := range results {
+		recs = append(recs, resultToJSONPackage(v))
+	}
+	return recs
+}
+
+// encodeJSONPackages writes records to stdout as an indented JSON array. A nil
+// or empty slice is emitted as "[]" (never "null") so consumers always receive
+// a valid JSON array.
+func encodeJSONPackages(recs []jsonPackage) error {
+	if recs == nil {
+		recs = []jsonPackage{}
+	}
+	enc := json.NewEncoder(print.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(recs)
+}

--- a/cmd/jsonout_test.go
+++ b/cmd/jsonout_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -295,5 +296,90 @@ func Test_doCheck_jsonOutput_errorRecord(t *testing.T) {
 	}
 	if recs[0].Error == "" {
 		t.Errorf("expected non-empty error field")
+	}
+}
+
+// Test_check_jsonFlag exercises the command entry point with --json so the
+// flag-parsing and JSON-dispatch branches in check() are covered.
+func Test_check_jsonFlag(t *testing.T) {
+	t.Setenv("GOBIN", filepath.Join("testdata", "check_success"))
+
+	origGetLatest := getLatestVer
+	t.Cleanup(func() { getLatestVer = origGetLatest })
+	getLatestVer = func(string) (string, error) { return testVersionNine, nil }
+
+	cmd := newCheckCmd()
+	if err := cmd.Flags().Set("json", "true"); err != nil {
+		t.Fatalf("failed to set json flag: %v", err)
+	}
+
+	recs := readJSON(t, func() int {
+		return check(cmd, []string{})
+	})
+	if len(recs) == 0 {
+		t.Fatal("expected at least one JSON record from check --json")
+	}
+	for _, r := range recs {
+		if r.Status == "" {
+			t.Errorf("record %q has empty status", r.Name)
+		}
+	}
+}
+
+// Test_list_jsonFlag exercises list() with --json end to end.
+func Test_list_jsonFlag(t *testing.T) {
+	t.Setenv("GOBIN", filepath.Join("testdata", "check_success"))
+
+	cmd := newListCmd()
+	if err := cmd.Flags().Set("json", "true"); err != nil {
+		t.Fatalf("failed to set json flag: %v", err)
+	}
+
+	recs := readJSON(t, func() int {
+		return list(cmd, []string{})
+	})
+	if len(recs) == 0 {
+		t.Fatal("expected at least one JSON record from list --json")
+	}
+	for _, r := range recs {
+		if r.Status != statusInstalled {
+			t.Errorf("list record %q status = %q, want %q", r.Name, r.Status, statusInstalled)
+		}
+	}
+}
+
+// Test_gup_jsonFlag exercises gup() with --json (and --dry-run) so the
+// flag-parsing and JSON-dispatch branches in gup()/updateWithChannels are
+// covered without performing real installs.
+func Test_gup_jsonFlag(t *testing.T) {
+	t.Setenv("GOBIN", filepath.Join("testdata", "check_success"))
+
+	origGetLatest := getLatestVer
+	origInstallLatest := installLatest
+	t.Cleanup(func() {
+		getLatestVer = origGetLatest
+		installLatest = origInstallLatest
+	})
+	getLatestVer = func(string) (string, error) { return testVersionNine, nil }
+	installLatest = func(string) error { return nil }
+
+	cmd := newUpdateCmd()
+	if err := cmd.Flags().Set("json", "true"); err != nil {
+		t.Fatalf("failed to set json flag: %v", err)
+	}
+	if err := cmd.Flags().Set("dry-run", "true"); err != nil {
+		t.Fatalf("failed to set dry-run flag: %v", err)
+	}
+
+	var got int
+	recs := readJSON(t, func() int {
+		got = gup(cmd, []string{})
+		return got
+	})
+	if got != 0 {
+		t.Fatalf("gup() = %d, want 0", got)
+	}
+	if len(recs) == 0 {
+		t.Fatal("expected at least one JSON record from update --json")
 	}
 }

--- a/cmd/jsonout_test.go
+++ b/cmd/jsonout_test.go
@@ -1,0 +1,299 @@
+//nolint:paralleltest // tests mutate global state (print.Stdout)
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/gup/internal/goutil"
+	"github.com/nao1215/gup/internal/print"
+)
+
+const (
+	testImportExampleTool     = "example.com/tool"
+	testImportExampleUpToDate = "example.com/uptodate"
+)
+
+func Test_newJSONPackage(t *testing.T) {
+	pkg := goutil.Package{
+		Name:       testBinTool,
+		ImportPath: testImportExampleTool,
+		ModulePath: testImportExampleTool,
+		Version:    &goutil.Version{Current: testVersionOne, Latest: testVersionTwo},
+		GoVersion:  &goutil.Version{Current: "go1.21.0", Latest: testGoVersion1224},
+		// empty channel must normalize to "latest"
+	}
+
+	got := newJSONPackage(pkg, statusUpdateAvailable, nil)
+
+	want := jsonPackage{
+		Name:               testBinTool,
+		ImportPath:         testImportExampleTool,
+		ModulePath:         testImportExampleTool,
+		Channel:            string(goutil.UpdateChannelLatest),
+		CurrentVersion:     testVersionOne,
+		LatestVersion:      testVersionTwo,
+		CurrentGoVersion:   "go1.21.0",
+		InstalledGoVersion: testGoVersion1224,
+		Status:             statusUpdateAvailable,
+	}
+	if got != want {
+		t.Errorf("newJSONPackage() = %+v, want %+v", got, want)
+	}
+}
+
+func Test_newJSONPackage_nilVersionsAndError(t *testing.T) {
+	pkg := goutil.Package{
+		Name:          "broken",
+		ImportPath:    "example.com/broken",
+		UpdateChannel: goutil.UpdateChannelMain,
+	}
+
+	got := newJSONPackage(pkg, statusError, errors.New("boom"))
+
+	if got.CurrentVersion != "" || got.LatestVersion != "" {
+		t.Errorf("expected empty versions for nil Version, got %+v", got)
+	}
+	if got.CurrentGoVersion != "" || got.InstalledGoVersion != "" {
+		t.Errorf("expected empty go versions for nil GoVersion, got %+v", got)
+	}
+	if got.Channel != string(goutil.UpdateChannelMain) {
+		t.Errorf("channel = %q, want main", got.Channel)
+	}
+	if got.Status != statusError || got.Error != "boom" {
+		t.Errorf("status/error = %q/%q, want error/boom", got.Status, got.Error)
+	}
+}
+
+func Test_encodeJSONPackages_empty(t *testing.T) {
+	out := captureCheckOutput(t, func() int {
+		if err := encodeJSONPackages(nil); err != nil {
+			t.Fatalf("encodeJSONPackages() error = %v", err)
+		}
+		return 0
+	})
+	// Must be a valid empty JSON array, not "null".
+	trimmed := strings.TrimSpace(out)
+	if trimmed != "[]" {
+		t.Fatalf("encodeJSONPackages(nil) = %q, want []", trimmed)
+	}
+}
+
+func Test_encodeJSONPackages_validJSON(t *testing.T) {
+	recs := []jsonPackage{
+		newJSONPackage(goutil.Package{
+			Name:       "a",
+			ImportPath: "example.com/a",
+			Version:    &goutil.Version{Current: testVersionOne, Latest: testVersionOne},
+			GoVersion:  &goutil.Version{Current: testGoVersion1224, Latest: testGoVersion1224},
+		}, statusUpToDate, nil),
+		newJSONPackage(goutil.Package{
+			Name:       "b",
+			ImportPath: "example.com/b",
+		}, statusError, errors.New("network down")),
+	}
+
+	out := captureCheckOutput(t, func() int {
+		if err := encodeJSONPackages(recs); err != nil {
+			t.Fatalf("encodeJSONPackages() error = %v", err)
+		}
+		return 0
+	})
+
+	var decoded []jsonPackage
+	if err := json.Unmarshal([]byte(out), &decoded); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	if len(decoded) != 2 {
+		t.Fatalf("decoded %d records, want 2", len(decoded))
+	}
+	if decoded[0].Status != statusUpToDate || decoded[1].Status != statusError {
+		t.Fatalf("unexpected statuses: %q, %q", decoded[0].Status, decoded[1].Status)
+	}
+	if decoded[1].Error != "network down" {
+		t.Fatalf("error field = %q, want 'network down'", decoded[1].Error)
+	}
+}
+
+// readJSON runs fn (capturing stdout) and decodes the captured output as a
+// slice of jsonPackage records, failing the test if it is not valid JSON.
+func readJSON(t *testing.T, fn func() int) []jsonPackage {
+	t.Helper()
+	orgStdout := print.Stdout
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	print.Stdout = pw
+
+	fn()
+
+	_ = pw.Close()
+	print.Stdout = orgStdout
+
+	buf := bytes.Buffer{}
+	if _, err := io.Copy(&buf, pr); err != nil {
+		t.Fatal(err)
+	}
+	_ = pr.Close()
+
+	var recs []jsonPackage
+	if err := json.Unmarshal(buf.Bytes(), &recs); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\n%s", err, buf.String())
+	}
+	return recs
+}
+
+func Test_doCheck_jsonOutput(t *testing.T) {
+	origLatest := getLatestVerCtx
+	origRef := getVerByRefCtx
+	t.Cleanup(func() {
+		getLatestVerCtx = origLatest
+		getVerByRefCtx = origRef
+	})
+	getLatestVerCtx = func(_ context.Context, _ string) (string, error) {
+		return testVersionTwo, nil
+	}
+	getVerByRefCtx = func(_ context.Context, _ string, _ string) (string, error) {
+		return testVersionNine, nil
+	}
+
+	pkgs := []goutil.Package{
+		newCheckPkg("uptodate", testVersionTwo, goutil.UpdateChannelLatest), // == latest -> up-to-date
+		newCheckPkg("outdated", testVersionOne, goutil.UpdateChannelLatest), // < latest -> update-available
+	}
+
+	recs := readJSON(t, func() int {
+		return doCheckJSON(pkgs, 1, 0, true)
+	})
+
+	got := map[string]string{}
+	for _, r := range recs {
+		got[r.Name] = r.Status
+	}
+	if got["uptodate"] != statusUpToDate {
+		t.Errorf("uptodate status = %q, want %q", got["uptodate"], statusUpToDate)
+	}
+	if got["outdated"] != statusUpdateAvailable {
+		t.Errorf("outdated status = %q, want %q", got["outdated"], statusUpdateAvailable)
+	}
+}
+
+func Test_listJSONRecords(t *testing.T) {
+	pkgs := []goutil.Package{
+		{
+			Name:          testBinTool,
+			ImportPath:    testImportExampleTool,
+			ModulePath:    testImportExampleTool,
+			Version:       &goutil.Version{Current: testVersion123},
+			UpdateChannel: goutil.UpdateChannelMaster,
+		},
+	}
+
+	recs := listJSONRecords(pkgs)
+	if len(recs) != 1 {
+		t.Fatalf("got %d records, want 1", len(recs))
+	}
+	r := recs[0]
+	if r.Status != statusInstalled {
+		t.Errorf("status = %q, want %q", r.Status, statusInstalled)
+	}
+	if r.CurrentVersion != testVersion123 {
+		t.Errorf("current_version = %q, want %s", r.CurrentVersion, testVersion123)
+	}
+	if r.Channel != string(goutil.UpdateChannelMaster) {
+		t.Errorf("channel = %q, want master", r.Channel)
+	}
+	// list does not query latest/go versions.
+	if r.LatestVersion != "" || r.CurrentGoVersion != "" {
+		t.Errorf("expected empty latest/go versions for list, got %+v", r)
+	}
+}
+
+func Test_updateWithChannels_jsonOutput(t *testing.T) {
+	origGetLatest := getLatestVer
+	origInstallLatest := installLatest
+	t.Cleanup(func() {
+		getLatestVer = origGetLatest
+		installLatest = origInstallLatest
+	})
+	// tool: outdated -> will be updated; uptodate: already current -> up-to-date
+	getLatestVer = func(string) (string, error) { return testVersionTwo, nil }
+	installLatest = func(string) error { return nil }
+
+	pkgs := []goutil.Package{
+		{
+			Name:       testBinTool,
+			ImportPath: testImportExampleTool,
+			ModulePath: testImportExampleTool,
+			Version:    &goutil.Version{Current: testVersionOne},
+			GoVersion:  &goutil.Version{Current: testGoVersion1224, Latest: testGoVersion1224},
+		},
+		{
+			Name:       "uptodate",
+			ImportPath: testImportExampleUpToDate,
+			ModulePath: testImportExampleUpToDate,
+			Version:    &goutil.Version{Current: testVersionTwo},
+			GoVersion:  &goutil.Version{Current: testGoVersion1224, Latest: testGoVersion1224},
+		},
+	}
+	channelMap := map[string]goutil.UpdateChannel{
+		testBinTool: goutil.UpdateChannelLatest,
+		"uptodate":  goutil.UpdateChannelLatest,
+	}
+
+	var recs []jsonPackage
+	var result int
+	out := captureCheckOutput(t, func() int {
+		result, _, _ = updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, true)
+		return result
+	})
+
+	if err := json.Unmarshal([]byte(out), &recs); err != nil {
+		t.Fatalf("update --json output is not valid JSON: %v\n%s", err, out)
+	}
+	if result != 0 {
+		t.Fatalf("updateWithChannels() = %d, want 0", result)
+	}
+	got := map[string]string{}
+	for _, r := range recs {
+		got[r.Name] = r.Status
+	}
+	if got["tool"] != statusUpdated {
+		t.Errorf("tool status = %q, want %q", got["tool"], statusUpdated)
+	}
+	if got["uptodate"] != statusUpToDate {
+		t.Errorf("uptodate status = %q, want %q", got["uptodate"], statusUpToDate)
+	}
+}
+
+func Test_doCheck_jsonOutput_errorRecord(t *testing.T) {
+	origLatest := getLatestVerCtx
+	t.Cleanup(func() { getLatestVerCtx = origLatest })
+	getLatestVerCtx = func(_ context.Context, _ string) (string, error) {
+		return "", errors.New("module not found")
+	}
+
+	pkgs := []goutil.Package{
+		newCheckPkg("brokentool", testVersionOne, goutil.UpdateChannelLatest),
+	}
+
+	recs := readJSON(t, func() int {
+		return doCheckJSON(pkgs, 1, 0, true)
+	})
+	if len(recs) != 1 {
+		t.Fatalf("got %d records, want 1", len(recs))
+	}
+	if recs[0].Status != statusError {
+		t.Errorf("status = %q, want %q", recs[0].Status, statusError)
+	}
+	if recs[0].Error == "" {
+		t.Errorf("expected non-empty error field")
+	}
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -11,7 +11,7 @@ import (
 )
 
 func newListCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:               "list",
 		Short:             "List command names with package path and version under $GOPATH/bin or $GOBIN",
 		Long:              `List command names with package path and version under $GOPATH/bin or $GOBIN`,
@@ -21,9 +21,11 @@ func newListCmd() *cobra.Command {
 			OsExit(list(cmd, args))
 		},
 	}
+	cmd.Flags().Bool("json", false, "output result as machine-readable JSON")
+	return cmd
 }
 
-func list(_ *cobra.Command, _ []string) int {
+func list(cmd *cobra.Command, _ []string) int {
 	if err := ensureGoCommandAvailable(); err != nil {
 		print.Err(err)
 		return 1
@@ -39,9 +41,35 @@ func list(_ *cobra.Command, _ []string) int {
 		print.Err("unable to list up package: no package information")
 		return 1
 	}
-	printPackageList(pkgs)
 
+	jsonOut, err := getFlagBool(cmd, "json")
+	if err != nil {
+		print.Err(err)
+		return 1
+	}
+
+	if jsonOut {
+		pkgs = applyCheckChannels(pkgs)
+		if err := encodeJSONPackages(listJSONRecords(pkgs)); err != nil {
+			print.Err(err)
+			return 1
+		}
+		return 0
+	}
+
+	printPackageList(pkgs)
 	return 0
+}
+
+// listJSONRecords builds JSON records for 'list'. list only knows the installed
+// (current) version, so latest/Go-version fields stay empty and status is
+// reported as "installed".
+func listJSONRecords(pkgs []goutil.Package) []jsonPackage {
+	recs := make([]jsonPackage, 0, len(pkgs))
+	for _, p := range pkgs {
+		recs = append(recs, newJSONPackage(p, statusInstalled, nil))
+	}
+	return recs
 }
 
 // PackageList list up command package in $GOPATH/bin or $GOBIN

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -252,7 +252,7 @@ func migratePackages(pkgs []goutil.Package, afterPath string, dryRun, notificati
 		return updateResult{updated: true, pkg: p}
 	}
 
-	result := executePackages(pkgs, cpus, timeout, migrator, func(prefix string, v updateResult) {
+	result, _ := executePackages(pkgs, cpus, timeout, migrator, func(prefix string, v updateResult) {
 		if v.skipped {
 			print.Info(fmt.Sprintf("%s skip %s: %s", prefix, v.pkg.Name, v.skipReason))
 			return

--- a/cmd/parallel.go
+++ b/cmd/parallel.go
@@ -19,33 +19,39 @@ func countFormat(total int) string {
 }
 
 // collectResults consumes one result per package from ch in completion order
-// and returns 1 if any package failed, otherwise 0. Failed results print the
-// shared "[i/n] <error>" line; every non-error result is passed to onResult
-// with the formatted "[i/n]" prefix so callers can render command-specific
-// success/skip output and collect data.
-func collectResults(ch <-chan updateResult, total int, onResult func(prefix string, v updateResult)) int {
+// and returns 1 if any package failed (otherwise 0) together with every result
+// in completion order. Failed results print the shared "[i/n] <error>" line to
+// STDERR; every non-error result is passed to onResult with the formatted
+// "[i/n]" prefix so callers can render command-specific success/skip output.
+// onResult may be nil (used by --json callers that render from the returned
+// results instead of streaming human-readable lines).
+func collectResults(ch <-chan updateResult, total int, onResult func(prefix string, v updateResult)) (int, []updateResult) {
 	countFmt := countFormat(total)
 	result := 0
 	count := 0
+	results := make([]updateResult, 0, total)
 	for v := range ch {
+		results = append(results, v)
 		prefix := fmt.Sprintf(countFmt, count+1, total)
 		if v.err != nil {
 			result = 1
 			print.Err(fmt.Errorf("%s %s", prefix, v.err.Error()))
-		} else {
+		} else if onResult != nil {
 			onResult(prefix, v)
 		}
 		count++
 	}
-	return result
+	return result, results
 }
 
 // executePackages runs worker over each package with signal-based cancellation
 // and a per-package timeout, then reports results via collectResults. It is the
-// shared operation engine used by update, check, import, and migrate.
+// shared operation engine used by update, check, import, and migrate. It returns
+// the exit code (1 if any package failed) and the per-package results in
+// completion order.
 func executePackages(pkgs []goutil.Package, cpus int, timeout time.Duration,
 	worker func(context.Context, goutil.Package) updateResult,
-	onResult func(prefix string, v updateResult)) int {
+	onResult func(prefix string, v updateResult)) (int, []updateResult) {
 	ctx, cancel, signals := newSignalCancelContext()
 	defer stopSignalCancelContext(cancel, signals)
 

--- a/cmd/parallel_test.go
+++ b/cmd/parallel_test.go
@@ -146,7 +146,7 @@ func TestCollectResults_AllSuccess(t *testing.T) {
 	close(ch)
 
 	var prefixes []string
-	code := collectResults(ch, len(pkgs), func(prefix string, _ updateResult) {
+	code, _ := collectResults(ch, len(pkgs), func(prefix string, _ updateResult) {
 		prefixes = append(prefixes, prefix)
 	})
 
@@ -171,7 +171,7 @@ func TestCollectResults_WithError(t *testing.T) {
 	close(ch)
 
 	onResultCalls := 0
-	code := collectResults(ch, 2, func(_ string, _ updateResult) {
+	code, _ := collectResults(ch, 2, func(_ string, _ updateResult) {
 		onResultCalls++
 	})
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -67,6 +67,7 @@ using the current installed Go toolchain.`,
 		panic(err)
 	}
 	cmd.Flags().Bool("ignore-go-update", false, "Ignore updates to the Go toolchain")
+	cmd.Flags().Bool("json", false, "output result as machine-readable JSON")
 	addTimeoutFlag(cmd)
 
 	return cmd
@@ -100,6 +101,12 @@ func gup(cmd *cobra.Command, args []string) int {
 	cpus = clampJobs(cpus)
 
 	ignoreGoUpdate, err := getFlagBool(cmd, "ignore-go-update")
+	if err != nil {
+		print.Err(err)
+		return 1
+	}
+
+	jsonOut, err := getFlagBool(cmd, "json")
 	if err != nil {
 		print.Err(err)
 		return 1
@@ -171,7 +178,7 @@ func gup(cmd *cobra.Command, args []string) int {
 		return 1
 	}
 
-	result, succeededPkgs, renamedPkgs := updateWithChannels(pkgs, dryRun, notify, cpus, ignoreGoUpdate, channelMap, timeout)
+	result, succeededPkgs, renamedPkgs := updateWithChannels(pkgs, dryRun, notify, cpus, ignoreGoUpdate, channelMap, timeout, jsonOut)
 
 	if !dryRun && (shouldPersistChannels(mainPkgNames, masterPkgNames, latestPkgNames) || len(renamedPkgs) > 0) {
 		merged := mergeConfigPackages(confPkgs, succeededPkgs, channelMap, renamedPkgs)
@@ -223,16 +230,17 @@ type updateResult struct {
 	renamedFrom string // original binary name if renamed during update
 	skipped     bool   // true when the package was intentionally skipped (no error)
 	skipReason  string // human-readable reason when skipped is true
+	status      string // machine-readable status for --json output (see jsonout.go)
 }
 
-func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus int, ignoreGoUpdate bool, channelMap map[string]goutil.UpdateChannel, timeout time.Duration) (int, []goutil.Package, map[string]string) {
+func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus int, ignoreGoUpdate bool, channelMap map[string]goutil.UpdateChannel, timeout time.Duration, jsonOut bool) (int, []goutil.Package, map[string]string) {
 	dryRunManager := goutil.NewGoPaths()
-	succeededPkgs := make([]goutil.Package, 0, len(pkgs))
-	renamedPkgs := map[string]string{} // oldName -> newName
 
 	verCache := newLatestVerCache()
 
-	print.Info("update binary under $GOPATH/bin or $GOBIN")
+	if !jsonOut {
+		print.Info("update binary under $GOPATH/bin or $GOBIN")
+	}
 	if dryRun {
 		if err := dryRunManager.StartDryRunMode(); err != nil {
 			print.Err(fmt.Errorf("can not change to dry run mode: %w", err))
@@ -280,6 +288,7 @@ func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus i
 				updated: false,
 				pkg:     p,
 				err:     nil,
+				status:  statusUpToDate,
 			}
 		}
 
@@ -324,22 +333,28 @@ func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus i
 		if updateErr == nil && p.Name != originalName {
 			renamed = originalName
 		}
+		status := statusUpdated
+		if updateErr != nil {
+			status = statusError
+		}
 		return updateResult{
 			updated:     updateErr == nil,
 			pkg:         p,
 			err:         updateErr,
 			renamedFrom: renamed,
+			status:      status,
+		}
+	}
+
+	var onResult func(prefix string, v updateResult)
+	if !jsonOut {
+		onResult = func(prefix string, v updateResult) {
+			print.Info(fmt.Sprintf("%s %s (%s)", prefix, v.pkg.ImportPath, v.pkg.CurrentToLatestStr()))
 		}
 	}
 
 	// update all packages
-	result := executePackages(pkgs, cpus, timeout, updater, func(prefix string, v updateResult) {
-		print.Info(fmt.Sprintf("%s %s (%s)", prefix, v.pkg.ImportPath, v.pkg.CurrentToLatestStr()))
-		succeededPkgs = append(succeededPkgs, v.pkg)
-		if v.renamedFrom != "" {
-			renamedPkgs[v.renamedFrom] = v.pkg.Name
-		}
-	})
+	result, results := executePackages(pkgs, cpus, timeout, updater, onResult)
 
 	if dryRun {
 		if err := dryRunManager.EndDryRunMode(); err != nil {
@@ -348,9 +363,35 @@ func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus i
 		}
 	}
 
+	if jsonOut {
+		if err := encodeJSONPackages(resultsToJSONPackages(results)); err != nil {
+			print.Err(err)
+			result = 1
+		}
+	}
+
 	desktopNotifyIfNeeded(result, notification)
 
+	succeededPkgs, renamedPkgs := succeededAndRenamed(results)
 	return result, succeededPkgs, renamedPkgs
+}
+
+// succeededAndRenamed derives the successfully-processed packages and the
+// old->new rename map from execution results, so the config-persistence logic
+// works identically in human-readable and --json modes.
+func succeededAndRenamed(results []updateResult) ([]goutil.Package, map[string]string) {
+	succeededPkgs := make([]goutil.Package, 0, len(results))
+	renamedPkgs := map[string]string{} // oldName -> newName
+	for _, v := range results {
+		if v.err != nil {
+			continue
+		}
+		succeededPkgs = append(succeededPkgs, v.pkg)
+		if v.renamedFrom != "" {
+			renamedPkgs[v.renamedFrom] = v.pkg.Name
+		}
+	}
+	return succeededPkgs, renamedPkgs
 }
 
 func desktopNotifyIfNeeded(result int, enable bool) {

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -865,7 +865,7 @@ func Test_update_modulePathChangedOnGetLatest(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinAir: goutil.UpdateChannelLatest}
-	if got, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0); got != 0 {
+	if got, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false); got != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", got)
 	}
 	if diff := cmp.Diff([]string{oldModule, newModule}, latestCalls); diff != "" {
@@ -934,7 +934,7 @@ func Test_update_modulePathChangedOnInstall(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinAir: goutil.UpdateChannelLatest}
-	if got, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0); got != 0 {
+	if got, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false); got != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", got)
 	}
 	if diff := cmp.Diff([]string{oldImport, newImport}, installCalls); diff != "" {
@@ -1390,7 +1390,7 @@ func Test_updateWithChannels_emptyImportPath(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0)
+	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false)
 	if result != 1 {
 		t.Fatalf("updateWithChannels() = %d, want 1 (empty import path)", result)
 	}
@@ -1412,7 +1412,7 @@ func Test_updateWithChannels_alreadyUpToDate(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, succeeded, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0)
+	result, succeeded, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
@@ -1469,7 +1469,7 @@ func Test_updateWithChannels_alreadyUpToDate_customGoBuildTag(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, succeeded, _ := updateWithChannels(pkgs, false, false, 1, false, channelMap, 0)
+	result, succeeded, _ := updateWithChannels(pkgs, false, false, 1, false, channelMap, 0, false)
 
 	if err := pw.Close(); err != nil {
 		t.Fatal(err)
@@ -1546,7 +1546,7 @@ func Test_updateWithChannels_customGoBuildTag_goVersionDiffColor(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, false, channelMap, 0)
+	result, _, _ := updateWithChannels(pkgs, false, false, 1, false, channelMap, 0, false)
 	if err := pw.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -1586,7 +1586,7 @@ func Test_updateWithChannels_emptyModulePath(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0)
+	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
@@ -1610,7 +1610,7 @@ func Test_updateWithChannels_getLatestVerError(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0)
+	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false)
 	if result != 1 {
 		t.Fatalf("updateWithChannels() = %d, want 1", result)
 	}
@@ -1639,7 +1639,7 @@ func Test_updateWithChannels_masterChannel(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelMaster}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0)
+	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
@@ -1712,7 +1712,7 @@ func Test_updateWithChannels_notify(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(pkgs, false, true, 1, true, channelMap, 0)
+	result, _, _ := updateWithChannels(pkgs, false, true, 1, true, channelMap, 0, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() with notify = %d, want 0", result)
 	}
@@ -1740,7 +1740,7 @@ func Test_updateWithChannels_installError(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0)
+	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false)
 	if result != 1 {
 		t.Fatalf("updateWithChannels() = %d, want 1", result)
 	}
@@ -1777,7 +1777,7 @@ func Test_updateWithChannels_mainChannel(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelMain}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0)
+	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}


### PR DESCRIPTION
## Summary

Fixes #284.

`gup` output is optimized for interactive terminal use, forcing scripting and CI consumers to scrape human-readable text. This adds a `--json` flag to `list`, `check`, and `update` that emits a stable, machine-readable JSON array. The existing human-readable output remains the default.

```shell
$ gup check --json | jq -r '.[] | select(.status == "update-available") | .name'
```

## Schema

One object per package, with a stable set of fields:

| Field | Description |
| ----- | ----------- |
| `name` | Binary name under `$GOBIN`/`$GOPATH/bin`. |
| `import_path` | Package import path used by `go install`. |
| `module_path` | Module path; may be empty if it cannot be determined. |
| `channel` | Update channel resolved from `gup.json`: `latest`/`main`/`master`. |
| `current_version` | Currently installed version. |
| `latest_version` | Version available on the channel (empty for `list`). |
| `current_go_version` | Go toolchain the binary was built with. |
| `installed_go_version` | Go toolchain currently installed. |
| `status` | `installed` (list) / `up-to-date` / `update-available` (check) / `updated` (update) / `error`. |
| `error` | Per-package error message; omitted when absent. |

## Behavior

- **Valid JSON for success and partial-failure**: a failed package is emitted with `"status": "error"` and an `error` message; the array is always valid JSON (and never `null`, even when empty). Error detail is still written to STDERR, so STDOUT stays pure JSON.
- **Exit codes unchanged**: the command exits non-zero only when a package actually fails. `check` reporting `update-available` is not an error and exits `0`.
- `update --json` still persists update channels to `gup.json` exactly as before.

## Implementation notes

- New `cmd/jsonout.go`: `jsonPackage` schema, status constants, and an indented-array encoder.
- `executePackages`/`collectResults` now also return the per-package results in completion order, so both the JSON renderer and `update`'s config-persistence logic derive their data uniformly (success/rename sets are computed from results rather than the streaming callback).
- In `--json` mode the stdout banners and per-line progress are suppressed; `update`/`check`/`list` render the JSON array at the end.

## Acceptance Criteria

- [x] `--json` emits valid JSON for success and partial-failure cases.
- [x] Exit codes remain meaningful.
- [x] Tests cover the new output mode.
- [x] The schema is documented in the README.

## Test

- `jsonout_test.go`: schema mapping (incl. nil Version/GoVersion and error records), empty-array encoding (`[]` not `null`), `doCheck`/`update`/`list` JSON integration with status assertions, and an error-record case.
- Existing `executePackages`/`collectResults` and command tests updated for the new return value.
- Smoke-tested `gup list --json` / `gup check --json` against a real `$GOBIN` (19 binaries) — output parses as valid JSON.

Developed TDD-style (tests written first); full suite and `golangci-lint` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added machine-readable `--json` (`-json`) output to `list`, `check`, and `update`, emitting a valid JSON array with consistent per-package fields and optional `error`.
  * In JSON mode, human-readable progress output is suppressed and results are produced at the end.
* **Documentation**
  * Updated README with the JSON schema, status meanings, failure behavior, and example output for scripting/CI.
* **Bug Fixes / Refactor**
  * Improved per-package JSON status accuracy and partial-failure/error-record handling.
* **Tests**
  * Expanded end-to-end and unit test coverage for JSON output and updated parallel execution expectations for new return values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->