### PR TITLE
fix(update): make gup update channel-aware in the skip/update decision

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -69,11 +69,17 @@ func helper_stubUpdateOps(t *testing.T) {
 	t.Helper()
 
 	orgGetLatestVer := getLatestVer
+	orgGetVerByRef := getVerByRefCtx
 	orgInstallLatest := installLatest
 	orgInstallMainOrMaster := installMainOrMaster
 	orgInstallByVersionUpd := installByVersionUpd
 
 	getLatestVer = func(string) (string, error) {
+		return testVersionNine, nil
+	}
+	// The channel-aware skip/update decision resolves @main/@master versions
+	// through this ref lookup, so stub it alongside the @latest lookup.
+	getVerByRefCtx = func(context.Context, string, string) (string, error) {
 		return testVersionNine, nil
 	}
 	installLatest = func(string) error {
@@ -88,6 +94,7 @@ func helper_stubUpdateOps(t *testing.T) {
 
 	t.Cleanup(func() {
 		getLatestVer = orgGetLatestVer
+		getVerByRefCtx = orgGetVerByRef
 		installLatest = orgInstallLatest
 		installMainOrMaster = orgInstallMainOrMaster
 		installByVersionUpd = orgInstallByVersionUpd

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -251,11 +251,19 @@ func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus i
 
 	updater := func(ctx context.Context, p goutil.Package) updateResult {
 		originalName := p.Name
-		// Collect online latest version if possible; else always update
+		// Resolve the update channel up front so the skip/update decision is
+		// derived from the version the selected channel would install, not from
+		// @latest. Without this, a package tracked on @main/@master would
+		// piggyback on the @latest lookup and could be skipped or updated
+		// incorrectly (see issue #292).
+		channel := packageUpdateChannel(p.Name, p.UpdateChannel, channelMap)
+		p.UpdateChannel = channel
+
+		// Collect online channel version if possible; else always update
 		shouldUpdate := true
 		modulePathChanged := false
 		if p.ModulePath != "" {
-			ver, err := verCache.get(ctx, p.ModulePath)
+			ver, err := verCache.getByChannel(ctx, p.ModulePath, channel)
 			if err != nil {
 				newPkg, changed := resolveModulePathChange(p, err)
 				if !changed {
@@ -268,7 +276,7 @@ func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus i
 				modulePathChanged = true
 				p = newPkg
 
-				ver, err = verCache.get(ctx, p.ModulePath)
+				ver, err = verCache.getByChannel(ctx, p.ModulePath, channel)
 				if err != nil {
 					return updateResult{
 						updated: false,
@@ -298,9 +306,6 @@ func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus i
 		if p.ImportPath == "" {
 			updateErr = fmt.Errorf("%s is not installed by 'go install' (or permission incorrect)", p.Name)
 		} else {
-			channel := packageUpdateChannel(p.Name, p.UpdateChannel, channelMap)
-			p.UpdateChannel = channel
-
 			if err := installWithSelectedVersion(ctx, p.ImportPath, channel); err != nil {
 				newPkg, changed := resolveModulePathChange(p, err)
 				if !changed {

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -1229,12 +1229,12 @@ func Test_latestVerCache_get_contextCanceled(t *testing.T) {
 	cancel()
 
 	cache := newLatestVerCache()
-	_, err := cache.get(ctx, "example.com/tool")
+	_, err := cache.getByChannel(ctx, "example.com/tool", goutil.UpdateChannelLatest)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("latestVerCache.get() error = %v, want %v", err, context.Canceled)
 	}
 
-	got, err := cache.get(context.Background(), "example.com/tool")
+	got, err := cache.getByChannel(context.Background(), "example.com/tool", goutil.UpdateChannelLatest)
 	if err != nil {
 		t.Fatalf("latestVerCache.get() second call error = %v, want nil", err)
 	}
@@ -1618,13 +1618,17 @@ func Test_updateWithChannels_getLatestVerError(t *testing.T) {
 
 func Test_updateWithChannels_masterChannel(t *testing.T) {
 	origGetLatest := getLatestVer
+	origRef := getVerByRefCtx
 	origInstallByVersionUpd := installByVersionUpd
 	defer func() {
 		getLatestVer = origGetLatest
+		getVerByRefCtx = origRef
 		installByVersionUpd = origInstallByVersionUpd
 	}()
 
 	getLatestVer = func(string) (string, error) { return testVersionNine, nil }
+	// The skip/update decision resolves the version via the @master ref.
+	getVerByRefCtx = func(_ context.Context, _ string, _ string) (string, error) { return testVersionNine, nil }
 	var calledVersion string
 	installByVersionUpd = func(_, ver string) error { calledVersion = ver; return nil }
 
@@ -1645,6 +1649,154 @@ func Test_updateWithChannels_masterChannel(t *testing.T) {
 	}
 	if calledVersion != "master" {
 		t.Fatalf("install called with version = %q, want master", calledVersion)
+	}
+}
+
+// Test_updateWithChannels_masterChannel_skipDecisionUsesChannel verifies that
+// the skip/update decision for a package tracked on @master is derived from the
+// @master ref, not from @latest. Here @latest still equals the installed
+// version (so an @latest-based decision would wrongly skip the package), while
+// @master has moved forward and must trigger an update.
+func Test_updateWithChannels_masterChannel_skipDecisionUsesChannel(t *testing.T) {
+	origGetLatest := getLatestVer
+	origRef := getVerByRefCtx
+	origInstallByVersionUpd := installByVersionUpd
+	defer func() {
+		getLatestVer = origGetLatest
+		getVerByRefCtx = origRef
+		installByVersionUpd = origInstallByVersionUpd
+	}()
+
+	getLatestVer = func(string) (string, error) { return testVersionOne, nil }
+	getVerByRefCtx = func(_ context.Context, _ string, ref string) (string, error) {
+		if ref == string(goutil.UpdateChannelMaster) {
+			return testVersionNine, nil
+		}
+		return "", fmt.Errorf("unexpected ref %q", ref)
+	}
+
+	var installCalled atomic.Bool
+	var calledVersion string
+	installByVersionUpd = func(_, ver string) error {
+		installCalled.Store(true)
+		calledVersion = ver
+		return nil
+	}
+
+	pkgs := []goutil.Package{
+		{
+			Name:       testBinTool,
+			ImportPath: testImportPathTool,
+			ModulePath: testImportPathTool,
+			Version:    &goutil.Version{Current: testVersionOne},
+			GoVersion:  &goutil.Version{Current: testGoVersion1224, Latest: testGoVersion1224},
+		},
+	}
+
+	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelMaster}
+	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false)
+	if result != 0 {
+		t.Fatalf("updateWithChannels() = %d, want 0", result)
+	}
+	if !installCalled.Load() {
+		t.Fatal("expected @master install to run, but the package was skipped using the @latest version")
+	}
+	if calledVersion != "master" {
+		t.Fatalf("install called with version = %q, want master", calledVersion)
+	}
+}
+
+// Test_updateWithChannels_masterChannel_latestMovedButMasterSame verifies the
+// reverse failure mode: @latest has moved forward (which would wrongly trigger
+// an update) but the @master ref still matches the installed version, so the
+// package must be skipped.
+func Test_updateWithChannels_masterChannel_latestMovedButMasterSame(t *testing.T) {
+	origGetLatest := getLatestVer
+	origRef := getVerByRefCtx
+	origInstallByVersionUpd := installByVersionUpd
+	defer func() {
+		getLatestVer = origGetLatest
+		getVerByRefCtx = origRef
+		installByVersionUpd = origInstallByVersionUpd
+	}()
+
+	getLatestVer = func(string) (string, error) { return testVersionNine, nil }
+	getVerByRefCtx = func(_ context.Context, _ string, ref string) (string, error) {
+		if ref == string(goutil.UpdateChannelMaster) {
+			return testVersionOne, nil
+		}
+		return "", fmt.Errorf("unexpected ref %q", ref)
+	}
+
+	installByVersionUpd = func(_, _ string) error {
+		t.Fatal("install must not run: @master is unchanged")
+		return nil
+	}
+
+	pkgs := []goutil.Package{
+		{
+			Name:       testBinTool,
+			ImportPath: testImportPathTool,
+			ModulePath: testImportPathTool,
+			Version:    &goutil.Version{Current: testVersionOne},
+			GoVersion:  &goutil.Version{Current: testGoVersion1224, Latest: testGoVersion1224},
+		},
+	}
+
+	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelMaster}
+	result, succeeded, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false)
+	if result != 0 {
+		t.Fatalf("updateWithChannels() = %d, want 0", result)
+	}
+	if len(succeeded) != 1 {
+		t.Fatalf("succeeded = %d, want 1 (up-to-date package is still a success)", len(succeeded))
+	}
+}
+
+// Test_updateWithChannels_mainChannel_skipDecisionUsesChannel verifies the same
+// channel-aware skip decision for the @main channel: @latest equals the
+// installed version, but @main has moved and must trigger an update.
+func Test_updateWithChannels_mainChannel_skipDecisionUsesChannel(t *testing.T) {
+	origGetLatest := getLatestVer
+	origRef := getVerByRefCtx
+	origInstallMain := installMainOrMaster
+	defer func() {
+		getLatestVer = origGetLatest
+		getVerByRefCtx = origRef
+		installMainOrMaster = origInstallMain
+	}()
+
+	getLatestVer = func(string) (string, error) { return testVersionOne, nil }
+	getVerByRefCtx = func(_ context.Context, _ string, ref string) (string, error) {
+		if ref == string(goutil.UpdateChannelMain) {
+			return testVersionNine, nil
+		}
+		return "", fmt.Errorf("unexpected ref %q", ref)
+	}
+
+	var installCalled atomic.Bool
+	installMainOrMaster = func(string) error {
+		installCalled.Store(true)
+		return nil
+	}
+
+	pkgs := []goutil.Package{
+		{
+			Name:       testBinTool,
+			ImportPath: testImportPathTool,
+			ModulePath: testImportPathTool,
+			Version:    &goutil.Version{Current: testVersionOne},
+			GoVersion:  &goutil.Version{Current: testGoVersion1224, Latest: testGoVersion1224},
+		},
+	}
+
+	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelMain}
+	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false)
+	if result != 0 {
+		t.Fatalf("updateWithChannels() = %d, want 0", result)
+	}
+	if !installCalled.Load() {
+		t.Fatal("expected @main install to run, but the package was skipped using the @latest version")
 	}
 }
 
@@ -1748,17 +1900,21 @@ func Test_updateWithChannels_installError(t *testing.T) {
 
 func Test_updateWithChannels_mainChannel(t *testing.T) {
 	origGetLatest := getLatestVer
+	origRef := getVerByRefCtx
 	origInstallLatest := installLatest
 	origInstallMain := installMainOrMaster
 	origInstallByVersionUpd := installByVersionUpd
 	defer func() {
 		getLatestVer = origGetLatest
+		getVerByRefCtx = origRef
 		installLatest = origInstallLatest
 		installMainOrMaster = origInstallMain
 		installByVersionUpd = origInstallByVersionUpd
 	}()
 
 	getLatestVer = func(string) (string, error) { return testVersionNine, nil }
+	// The skip/update decision resolves the version via the @main ref.
+	getVerByRefCtx = func(_ context.Context, _ string, _ string) (string, error) { return testVersionNine, nil }
 	installLatest = func(string) error {
 		t.Fatal("installLatest should not be called for main channel")
 		return nil

--- a/cmd/version_cache.go
+++ b/cmd/version_cache.go
@@ -29,12 +29,6 @@ func newLatestVerCache() *latestVerCache {
 	return &latestVerCache{entries: make(map[string]*latestVerEntry)}
 }
 
-// get returns the latest version for the given module path on the @latest
-// channel, calling the fetcher at most once per unique module path.
-func (c *latestVerCache) get(ctx context.Context, modulePath string) (string, error) {
-	return c.getByChannel(ctx, modulePath, goutil.UpdateChannelLatest)
-}
-
 // getByChannel returns the resolved version for the given module path on the
 // requested update channel. Results are cached per (module path, channel) pair
 // so that, for example, a package tracked on @main is not confused with the

--- a/cmd/version_cache_test.go
+++ b/cmd/version_cache_test.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/nao1215/gup/internal/goutil"
 )
 
 func Test_latestVerCache_get_nonContextErrorCached(t *testing.T) {
@@ -21,12 +23,12 @@ func Test_latestVerCache_get_nonContextErrorCached(t *testing.T) {
 	}
 
 	cache := newLatestVerCache()
-	_, err := cache.get(context.Background(), "example.com/tool")
+	_, err := cache.getByChannel(context.Background(), "example.com/tool", goutil.UpdateChannelLatest)
 	if !errors.Is(err, networkErr) {
 		t.Fatalf("latestVerCache.get() error = %v, want %v", err, networkErr)
 	}
 
-	_, err = cache.get(context.Background(), "example.com/tool")
+	_, err = cache.getByChannel(context.Background(), "example.com/tool", goutil.UpdateChannelLatest)
 	if !errors.Is(err, networkErr) {
 		t.Fatalf("latestVerCache.get() cached error = %v, want %v", err, networkErr)
 	}
@@ -53,7 +55,7 @@ func Test_latestVerCache_get_waiterContextCanceled(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_, _ = cache.get(context.Background(), "example.com/tool")
+		_, _ = cache.getByChannel(context.Background(), "example.com/tool", goutil.UpdateChannelLatest)
 	}()
 
 	select {
@@ -64,7 +66,7 @@ func Test_latestVerCache_get_waiterContextCanceled(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, err := cache.get(ctx, "example.com/tool")
+	_, err := cache.getByChannel(ctx, "example.com/tool", goutil.UpdateChannelLatest)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("latestVerCache.get() error = %v, want %v", err, context.Canceled)
 	}
@@ -104,7 +106,7 @@ func Test_latestVerCache_get_waiterSharesFetchedResult(t *testing.T) {
 	errs := make(chan error, 2)
 	go func() {
 		defer wg.Done()
-		v, err := cache.get(context.Background(), "example.com/tool")
+		v, err := cache.getByChannel(context.Background(), "example.com/tool", goutil.UpdateChannelLatest)
 		results <- v
 		errs <- err
 	}()
@@ -117,7 +119,7 @@ func Test_latestVerCache_get_waiterSharesFetchedResult(t *testing.T) {
 
 	go func() {
 		defer wg.Done()
-		v, err := cache.get(context.Background(), "example.com/tool")
+		v, err := cache.getByChannel(context.Background(), "example.com/tool", goutil.UpdateChannelLatest)
 		results <- v
 		errs <- err
 	}()


### PR DESCRIPTION
## Summary

`gup update` resolved each package's update channel (`latest`/`main`/`master`) only at install time, so the "should this package be updated?" decision still came from the `@latest` lookup regardless of the selected channel. This makes the skip/update decision channel-aware, matching the logic `gup check` already uses. Closes #292.

## Changes

- `cmd/update.go`: resolve the update channel up front in `updateWithChannels` and base the skip/update decision on `verCache.getByChannel(ctx, modulePath, channel)` instead of the `@latest`-only `verCache.get`.
- `cmd/version_cache.go`: remove the now-unused `latestVerCache.get` wrapper; production code goes through `getByChannel`.
- `cmd/update_test.go`: add regression tests covering the master/main skip decision in both directions (channel ref moved while `@latest` is current, and `@latest` moved while the channel ref is unchanged), and stub the channel-aware lookup in the existing master/main tests.
- `cmd/root_test.go`, `cmd/version_cache_test.go`: stub `getVerByRefCtx` in the shared update helper and call `getByChannel(..., UpdateChannelLatest)` from the cache tests.

## Design Decisions

Channel resolution is moved to the top of the `updater` closure instead of doing a separate lookup, because the channel is needed both for the skip decision and the install step, so resolving it once keeps a single source of truth and cannot diverge between the two. The fix reuses the existing per-(module,channel) `getByChannel` cache path that `gup check` already relies on, so update and check now share identical channel-resolution semantics including the `@main`-with-`@master`-fallback behavior. `latestVerCache.get` is removed rather than kept as a convenience wrapper because production code no longer calls it and `unparam` flags the always-`@latest` parameter; tests now pass `UpdateChannelLatest` explicitly.