### PR TITLE
fix(update): keep update --json stdout pure JSON when excluding packages

### DIFF
--- a/cmd/jsonout_test.go
+++ b/cmd/jsonout_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/nao1215/gup/internal/goutil"
 	"github.com/nao1215/gup/internal/print"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -352,24 +353,9 @@ func Test_list_jsonFlag(t *testing.T) {
 // flag-parsing and JSON-dispatch branches in gup()/updateWithChannels are
 // covered without performing real installs.
 func Test_gup_jsonFlag(t *testing.T) {
-	t.Setenv("GOBIN", filepath.Join("testdata", "check_success"))
+	helper_stubUpdateForJSON(t, func(string) error { return nil })
 
-	origGetLatest := getLatestVer
-	origInstallLatest := installLatest
-	t.Cleanup(func() {
-		getLatestVer = origGetLatest
-		installLatest = origInstallLatest
-	})
-	getLatestVer = func(string) (string, error) { return testVersionNine, nil }
-	installLatest = func(string) error { return nil }
-
-	cmd := newUpdateCmd()
-	if err := cmd.Flags().Set("json", "true"); err != nil {
-		t.Fatalf("failed to set json flag: %v", err)
-	}
-	if err := cmd.Flags().Set("dry-run", "true"); err != nil {
-		t.Fatalf("failed to set dry-run flag: %v", err)
-	}
+	cmd := helper_newJSONDryRunUpdateCmd(t)
 
 	var got int
 	recs := readJSON(t, func() int {
@@ -381,5 +367,129 @@ func Test_gup_jsonFlag(t *testing.T) {
 	}
 	if len(recs) == 0 {
 		t.Fatal("expected at least one JSON record from update --json")
+	}
+}
+
+// helper_stubUpdateForJSON stubs the update operations and points $GOBIN at the
+// check_success fixtures so gup() can run --json end-to-end without real
+// installs. The returned readJSON helper fails the test if STDOUT is not valid
+// JSON, which is exactly the contamination this issue (#291) guards against.
+func helper_stubUpdateForJSON(t *testing.T, install func(string) error) {
+	t.Helper()
+	t.Setenv("GOBIN", filepath.Join("testdata", "check_success"))
+
+	origGetLatest := getLatestVer
+	origInstallLatest := installLatest
+	t.Cleanup(func() {
+		getLatestVer = origGetLatest
+		installLatest = origInstallLatest
+	})
+	getLatestVer = func(string) (string, error) { return testVersionNine, nil }
+	installLatest = install
+}
+
+// helper_newJSONDryRunUpdateCmd returns an update command with --json and
+// --dry-run already set, so JSON-mode regression tests don't repeat the flag
+// wiring (and perform no real installs).
+func helper_newJSONDryRunUpdateCmd(t *testing.T) *cobra.Command {
+	t.Helper()
+	cmd := newUpdateCmd()
+	if err := cmd.Flags().Set("json", "true"); err != nil {
+		t.Fatalf("failed to set json flag: %v", err)
+	}
+	if err := cmd.Flags().Set("dry-run", "true"); err != nil {
+		t.Fatalf("failed to set dry-run flag: %v", err)
+	}
+	return cmd
+}
+
+// Test_gup_jsonFlag_excludeKeepsStdoutPure verifies that --json keeps STDOUT
+// pure JSON even when --exclude would print a human-readable "Exclude ..." line
+// in normal mode. This is the core regression for issue #291: before the fix,
+// excludePkgs wrote that line to STDOUT (print.Info) and broke JSON parsing.
+func Test_gup_jsonFlag_excludeKeepsStdoutPure(t *testing.T) {
+	helper_stubUpdateForJSON(t, func(string) error { return nil })
+
+	cmd := helper_newJSONDryRunUpdateCmd(t)
+	if err := cmd.Flags().Set("exclude", testBinPosixer); err != nil {
+		t.Fatalf("failed to set exclude flag: %v", err)
+	}
+
+	var got int
+	recs := readJSON(t, func() int {
+		got = gup(cmd, []string{})
+		return got
+	})
+	if got != 0 {
+		t.Fatalf("gup() = %d, want 0", got)
+	}
+	if len(recs) == 0 {
+		t.Fatal("expected JSON records for the non-excluded packages")
+	}
+	for _, r := range recs {
+		if strings.Contains(r.Name, testBinPosixer) {
+			t.Errorf("excluded package %q must not appear in JSON output", r.Name)
+		}
+	}
+}
+
+// Test_gup_jsonFlag_missingFlagTargetKeepsStdoutPure verifies that a "not found"
+// warning for an unknown --main target (emitted via print.Warn to STDERR) does
+// not contaminate the JSON written to STDOUT, while the valid packages are still
+// reported. This pins STDOUT purity for the missing-targets edge case.
+func Test_gup_jsonFlag_missingFlagTargetKeepsStdoutPure(t *testing.T) {
+	helper_stubUpdateForJSON(t, func(string) error { return nil })
+
+	cmd := helper_newJSONDryRunUpdateCmd(t)
+	if err := cmd.Flags().Set("main", "doesnotexist"); err != nil {
+		t.Fatalf("failed to set main flag: %v", err)
+	}
+
+	var got int
+	recs := readJSON(t, func() int {
+		got = gup(cmd, []string{})
+		return got
+	})
+	if got != 0 {
+		t.Fatalf("gup() = %d, want 0", got)
+	}
+	if len(recs) == 0 {
+		t.Fatal("expected JSON records even when an unknown --main target is given")
+	}
+}
+
+// Test_gup_jsonFlag_partialFailureKeepsStdoutPure verifies that when one package
+// fails to install, its error (emitted via print.Err to STDERR) does not
+// contaminate STDOUT and the JSON still reports a per-package error status.
+func Test_gup_jsonFlag_partialFailureKeepsStdoutPure(t *testing.T) {
+	helper_stubUpdateForJSON(t, func(importPath string) error {
+		if strings.Contains(importPath, testBinPosixer) {
+			return errors.New("install failed")
+		}
+		return nil
+	})
+
+	cmd := helper_newJSONDryRunUpdateCmd(t)
+
+	var got int
+	recs := readJSON(t, func() int {
+		got = gup(cmd, []string{})
+		return got
+	})
+	if got != 1 {
+		t.Fatalf("gup() = %d, want 1 (one package failed)", got)
+	}
+
+	statusByName := map[string]string{}
+	for _, r := range recs {
+		statusByName[r.Name] = r.Status
+	}
+	if statusByName[testBinPosixer] != statusError {
+		t.Errorf("%s status = %q, want %q", testBinPosixer, statusByName[testBinPosixer], statusError)
+	}
+	for name, status := range statusByName {
+		if name != testBinPosixer && status == statusError {
+			t.Errorf("package %q unexpectedly reported error status", name)
+		}
 	}
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -147,7 +147,7 @@ func gup(cmd *cobra.Command, args []string) int {
 	}
 
 	pkgs = extractUserSpecifyPkg(pkgs, args)
-	pkgs = excludePkgs(excludePkgList, pkgs)
+	pkgs = excludePkgs(excludePkgList, pkgs, jsonOut)
 
 	if len(pkgs) == 0 {
 		print.Err("unable to update package: no package information or no package under $GOBIN")
@@ -190,7 +190,11 @@ func gup(cmd *cobra.Command, args []string) int {
 	return result
 }
 
-func excludePkgs(excludePkgList []string, pkgs []goutil.Package) []goutil.Package {
+// excludePkgs drops the binaries named in excludePkgList from pkgs. In JSON mode
+// the human-readable "Exclude ..." notice is suppressed so STDOUT stays valid
+// JSON (the notice goes to STDOUT via print.Info, which would otherwise break
+// machine-readable output; see issue #291).
+func excludePkgs(excludePkgList []string, pkgs []goutil.Package, jsonOut bool) []goutil.Package {
 	excluded := make(map[string]struct{}, len(excludePkgList))
 	for _, name := range excludePkgList {
 		normalized := normalizeBinaryNameForMatch(name)
@@ -203,7 +207,9 @@ func excludePkgs(excludePkgList []string, pkgs []goutil.Package) []goutil.Packag
 	packageList := []goutil.Package{}
 	for _, v := range pkgs {
 		if _, ok := excluded[normalizeBinaryNameForMatch(v.Name)]; ok {
-			print.Info(fmt.Sprintf("Exclude '%s' from the update target", v.Name))
+			if !jsonOut {
+				print.Info(fmt.Sprintf("Exclude '%s' from the update target", v.Name))
+			}
 			continue
 		}
 		packageList = append(packageList, v)

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -573,7 +573,7 @@ func Test_excludeUserSpecifiedPkg(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := excludePkgs(tt.args.excludePkgList, tt.args.pkgs)
+			got := excludePkgs(tt.args.excludePkgList, tt.args.pkgs, false)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("value is mismatch (-want +got):\n%s", diff)
 			}


### PR DESCRIPTION
## Summary

`gup update --json` is documented as machine-readable output, but `--exclude` printed a human-readable "Exclude '<name>' from the update target" line to STDOUT (via `print.Info`) before the JSON array, so STDOUT was no longer valid JSON and broke scripting. This makes JSON mode suppress that notice so STDOUT stays pure JSON. Closes #291.

## Changes

- `cmd/update.go`: add a `jsonOut bool` parameter to `excludePkgs` and guard the "Exclude ..." `print.Info` with `if !jsonOut`; pass `jsonOut` at the call site in `gup()`.
- `cmd/jsonout_test.go`: add three regression tests driving `gup()` end-to-end through the existing `readJSON` helper (which fails if STDOUT is not valid JSON) — `--json --exclude`, an unknown `--main` target, and a partial install failure — plus `helper_stubUpdateForJSON`/`helper_newJSONDryRunUpdateCmd` helpers, and route the existing `Test_gup_jsonFlag` through them.
- `cmd/update_test.go`: update the existing `excludePkgs` table-test call for the new signature.

## Design Decisions

The only STDOUT contamination source on the `update --json` path was `excludePkgs`'s `print.Info`; `print.Warn`/`print.Err` already write to STDERR (confirmed in `internal/print/print.go`), so "not found" warnings and per-package install errors never touch STDOUT and were intentionally left unchanged to avoid over-reaching. Suppressing the notice in JSON mode (rather than redirecting it to STDERR) matches the existing convention in `updateWithChannels`, where the progress lines are likewise gated behind `if !jsonOut`; the excluded package is already discoverable by its absence from the JSON array, so no information is lost. The regression tests reuse `readJSON` instead of adding a new stdout/stderr-splitting capture helper, because `readJSON` already captures STDOUT only and unmarshals it, which is exactly the purity guarantee under test; the missing-target and partial-failure cases are STDERR paths today and serve to pin STDOUT purity against future regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JSON output purity: excluded packages and informational notices no longer appear in JSON output when using `--json` flag, ensuring clean machine-readable results.
  * Improved error handling in JSON mode for missing targets and partial installation failures while maintaining output integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->