### PR TITLE
docs: keep translated READMEs in sync with the English source of truth

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+<!-- Thanks for contributing to gup! Please fill in the sections below. -->
+
+## Summary
+
+<!-- What does this PR change and why? -->
+
+## Related issue
+
+<!-- e.g. Closes #123 -->
+
+## Checklist
+
+- [ ] Added or updated unit tests for the change
+- [ ] `make test` / `make vet` / `make fmt` pass locally
+- [ ] If I changed `README.md`, I updated the translated READMEs under
+      `doc/<lang>/README.md` for the affected sections, or confirmed the
+      "translation may lag behind English" banner is present
+      (see [CONTRIBUTING.md](../CONTRIBUTING.md#documentation-and-translations))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,22 @@ Use the command below to add or update tool dependencies:
 make update-tools
 ```
 
+## Documentation and translations
+`README.md` (English) is the **source of truth** for user-facing documentation.
+Translated READMEs live under `doc/<lang>/README.md` (`ja`, `es`, `fr`, `ko`,
+`ru`, `zh-cn`).
+
+When you change `README.md`:
+
+- Update the translated READMEs for the affected sections, **or** leave them as
+  is — every translation carries a "this translation may lag behind English"
+  banner (marked with the `<!-- gup:translation-sync -->` comment) so readers
+  know where the latest information lives.
+- Keep the English README's first-class sections intact. A CI test
+  (`doc_sync_test.go`) enforces that `README.md` keeps its required sections and
+  that every translated README keeps the sync banner and a link back to English.
+- Run `make test` so `doc_sync_test.go` runs before you open the PR.
+
 ## Contributing Outside of Coding
 You can still make a huge impact even if you are not writing code:
 

--- a/doc/es/README.md
+++ b/doc/es/README.md
@@ -8,7 +8,10 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/nao1215/gup)](https://goreportcard.com/report/github.com/nao1215/gup)
 ![GitHub](https://img.shields.io/github/license/nao1215/gup)
 
-[日本語](../ja/README.md) | [Русский](../ru/README.md) | [中文](../zh-cn/README.md) | [한국어](../ko/README.md) | [Español](../es/README.md) | [Français](../fr/README.md)
+[English](../../README.md) | [日本語](../ja/README.md) | [Русский](../ru/README.md) | [中文](../zh-cn/README.md) | [한국어](../ko/README.md) | [Español](../es/README.md) | [Français](../fr/README.md)
+
+<!-- gup:translation-sync -->
+> 📖 Este documento es una traducción y puede estar desactualizado respecto al [README en inglés](../../README.md), que es la fuente de verdad.
 
 # gup - Actualizar binarios instalados por "go install"
 

--- a/doc/fr/README.md
+++ b/doc/fr/README.md
@@ -8,7 +8,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/nao1215/gup)](https://goreportcard.com/report/github.com/nao1215/gup)
 ![GitHub](https://img.shields.io/github/license/nao1215/gup)
 
-[日本語](../ja/README.md) | [Русский](../ru/README.md) | [中文](../zh-cn/README.md) | [한국어](../ko/README.md) | [Español](../es/README.md) | [English](../../README.md)
+[English](../../README.md) | [日本語](../ja/README.md) | [Русский](../ru/README.md) | [中文](../zh-cn/README.md) | [한국어](../ko/README.md) | [Español](../es/README.md) | [Français](../fr/README.md)
 
 <!-- gup:translation-sync -->
 > 📖 Ce document est une traduction et peut être en retard par rapport au [README anglais](../../README.md), qui fait foi.

--- a/doc/fr/README.md
+++ b/doc/fr/README.md
@@ -10,6 +10,9 @@
 
 [日本語](../ja/README.md) | [Русский](../ru/README.md) | [中文](../zh-cn/README.md) | [한국어](../ko/README.md) | [Español](../es/README.md) | [English](../../README.md)
 
+<!-- gup:translation-sync -->
+> 📖 Ce document est une traduction et peut être en retard par rapport au [README anglais](../../README.md), qui fait foi.
+
 # gup - Mettre à jour les binaires installés par "go install"
 
 ![sample](../img/sample.gif)

--- a/doc/ja/README.md
+++ b/doc/ja/README.md
@@ -8,7 +8,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/nao1215/gup)](https://goreportcard.com/report/github.com/nao1215/gup)
 ![GitHub](https://img.shields.io/github/license/nao1215/gup)
 
-[English](../../README.md) | [日本語](./README.md) | [Русский](../ru/README.md) | [中文](../zh-cn/README.md) | [한국어](../ko/README.md) | [Español](../es/README.md) | [Français](../fr/README.md)
+[English](../../README.md) | [日本語](../ja/README.md) | [Русский](../ru/README.md) | [中文](../zh-cn/README.md) | [한국어](../ko/README.md) | [Español](../es/README.md) | [Français](../fr/README.md)
 
 <!-- gup:translation-sync -->
 > 📖 これは翻訳版です。最新の情報は、正典である [English README](../../README.md) を参照してください（翻訳は英語版より遅れることがあります）。

--- a/doc/ja/README.md
+++ b/doc/ja/README.md
@@ -8,15 +8,31 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/nao1215/gup)](https://goreportcard.com/report/github.com/nao1215/gup)
 ![GitHub](https://img.shields.io/github/license/nao1215/gup)
 
-[日本語](./README.md) | [Русский](../ru/README.md) | [中文](../zh-cn/README.md) | [한국어](../ko/README.md) | [Español](../es/README.md) | [Français](../fr/README.md)
+[English](../../README.md) | [日本語](./README.md) | [Русский](../ru/README.md) | [中文](../zh-cn/README.md) | [한국어](../ko/README.md) | [Español](../es/README.md) | [Français](../fr/README.md)
+
+<!-- gup:translation-sync -->
+> 📖 これは翻訳版です。最新の情報は、正典である [English README](../../README.md) を参照してください（翻訳は英語版より遅れることがあります）。
 
 # gup - "go install"でインストールしたバイナリを更新
 
 ![sample](../img/sample.gif)
 
-**gup** コマンドは、"go install" でインストールしたバイナリを最新版に更新します。gupはすべてのバイナリを並列で更新するため、非常に高速です。また、\$GOPATH/bin (\$GOBIN) 配下のバイナリを操作するためのサブコマンドも提供しています。Windows、Mac、Linuxで動作するクロスプラットフォーム対応のソフトウェアです。
+**gup** コマンドは、"go install" でインストールしたバイナリを1つずつではなく並列で更新するため、非常に高速です。
+
+gupは `$GOPATH/bin`（`$GOBIN`）配下のツールを管理するサブコマンドも提供します。インストール済みのバイナリを `list`／`check` し、`remove` で削除し、`export`／`import` でツール一式を別マシンに再現し、`migrate` で別の `$GOBIN` へ移行できます。Windows、Mac、Linuxで動作します。
 
 oh-my-zshを使用している場合、gupにはエイリアスが設定されています。そのエイリアスは `gup - git pull --rebase` です。そのため、oh-my-zshのエイリアスを無効にして使用してください（例：$ \gup update）。
+
+## ベンチマーク
+gupは更新を並列実行するため、バイナリを1つずつ更新するツールよりも短時間で完了します。新しいバージョンが利用可能な9個のバイナリを更新した場合:
+
+| ツール | 方式 | 時間 |
+|------|----------|-----:|
+| gup update | 並列 | 0.7s |
+| [go-global-update](https://github.com/Gelio/go-global-update) | 逐次 | 2.9s |
+| `go install` ループ | 逐次 | 2.9s |
+
+計測環境: AMD Ryzen AI Max+ 395（32コア）/ 64 GB RAM / Ubuntu 26.04 / go 1.26.4。ウォームな Go モジュールキャッシュで5回計測した中央値です。時間は各バイナリのビルド時間とCPUに依存します。
 
 ## 破壊的変更（v1.0.0）
 - 設定ファイル形式は `gup.conf` から `gup.json` に変更されました。
@@ -61,6 +77,30 @@ nix profile install nixpkgs#gogup
 ### パッケージまたはバイナリからインストール
 [リリースページ](https://github.com/nao1215/gup/releases) には、.deb、.rpm、.apk形式のパッケージが含まれています。gupコマンドは内部的にgoコマンドを使用するため、Golangのインストールが必要です。
 
+## リリースの完全性を検証する
+各リリースには、ダウンロードしたものを検証できるようにサプライチェーンのメタデータが添付されています:
+
+- **署名付きチェックサム** — `checksums.txt` は [cosign](https://github.com/sigstore/cosign)（keyless）で署名され、`checksums.txt.sig` と `checksums.txt.pem` が生成されます。
+- **SBOM** — 各リリースアーカイブに SPDX 形式のソフトウェア部品表（SBOM）が添付されます。
+- **ビルドプロベナンス** — GitHub OIDC を用いて SLSA ビルドプロベナンスが付与されます。
+
+署名付きチェックサムを検証する（その後アーカイブを `checksums.txt` と照合する）:
+
+```shell
+cosign verify-blob \
+  --certificate checksums.txt.pem \
+  --signature checksums.txt.sig \
+  --certificate-identity-regexp 'https://github.com/nao1215/gup/\.github/workflows/release\.yml@refs/tags/.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  checksums.txt
+sha256sum --check --ignore-missing checksums.txt
+```
+
+GitHub CLI でダウンロードしたアーティファクトのビルドプロベナンスを検証する:
+
+```shell
+gh attestation verify gup_<version>_<os>_<arch>.tar.gz --repo nao1215/gup
+```
 
 ## 使用方法
 ### すべてのバイナリを更新
@@ -153,6 +193,31 @@ check binary under $GOPATH/bin or $GOBIN
 If you want to update binaries, the following command.
           $ gup update mimixbox
 ```
+
+### 機械可読なJSON出力（スクリプト／CI向け）
+`list`、`check`、`update` は `--json` を受け付け、人間向けの出力の代わりにJSON配列を出力します（デフォルトは従来どおり人間向け出力）。
+
+```shell
+$ gup check --json
+[
+  {
+    "name": "gup",
+    "import_path": "github.com/nao1215/gup",
+    "module_path": "github.com/nao1215/gup",
+    "channel": "latest",
+    "current_version": "v1.0.0",
+    "latest_version": "v1.1.0",
+    "current_go_version": "go1.22.4",
+    "installed_go_version": "go1.22.4",
+    "status": "update-available"
+  }
+]
+```
+
+各要素のフィールドは次のとおりです: `name`、`import_path`、`module_path`、`channel`（`latest`／`main`／`master`）、`current_version`、`latest_version`（`list` では空）、`current_go_version`、`installed_go_version`、`status`、`error`（無い場合は省略）。`status` は `installed`（list）、`up-to-date`、`update-available`（check）、`updated`（update）、`error` のいずれかです。
+
+部分的な失敗を含めて出力は常に valid な JSON です（失敗したパッケージは `"status": "error"` になり、エラー詳細はSTDERRに出るためSTDOUTはJSONのみに保たれます）。終了コードは従来と同じで、`check` が `update-available` を報告しても終了コードは `0` のままです。
+
 ### Export／Importサブコマンド
 複数のシステム間で同じGolangバイナリをインストールしたい場合は、export／importサブコマンドを使用します。
 `gup.json` は import path、バイナリバージョン、更新チャネル（`latest` / `main` / `master`）を保存し、`import` はそのバージョンをそのままインストールします。
@@ -202,6 +267,37 @@ $ gup export --output > gup.json
 ※ 環境B (例: debian)
 $ gup import --file=gup.json
 ```
+
+### 新しい$GOBINへのバイナリ移行
+
+```shell
+gup migrate BEFORE_PATH AFTER_PATH [BINARY...]
+```
+
+`gup migrate` は `BEFORE_PATH` 配下のGoバイナリを、各バイナリのビルド情報に記録された `import path@version` のまま `AFTER_PATH` に再インストールします（暗黙に `@latest` へ更新することはありません）。内部的には `GOBIN` を `AFTER_PATH` に設定して通常の `go install` を実行するだけなので、現在使用中のGoツールチェインで再ビルドされます。
+
+#### これが役立つ場面（例: `mise`）
+
+[`mise`](https://mise.jdx.dev/) でGoを管理している場合、Goを更新するとGoのバージョンごとに `$GOBIN` の実体パスが変わることがあります。その結果、以前の `$GOBIN` 配下にインストールしたツールが新しいGoから見えなくなります。`gup migrate` を使うと、古い `$GOBIN` から新しい `$GOBIN` へ同じツール一式を再インストールできます:
+
+```shell
+# 古いGOBINのすべてのgo-installツールを新しいGOBINへ再インストール
+$ gup migrate ~/.local/share/mise/installs/go/1.24.0/bin ~/.local/share/mise/installs/go/1.25.0/bin
+
+# 特定のバイナリだけを移行
+$ gup migrate /old/gobin /new/gobin gopls air
+```
+
+`migrate` は追加のみを行います:
+
+- `AFTER_PATH` 内のファイルを削除・整理することはありません。
+- `AFTER_PATH` に既に存在するバイナリはデフォルトでスキップされます。上書き再インストールするには `--force` を使用します。
+- `AFTER_PATH` が存在しない場合は自動的に作成されます。
+- `BEFORE_PATH` と `AFTER_PATH` は異なるディレクトリである必要があります。
+
+import path や version を解決できないバイナリ、および開発ビルド（`devel` / `(devel)`）は、更新されずにスキップされます。これにより、ローカルビルドや再現不能なビルドが壊れることはありません。
+
+対応フラグ: `--dry-run`（`-n`）、`--notify`（`-N`）、`--jobs`（`-j`）、`--force`。
 
 ### manページの生成（LinuxとMac用）
 manサブコマンドは/usr/share/man/man1配下にmanページを生成します。

--- a/doc/ko/README.md
+++ b/doc/ko/README.md
@@ -8,7 +8,10 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/nao1215/gup)](https://goreportcard.com/report/github.com/nao1215/gup)
 ![GitHub](https://img.shields.io/github/license/nao1215/gup)
 
-[日本語](../ja/README.md) | [Русский](../ru/README.md) | [中文](../zh-cn/README.md) | [한국어](../ko/README.md) | [Español](../es/README.md) | [Français](../fr/README.md)
+[English](../../README.md) | [日本語](../ja/README.md) | [Русский](../ru/README.md) | [中文](../zh-cn/README.md) | [한국어](../ko/README.md) | [Español](../es/README.md) | [Français](../fr/README.md)
+
+<!-- gup:translation-sync -->
+> 📖 이 문서는 번역본이며, 최신 정보는 정본인 [영문 README](../../README.md)를 참고하세요 (번역이 영문판보다 늦을 수 있습니다).
 
 # gup - "go install"로 설치된 바이너리 업데이트
 

--- a/doc/ru/README.md
+++ b/doc/ru/README.md
@@ -8,7 +8,10 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/nao1215/gup)](https://goreportcard.com/report/github.com/nao1215/gup)
 ![GitHub](https://img.shields.io/github/license/nao1215/gup)
 
-[日本語](../ja/README.md) | [Русский](./README.md) | [中文](../zh-cn/README.md) | [한국어](../ko/README.md) | [Español](../es/README.md) | [Français](../fr/README.md)
+[English](../../README.md) | [日本語](../ja/README.md) | [Русский](./README.md) | [中文](../zh-cn/README.md) | [한국어](../ko/README.md) | [Español](../es/README.md) | [Français](../fr/README.md)
+
+<!-- gup:translation-sync -->
+> 📖 Это перевод, который может отставать от [английского README](../../README.md) — основного источника информации.
 
 # gup - Обновляет бинарные файлы, установленные через "go install"
 

--- a/doc/ru/README.md
+++ b/doc/ru/README.md
@@ -8,7 +8,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/nao1215/gup)](https://goreportcard.com/report/github.com/nao1215/gup)
 ![GitHub](https://img.shields.io/github/license/nao1215/gup)
 
-[English](../../README.md) | [日本語](../ja/README.md) | [Русский](./README.md) | [中文](../zh-cn/README.md) | [한국어](../ko/README.md) | [Español](../es/README.md) | [Français](../fr/README.md)
+[English](../../README.md) | [日本語](../ja/README.md) | [Русский](../ru/README.md) | [中文](../zh-cn/README.md) | [한국어](../ko/README.md) | [Español](../es/README.md) | [Français](../fr/README.md)
 
 <!-- gup:translation-sync -->
 > 📖 Это перевод, который может отставать от [английского README](../../README.md) — основного источника информации.

--- a/doc/zh-cn/README.md
+++ b/doc/zh-cn/README.md
@@ -8,7 +8,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/nao1215/gup)](https://goreportcard.com/report/github.com/nao1215/gup)
 ![GitHub](https://img.shields.io/github/license/nao1215/gup)
 
-[English](../../README.md) | [日本語](../ja/README.md) | [Русский](../ru/README.md) | [한국어](../ko/README.md) | [Español](../es/README.md) | [Français](../fr/README.md)
+[English](../../README.md) | [日本語](../ja/README.md) | [Русский](../ru/README.md) | [中文](../zh-cn/README.md) | [한국어](../ko/README.md) | [Español](../es/README.md) | [Français](../fr/README.md)
 
 <!-- gup:translation-sync -->
 > 📖 本文档为翻译版本，可能落后于作为权威来源的 [英文 README](../../README.md)。

--- a/doc/zh-cn/README.md
+++ b/doc/zh-cn/README.md
@@ -10,6 +10,9 @@
 
 [English](../../README.md) | [日本語](../ja/README.md) | [Русский](../ru/README.md) | [한국어](../ko/README.md) | [Español](../es/README.md) | [Français](../fr/README.md)
 
+<!-- gup:translation-sync -->
+> 📖 本文档为翻译版本，可能落后于作为权威来源的 [英文 README](../../README.md)。
+
 # gup - 更新通过"go install"安装的二进制文件
 
 ![sample](../img/sample.gif)

--- a/doc_sync_test.go
+++ b/doc_sync_test.go
@@ -15,6 +15,18 @@ import (
 // "this translation may lag behind English" banner in every translated README.
 const translationSyncMarker = "<!-- gup:translation-sync -->"
 
+// canonicalLanguageBar is the language switcher every translated README must
+// carry verbatim, so each doc links to English and to every sibling language
+// (including a self-link). This guards against drift like a missing self-link
+// or a different ordering between translations.
+const canonicalLanguageBar = "[English](../../README.md) | " +
+	"[日本語](../ja/README.md) | " +
+	"[Русский](../ru/README.md) | " +
+	"[中文](../zh-cn/README.md) | " +
+	"[한국어](../ko/README.md) | " +
+	"[Español](../es/README.md) | " +
+	"[Français](../fr/README.md)"
+
 func Test_englishReadme_hasRequiredSections(t *testing.T) {
 	t.Parallel()
 	// requiredEnglishSections lists structural headings the English README must
@@ -66,6 +78,11 @@ func Test_translatedReadmes_haveSyncBanner(t *testing.T) {
 			// Every translation must link back to the English source of truth.
 			if !strings.Contains(content, "../../README.md") {
 				t.Errorf("%s does not link back to the English README (../../README.md)", path)
+			}
+			// Every translation must carry the same language switcher (English +
+			// all siblings + a self-link), so navigation stays consistent.
+			if !strings.Contains(content, canonicalLanguageBar) {
+				t.Errorf("%s is missing the canonical language bar:\n%s", path, canonicalLanguageBar)
 			}
 		})
 	}

--- a/doc_sync_test.go
+++ b/doc_sync_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// README.md is the source of truth for user-facing documentation (issue #282).
+// These tests keep the translated READMEs honest: the English file must keep its
+// structural sections, and every translation must carry the sync banner that
+// links back to English so readers know where the latest information lives.
+
+// translationSyncMarker is a language-agnostic marker that must sit next to the
+// "this translation may lag behind English" banner in every translated README.
+const translationSyncMarker = "<!-- gup:translation-sync -->"
+
+func Test_englishReadme_hasRequiredSections(t *testing.T) {
+	t.Parallel()
+	// requiredEnglishSections lists structural headings the English README must
+	// keep. Add new first-class sections here so a regression is caught early.
+	requiredEnglishSections := []string{
+		"## Benchmark",
+		"## Supported OS",
+		"## How to install",
+		"## Verifying release integrity",
+		"## How to use",
+		"## Contributing",
+		"## LICENSE",
+	}
+	raw, err := os.ReadFile("README.md")
+	if err != nil {
+		t.Fatalf("failed to read README.md: %v", err)
+	}
+	content := string(raw)
+	for _, section := range requiredEnglishSections {
+		if !strings.Contains(content, section) {
+			t.Errorf("README.md is missing required section %q", section)
+		}
+	}
+}
+
+func Test_translatedReadmes_haveSyncBanner(t *testing.T) {
+	t.Parallel()
+	// translatedREADMEs are the localized READMEs that must stay in sync with, or
+	// be explicitly marked as lagging behind, the English README.
+	translatedREADMEs := []string{
+		"doc/ja/README.md",
+		"doc/es/README.md",
+		"doc/fr/README.md",
+		"doc/ko/README.md",
+		"doc/ru/README.md",
+		"doc/zh-cn/README.md",
+	}
+	for _, path := range translatedREADMEs {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+			raw, err := os.ReadFile(path) //nolint:gosec // fixed in-repo doc path
+			if err != nil {
+				t.Fatalf("failed to read %s: %v", path, err)
+			}
+			content := string(raw)
+			if !strings.Contains(content, translationSyncMarker) {
+				t.Errorf("%s is missing the translation sync marker %q", path, translationSyncMarker)
+			}
+			// Every translation must link back to the English source of truth.
+			if !strings.Contains(content, "../../README.md") {
+				t.Errorf("%s does not link back to the English README (../../README.md)", path)
+			}
+		})
+	}
+}


### PR DESCRIPTION
@/tmp/claude-1000/-home-nao-ghq-github-com-nao1215-gup/948cbe88-bcaf-49f8-b72b-88e97f14ff70/scratchpad/pr289_body.md