### PR TITLE
fix: skip Go-version comparison when 'go version' detection fails

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -71,11 +71,15 @@ func check(cmd *cobra.Command, args []string) int {
 		return 1
 	}
 
-	pkgs, err := getPackageInfoByTargets(args)
+	pkgs, goVersionAvailable, err := getPackageInfoByTargets(args)
 	if err != nil {
 		print.Err(err)
 		return 1
 	}
+	// When the installed Go version can't be detected, behave as
+	// --ignore-go-update so check does not report every binary as outdated
+	// (see issue #296).
+	ignoreGoUpdate = ignoreGoUpdate || !goVersionAvailable
 	pkgs = extractUserSpecifyPkg(pkgs, args)
 
 	if len(pkgs) == 0 {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -118,11 +118,15 @@ func gup(cmd *cobra.Command, args []string) int {
 		return 1
 	}
 
-	pkgs, err := getPackageInfoByTargets(args)
+	pkgs, goVersionAvailable, err := getPackageInfoByTargets(args)
 	if err != nil {
 		print.Err(err)
 		return 1
 	}
+	// When the installed Go version can't be detected, behave as
+	// --ignore-go-update so a transient "go version" failure does not force
+	// every binary to reinstall (see issue #296).
+	ignoreGoUpdate = ignoreGoUpdate || !goVersionAvailable
 
 	excludePkgList, err := getFlagStringSlice(cmd, "exclude")
 	if err != nil {
@@ -670,14 +674,18 @@ func getPackageInfo() ([]goutil.Package, error) {
 	return goutil.GetPackageInformationWithoutGoVersion(binList), nil
 }
 
-func getPackageInfoByTargets(targets []string) ([]goutil.Package, error) {
+// getPackageInfoByTargets returns the packages to process and a bool reporting
+// whether the installed Go version was detected. When the bool is false,
+// callers must disable Go-version comparison (see issue #296).
+func getPackageInfoByTargets(targets []string) ([]goutil.Package, bool, error) {
 	binList, err := getBinaryPathList()
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", "can't get package info", err)
+		return nil, false, fmt.Errorf("%s: %w", "can't get package info", err)
 	}
 
 	filtered := filterBinaryPathListByTargets(binList, targets)
-	return goutil.GetPackageInformation(filtered), nil
+	pkgs, goVersionAvailable := goutil.GetPackageInformation(filtered)
+	return pkgs, goVersionAvailable, nil
 }
 
 func filterBinaryPathListByTargets(binList, targets []string) []string {

--- a/internal/goutil/examples_test.go
+++ b/internal/goutil/examples_test.go
@@ -67,7 +67,7 @@ func ExampleGetPackageInformation() {
 
 	pathFileBin := filepath.Join("..", "..", "cmd", "testdata", nameDirCheckSuccess, nameFileBin)
 
-	pkgInfo := goutil.GetPackageInformation([]string{pathFileBin})
+	pkgInfo, _ := goutil.GetPackageInformation([]string{pathFileBin})
 	if pkgInfo == nil {
 		log.Fatal("example GetPackageInformation failed. The returned package information is nil")
 	}
@@ -252,7 +252,7 @@ func ExampleGoPaths_StartDryRunMode() {
 //
 // ----------------------------------------------------------------------------
 func ExamplePackage_SetLatestVer() {
-	packages := goutil.GetPackageInformation([]string{"../../cmd/testdata/check_success/gal"})
+	packages, _ := goutil.GetPackageInformation([]string{"../../cmd/testdata/check_success/gal"})
 	if len(packages) == 0 {
 		log.Fatal("example GetPackageInformation failed. The returned package information is nil")
 	}

--- a/internal/goutil/goutil.go
+++ b/internal/goutil/goutil.go
@@ -510,12 +510,20 @@ func IsStdCmd(importPath string) bool {
 // GetPackageInformation return golang package information including the latest
 // installed Go toolchain version. Use it for commands that compare Go versions
 // (check, update). Binary info is read in parallel using a worker pool.
-func GetPackageInformation(binList []string) []Package {
+//
+// The second return value reports whether the installed Go version was
+// detected. When it is false, callers must disable Go-version comparison
+// (behave as --ignore-go-update); otherwise a transient "go version" failure
+// stamps "unknown" on every package and forces a needless reinstall of all
+// binaries (see issue #296).
+func GetPackageInformation(binList []string) ([]Package, bool) {
 	goVer, err := GetInstalledGoVersion()
 	if err != nil {
-		goVer = unknown
+		print.Warn(fmt.Sprintf("failed to detect installed Go version (%v); "+
+			"skipping Go-version comparison this run. Module versions are still checked.", err))
+		return collectPackageInformation(binList, unknown), false
 	}
-	return collectPackageInformation(binList, goVer)
+	return collectPackageInformation(binList, goVer), true
 }
 
 // GetPackageInformationWithoutGoVersion is like GetPackageInformation but skips

--- a/internal/goutil/goutil_test.go
+++ b/internal/goutil/goutil_test.go
@@ -179,7 +179,7 @@ func TestGetPackageInformation_unknown_module(t *testing.T) {
 
 	print.Stderr = &tmpBuff
 
-	result := GetPackageInformation([]string{"unknown-module"})
+	result, _ := GetPackageInformation([]string{"unknown-module"})
 
 	// Require to be empty
 	if len(result) != 0 {
@@ -191,6 +191,63 @@ func TestGetPackageInformation_unknown_module(t *testing.T) {
 	got := tmpBuff.String()
 	if !strings.Contains(got, wantContain) {
 		t.Errorf("it should print error message '%v'. got: %v", wantContain, got)
+	}
+}
+
+// TestGetPackageInformation_goVersionFailure verifies the fix for issue #296:
+// when "go version" cannot be read, GetPackageInformation reports that the Go
+// version is unavailable (second return value false) and warns exactly once,
+// instead of silently stamping "unknown" and forcing every binary to reinstall.
+func TestGetPackageInformation_goVersionFailure(t *testing.T) {
+	oldGoExe := goExe
+	oldPrintStderr := print.Stderr
+	defer func() {
+		goExe = oldGoExe
+		print.Stderr = oldPrintStderr
+	}()
+	// Point the go command at a binary that does not exist so "go version"
+	// fails on every OS (unlike "false", which is absent on Windows).
+	goExe = "gup-nonexistent-go-command-for-test"
+
+	var stderr bytes.Buffer
+	print.Stderr = &stderr
+
+	nameDir := "check_success"
+	nameBin := "gal"
+	if runtime.GOOS == "windows" {
+		nameDir = "check_success_for_windows"
+		nameBin = "gal.exe"
+	}
+	pathBin := filepath.Join("..", "..", "cmd", "testdata", nameDir, nameBin)
+
+	pkgs, goVersionAvailable := GetPackageInformation([]string{pathBin})
+
+	// The Go-version detection failure is reported, not swallowed.
+	if goVersionAvailable {
+		t.Error("goVersionAvailable should be false when 'go version' fails")
+	}
+	// Packages are still returned so module-version checks can proceed.
+	if len(pkgs) != 1 {
+		t.Fatalf("GetPackageInformation() returned %d packages, want 1", len(pkgs))
+	}
+	// Exactly one warning explains why the Go-version comparison was skipped.
+	if c := strings.Count(stderr.String(), "skipping Go-version comparison"); c != 1 {
+		t.Errorf("want exactly one Go-version warning, got %d: %q", c, stderr.String())
+	}
+
+	// Acceptance criterion (1): an otherwise up-to-date binary must not be
+	// flagged for update. Without the fix, the Go version is "unknown" so
+	// IsGoUpToDate() is false and, with ignore-go-update off, the Go-version
+	// term would force a reinstall. The fix makes callers treat a detection
+	// failure as ignore-go-update, which disables that term.
+	p := pkgs[0]
+	p.Version.Latest = p.Version.Current // module side is up-to-date
+	if p.IsGoUpToDate() {
+		t.Fatal("precondition: IsGoUpToDate() should be false when the Go version is unknown")
+	}
+	ignoreGoUpdate := !goVersionAvailable
+	if goVersionForcesUpdate := !ignoreGoUpdate && !p.IsGoUpToDate(); goVersionForcesUpdate {
+		t.Error("Go-version comparison must be disabled on detection failure so it cannot force a reinstall")
 	}
 }
 
@@ -623,7 +680,7 @@ func TestGetPackageInformation_std_cmd_filtered(t *testing.T) {
 		t.Skipf("gofmt not found at %s: %v", gofmt, err)
 	}
 
-	result := GetPackageInformation([]string{gofmt})
+	result, _ := GetPackageInformation([]string{gofmt})
 	if len(result) != 0 {
 		t.Errorf("GetPackageInformation() should filter standard library commands, got: %v", result)
 	}
@@ -1257,7 +1314,7 @@ func TestVersionUpToDate_invalidVersion(t *testing.T) {
 }
 
 func TestGetPackageInformation_emptyList(t *testing.T) {
-	result := GetPackageInformation([]string{})
+	result, _ := GetPackageInformation([]string{})
 	if result != nil {
 		t.Errorf("expected nil for empty list, got %v", result)
 	}
@@ -1369,7 +1426,7 @@ func BenchmarkGetPackageInformation(b *testing.B) {
 			}
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_ = GetPackageInformation(list)
+				_, _ = GetPackageInformation(list)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

When `go version` cannot be read, `GetPackageInformation` silently stamped `unknown` as every package's Go toolchain version, which `goVersionUpToDate` treats as "not up to date", so `IsGoUpToDate()` returned false for all binaries and `gup update` reinstalled every binary unless `--ignore-go-update` was passed. This makes a failed Go-version detection behave as `--ignore-go-update` for that run and warn once, instead of triggering a silent full-fleet over-update. Closes #296.

## Changes

- `internal/goutil/goutil.go`: change `GetPackageInformation` to return `([]Package, bool)`, where the bool reports whether the installed Go version was detected; on failure it warns once and returns false instead of swallowing the error.
- `cmd/update.go`: thread the new bool through `getPackageInfoByTargets` and, in `gup()`, set `ignoreGoUpdate = ignoreGoUpdate || !goVersionAvailable` so the existing update-decision wiring disables the Go-version term.
- `cmd/check.go`: apply the same effective `ignoreGoUpdate` in `check()` so `gup check` does not report every binary as outdated either.
- `internal/goutil/goutil_test.go`: add `TestGetPackageInformation_goVersionFailure`, which forces `go version` to fail and asserts the failure is reported, warned exactly once, and no longer forces an up-to-date binary to update; existing call sites follow the new signature.

## Design Decisions

The comparison helpers (`IsGoUpToDate`/`goVersionUpToDate`) are deliberately left untouched so that genuine "the installed Go is newer" detection still works; the fix only suppresses the comparison when the Go version is unknown, by reusing the existing `ignoreGoUpdate` path rather than adding new parameters to `updateWithChannels`/`doCheckWith` (minimal diff). The warning is emitted inside `GetPackageInformation`, which is called exactly once per run via the single `getPackageInfoByTargets` call shared by both `update` and `check`, so "warn once" is guaranteed structurally and both commands are covered. `GetPackageInformation`'s signature change is safe because `internal/goutil` is an internal package with no external importers. The regression test injects a real failure by pointing `goExe` at a nonexistent command (rather than `false`, which is absent on Windows), exercising the actual subprocess-failure path cross-platform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when Go version detection fails, preventing unnecessary package update attempts due to toolchain version mismatches.
  * Added graceful fallback behavior to avoid erroneous outdated status when Go version information is unavailable.

* **Tests**
  * Added regression test to verify robust behavior during Go version detection failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->