### PR TITLE
feat(release): curated release notes plus signing, SBOM, and provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,14 @@ on:
     tags:
       - "v*"
 
+# id-token: keyless cosign signing + provenance via GitHub OIDC.
+# attestations: publish build provenance for the release artifacts.
+# contents: create the GitHub Release and upload assets.
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
 jobs:
   release:
     name: Release
@@ -18,6 +26,10 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+      - name: Install Syft (SBOM generator)
+        uses: anchore/sbom-action/download-syft@v0
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -26,3 +38,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/*.deb
+            dist/*.rpm
+            dist/*.apk
+            dist/checksums.txt

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -65,10 +65,10 @@ changelog:
       order: 999
   filters:
     exclude:
-      - "^test:"
-      - "^chore:"
-      - "^style:"
-      - "^ci:"
+      - "^tests?(\\(.+\\))?!?:"
+      - "^chore(\\(.+\\))?!?:"
+      - "^style(\\(.+\\))?!?:"
+      - "^ci(\\(.+\\))?!?:"
       - "Merge pull request"
       - "Merge branch"
 # Software Bill of Materials for every release archive (issue #285).

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,12 +27,64 @@ checksum:
   name_template: "checksums.txt"
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
+# Curated release notes: a short human summary first, then changes grouped by
+# user-facing category (instead of a raw commit dump). See issue #283.
+release:
+  header: |
+    ## gup {{ .Tag }}
+
+    Fast parallel updater and manager for binaries installed with `go install`.
+
+    Install or upgrade, then see the grouped highlights below. Every artifact is
+    signed and ships with an SBOM and build provenance — see
+    [Verifying release integrity](https://github.com/nao1215/gup#verifying-release-integrity).
+  footer: |
+    **Full changelog**: https://github.com/nao1215/gup/compare/{{ .PreviousTag }}...{{ .Tag }}
 changelog:
   sort: asc
+  use: github
+  groups:
+    - title: "Breaking changes"
+      regexp: '^.*?[a-zA-Z]+(\(.+\))??!:.+$'
+      order: 0
+    - title: "Features"
+      regexp: '^.*?feat(\(.+\))??!?:.+$'
+      order: 1
+    - title: "Bug fixes"
+      regexp: '^.*?fix(\(.+\))??!?:.+$'
+      order: 2
+    - title: "Performance"
+      regexp: '^.*?perf(\(.+\))??!?:.+$'
+      order: 3
+    - title: "Documentation"
+      regexp: '^.*?docs(\(.+\))??!?:.+$'
+      order: 4
+    - title: "Others"
+      order: 999
   filters:
     exclude:
-      - "^docs:"
       - "^test:"
+      - "^chore:"
+      - "^style:"
+      - "^ci:"
+      - "Merge pull request"
+      - "Merge branch"
+# Software Bill of Materials for every release archive (issue #285).
+sboms:
+  - artifacts: archive
+# Keyless artifact signing with cosign. Signing the checksums file transitively
+# covers every published artifact (issue #285).
+signs:
+  - cmd: cosign
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: checksum
+    output: true
 nfpms:
   - maintainer: 'Naohiro CHIKAMATSU <n.chika156@gmail.com>'
     description: gup - Fast parallel updater and manager for binaries installed with 'go install'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 project_name: gup
 env:
   - GO111MODULE=on
@@ -18,15 +19,16 @@ builds:
       - darwin
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats: [tar.gz]
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
     files:
     - completions/*
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 # Curated release notes: a short human summary first, then changes grouped by
 # user-facing category (instead of a raw commit dump). See issue #283.
 release:

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Verify the signed checksums (then check your archive against `checksums.txt`):
 cosign verify-blob \
   --certificate checksums.txt.pem \
   --signature checksums.txt.sig \
-  --certificate-identity-regexp 'https://github.com/nao1215/gup/.*' \
+  --certificate-identity-regexp 'https://github.com/nao1215/gup/\.github/workflows/release\.yml@refs/tags/.*' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
   checksums.txt
 sha256sum --check --ignore-missing checksums.txt

--- a/README.md
+++ b/README.md
@@ -68,6 +68,30 @@ nix profile install nixpkgs#gogup
 ### Install from Package or Binary
 [The release page](https://github.com/nao1215/gup/releases) contains packages in .deb, .rpm, and .apk formats. gup command uses the go command internally, so the golang installation is required.
 
+## Verifying release integrity
+Every release ships supply-chain metadata so you can verify what you download:
+
+- **Signed checksums** — `checksums.txt` is signed with [cosign](https://github.com/sigstore/cosign) (keyless), producing `checksums.txt.sig` and `checksums.txt.pem`.
+- **SBOM** — an SPDX Software Bill of Materials is attached to each release archive.
+- **Build provenance** — SLSA build provenance is attested via GitHub OIDC.
+
+Verify the signed checksums (then check your archive against `checksums.txt`):
+
+```shell
+cosign verify-blob \
+  --certificate checksums.txt.pem \
+  --signature checksums.txt.sig \
+  --certificate-identity-regexp 'https://github.com/nao1215/gup/.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  checksums.txt
+sha256sum --check --ignore-missing checksums.txt
+```
+
+Verify the build provenance of a downloaded artifact with the GitHub CLI:
+
+```shell
+gh attestation verify gup_<version>_<os>_<arch>.tar.gz --repo nao1215/gup
+```
 
 ## How to use
 ### Update all binaries

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/mattn/go-colorable v0.1.15
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.10.2
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/release_test.go
+++ b/release_test.go
@@ -62,7 +62,14 @@ func Test_goreleaser_curatedChangelog(t *testing.T) {
 		}
 	}
 
-	for _, want := range []string{"features", "bug fixes", "performance", "documentation"} {
+	for _, want := range []string{
+		"breaking changes",
+		"features",
+		"bug fixes",
+		"performance",
+		"documentation",
+		"others",
+	} {
 		if !hasTitleContaining(titles, want) {
 			t.Errorf("changelog.groups is missing a %q category; got titles %v", want, keys(titles))
 		}
@@ -103,16 +110,7 @@ func Test_goreleaser_supplyChain(t *testing.T) {
 // the cosign installer, and an attestation step.
 func Test_releaseWorkflow_provenanceAndSigning(t *testing.T) {
 	t.Parallel()
-	raw, err := os.ReadFile(".github/workflows/release.yml")
-	if err != nil {
-		t.Fatalf("failed to read release workflow: %v", err)
-	}
-	content := string(raw)
-
-	doc := map[string]any{}
-	if err := yaml.Unmarshal(raw, &doc); err != nil {
-		t.Fatalf("release.yml is not valid YAML: %v", err)
-	}
+	doc := readYAMLFile(t, ".github/workflows/release.yml")
 
 	perms, ok := doc["permissions"].(map[string]any)
 	if !ok {
@@ -125,12 +123,52 @@ func Test_releaseWorkflow_provenanceAndSigning(t *testing.T) {
 		t.Errorf("release workflow needs 'attestations: write' for provenance, got %v", perms["attestations"])
 	}
 
-	if !strings.Contains(content, "sigstore/cosign-installer") {
-		t.Error("release workflow does not install cosign")
+	// Validate the structured jobs.release.steps[*].uses rather than raw text so
+	// a substring elsewhere in the file cannot make this pass by accident.
+	uses := releaseStepUses(t, doc)
+	if !anyHasPrefix(uses, "sigstore/cosign-installer") {
+		t.Errorf("release workflow does not install cosign; steps use: %v", uses)
 	}
-	if !strings.Contains(content, "attest-build-provenance") {
-		t.Error("release workflow does not attest build provenance")
+	if !anyHasPrefix(uses, "actions/attest-build-provenance") {
+		t.Errorf("release workflow does not attest build provenance; steps use: %v", uses)
 	}
+}
+
+// releaseStepUses returns every `uses:` value of the jobs.release.steps entries.
+func releaseStepUses(t *testing.T, doc map[string]any) []string {
+	t.Helper()
+	jobs, ok := doc["jobs"].(map[string]any)
+	if !ok {
+		t.Fatal("release workflow has no jobs block")
+	}
+	release, ok := jobs["release"].(map[string]any)
+	if !ok {
+		t.Fatal("release workflow has no 'release' job")
+	}
+	steps, ok := release["steps"].([]any)
+	if !ok {
+		t.Fatal("release job has no steps")
+	}
+	uses := make([]string, 0, len(steps))
+	for _, s := range steps {
+		step, ok := s.(map[string]any)
+		if !ok {
+			continue
+		}
+		if u, ok := step["uses"].(string); ok {
+			uses = append(uses, u)
+		}
+	}
+	return uses
+}
+
+func anyHasPrefix(values []string, prefix string) bool {
+	for _, v := range values {
+		if strings.HasPrefix(v, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func hasTitleContaining(titles map[string]bool, want string) bool {

--- a/release_test.go
+++ b/release_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// These tests guard the release pipeline configuration so the supply-chain and
+// release-notes guarantees promised in the README and issues #283/#285 cannot
+// silently regress. They parse the committed YAML rather than running the
+// release, which keeps them fast and offline.
+
+func readYAMLFile(t *testing.T, path string) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(path) //nolint:gosec // path is a fixed in-repo config file
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", path, err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("%s is not valid YAML: %v", path, err)
+	}
+	return doc
+}
+
+// Test_goreleaser_curatedChangelog verifies issue #283: release notes are
+// grouped by user-facing categories instead of a raw commit dump.
+func Test_goreleaser_curatedChangelog(t *testing.T) {
+	t.Parallel()
+	doc := readYAMLFile(t, ".goreleaser.yml")
+
+	changelog, ok := doc["changelog"].(map[string]any)
+	if !ok {
+		t.Fatal("changelog section is missing in .goreleaser.yml")
+	}
+	groupsRaw, ok := changelog["groups"].([]any)
+	if !ok || len(groupsRaw) == 0 {
+		t.Fatal("changelog.groups is missing; release notes would be a raw commit dump")
+	}
+
+	titles := make(map[string]bool)
+	for _, g := range groupsRaw {
+		group, ok := g.(map[string]any)
+		if !ok {
+			continue
+		}
+		if title, ok := group["title"].(string); ok {
+			titles[strings.ToLower(title)] = true
+		}
+	}
+
+	for _, want := range []string{"features", "bug fixes", "performance", "documentation"} {
+		if !hasTitleContaining(titles, want) {
+			t.Errorf("changelog.groups is missing a %q category; got titles %v", want, keys(titles))
+		}
+	}
+}
+
+// Test_goreleaser_supplyChain verifies issue #285: SBOM generation and artifact
+// signing are configured.
+func Test_goreleaser_supplyChain(t *testing.T) {
+	t.Parallel()
+	doc := readYAMLFile(t, ".goreleaser.yml")
+
+	if _, ok := doc["sboms"]; !ok {
+		t.Error("sboms section is missing in .goreleaser.yml (no SBOM published)")
+	}
+
+	signsRaw, ok := doc["signs"].([]any)
+	if !ok || len(signsRaw) == 0 {
+		t.Fatal("signs section is missing in .goreleaser.yml (artifacts are not signed)")
+	}
+	usesCosign := false
+	for _, s := range signsRaw {
+		sign, ok := s.(map[string]any)
+		if !ok {
+			continue
+		}
+		if cmd, ok := sign["cmd"].(string); ok && strings.Contains(cmd, "cosign") {
+			usesCosign = true
+		}
+	}
+	if !usesCosign {
+		t.Error("signs section does not use cosign")
+	}
+}
+
+// Test_releaseWorkflow_provenanceAndSigning verifies issue #285 at the workflow
+// level: keyless signing and provenance attestation require id-token permission,
+// the cosign installer, and an attestation step.
+func Test_releaseWorkflow_provenanceAndSigning(t *testing.T) {
+	t.Parallel()
+	raw, err := os.ReadFile(".github/workflows/release.yml")
+	if err != nil {
+		t.Fatalf("failed to read release workflow: %v", err)
+	}
+	content := string(raw)
+
+	doc := map[string]any{}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("release.yml is not valid YAML: %v", err)
+	}
+
+	perms, ok := doc["permissions"].(map[string]any)
+	if !ok {
+		t.Fatal("release workflow is missing a permissions block")
+	}
+	if perms["id-token"] != "write" {
+		t.Errorf("release workflow needs 'id-token: write' for keyless signing/provenance, got %v", perms["id-token"])
+	}
+	if perms["attestations"] != "write" {
+		t.Errorf("release workflow needs 'attestations: write' for provenance, got %v", perms["attestations"])
+	}
+
+	if !strings.Contains(content, "sigstore/cosign-installer") {
+		t.Error("release workflow does not install cosign")
+	}
+	if !strings.Contains(content, "attest-build-provenance") {
+		t.Error("release workflow does not attest build provenance")
+	}
+}
+
+func hasTitleContaining(titles map[string]bool, want string) bool {
+	for title := range titles {
+		if strings.Contains(title, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/release_test.go
+++ b/release_test.go
@@ -26,6 +26,16 @@ func readYAMLFile(t *testing.T, path string) map[string]any {
 	return doc
 }
 
+// Test_goreleaser_isVersion2 guards the GoReleaser v2 schema declaration so the
+// config keeps parsing under the v2 toolchain used in CI.
+func Test_goreleaser_isVersion2(t *testing.T) {
+	t.Parallel()
+	doc := readYAMLFile(t, ".goreleaser.yml")
+	if doc["version"] != 2 {
+		t.Errorf("`.goreleaser.yml` must declare `version: 2`, got %v", doc["version"])
+	}
+}
+
 // Test_goreleaser_curatedChangelog verifies issue #283: release notes are
 // grouped by user-facing categories instead of a raw commit dump.
 func Test_goreleaser_curatedChangelog(t *testing.T) {


### PR DESCRIPTION
Closes #283 and #285 in one PR (both touch the release pipeline).

## #283 — Curated release notes instead of raw commit dumps

- GoReleaser `changelog` now groups entries by user-facing category: **Breaking changes**, **Features**, **Bug fixes**, **Performance**, **Documentation**, **Others** — so readers see outcomes, not commit hashes.
- The release body leads with a short human-readable `header` (what gup is, where to verify integrity) and ends with a full-changelog `footer`.
- Noise (`test`/`chore`/`style`/`ci`, merge commits) is filtered out; the pipeline stays tag-driven.

## #285 — Signed artifacts, SBOM, and provenance

- **Signing**: `checksums.txt` is signed with cosign (keyless via GitHub OIDC), producing `checksums.txt.sig` / `checksums.txt.pem`. Signing the checksums transitively covers every published artifact.
- **SBOM**: an SPDX SBOM is generated per release archive (syft).
- **Provenance**: SLSA build provenance is attested with `actions/attest-build-provenance` (GitHub OIDC).
- `release.yml` gains `id-token: write` + `attestations: write` permissions and installs cosign and syft before GoReleaser.
- README documents verification (`cosign verify-blob` + `sha256sum`, and `gh attestation verify`).

## Acceptance criteria

**#283**
- [x] New tagged releases publish a concise summary first.
- [x] User-facing changes are visible without reading the full commit list (grouped categories).
- [x] The release workflow remains automated (tag-driven).

**#285**
- [x] Each release includes signed checksums.
- [x] Each release includes an SBOM.
- [x] Each release includes provenance metadata.
- [x] Verification steps are documented.

## Test

`release_test.go` parses the committed `.goreleaser.yml` and `.github/workflows/release.yml` and asserts the changelog groups, `sboms`, cosign `signs`, the `id-token`/`attestations` permissions, the cosign installer, and the provenance step — guarding both guarantees against regression. Written TDD-style (tests first, red → green).

Full suite and `golangci-lint` pass. Note: GoReleaser isn't run locally (not installed here); the config is validated structurally by the test and follows the documented GoReleaser/cosign/syft schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Organized release notes with categorized change tracking
  * Enhanced release security with artifact signing and verification capabilities
  * Automated provenance attestation for releases

* **Documentation**
  * Added instructions for verifying release authenticity and integrity

* **Tests**
  * Added release pipeline configuration validation tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->