### PR TITLE
fix: guarantee dry-run temp-dir cleanup and make it panic-safe

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -112,7 +112,7 @@ func runImport(cmd *cobra.Command, _ []string) int {
 	return installFromConfig(pkgs, dryRun, notify, cpus, timeout)
 }
 
-func installFromConfig(pkgs []goutil.Package, dryRun, notification bool, cpus int, timeout time.Duration) int {
+func installFromConfig(pkgs []goutil.Package, dryRun, notification bool, cpus int, timeout time.Duration) (exitCode int) {
 	dryRunManager := goutil.NewGoPaths()
 
 	if dryRun {
@@ -120,6 +120,14 @@ func installFromConfig(pkgs []goutil.Package, dryRun, notification bool, cpus in
 			print.Err(fmt.Errorf("can not change to dry run mode: %w", err))
 			return 1
 		}
+		// Restore the environment and remove the temp dir via defer so it runs
+		// even if a package install panics (see issue #297).
+		defer func() {
+			if err := dryRunManager.EndDryRunMode(); err != nil {
+				print.Err(fmt.Errorf("can not change dry run mode to normal mode: %w", err))
+				exitCode = 1
+			}
+		}()
 	}
 
 	installer := func(ctx context.Context, p goutil.Package) updateResult {
@@ -163,13 +171,6 @@ func installFromConfig(pkgs []goutil.Package, dryRun, notification bool, cpus in
 	result, _ := executePackages(pkgs, cpus, timeout, installer, func(prefix string, v updateResult) {
 		print.Info(fmt.Sprintf("%s %s@%s", prefix, v.pkg.ImportPath, v.pkg.Version.Current))
 	})
-
-	if dryRun {
-		if err := dryRunManager.EndDryRunMode(); err != nil {
-			print.Err(fmt.Errorf("can not change dry run mode to normal mode: %w", err))
-			return 1
-		}
-	}
 
 	desktopNotifyIfNeeded(result, notification)
 	return result

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -243,7 +243,7 @@ type updateResult struct {
 	status      string // machine-readable status for --json output (see jsonout.go)
 }
 
-func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus int, ignoreGoUpdate bool, channelMap map[string]goutil.UpdateChannel, timeout time.Duration, jsonOut bool) (int, []goutil.Package, map[string]string) {
+func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus int, ignoreGoUpdate bool, channelMap map[string]goutil.UpdateChannel, timeout time.Duration, jsonOut bool) (exitCode int, succeeded []goutil.Package, renamed map[string]string) {
 	dryRunManager := goutil.NewGoPaths()
 
 	verCache := newLatestVerCache()
@@ -257,6 +257,14 @@ func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus i
 			notify.Warn("gup", "Can not change to dry run mode")
 			return 1, nil, nil
 		}
+		// Restore the environment and remove the temp dir via defer so it runs
+		// even if a package update panics (see issue #297).
+		defer func() {
+			if err := dryRunManager.EndDryRunMode(); err != nil {
+				print.Err(fmt.Errorf("can not change dry run mode to normal mode: %w", err))
+				exitCode = 1
+			}
+		}()
 	}
 
 	updater := func(ctx context.Context, p goutil.Package) updateResult {
@@ -370,13 +378,6 @@ func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus i
 
 	// update all packages
 	result, results := executePackages(pkgs, cpus, timeout, updater, onResult)
-
-	if dryRun {
-		if err := dryRunManager.EndDryRunMode(); err != nil {
-			print.Err(fmt.Errorf("can not change dry run mode to normal mode: %w", err))
-			return 1, nil, nil
-		}
-	}
 
 	if jsonOut {
 		if err := encodeJSONPackages(resultsToJSONPackages(results)); err != nil {

--- a/internal/goutil/goutil.go
+++ b/internal/goutil/goutil.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"debug/buildinfo"
+	stderrors "errors"
 	"fmt"
 	"go/build"
 	"os"
@@ -277,6 +278,8 @@ func (gp *GoPaths) StartDryRunMode() error {
 	switch {
 	case gp.GOBIN != "":
 		if err := os.Setenv(keyGoBin, tmpDir); err != nil {
+			// Avoid leaking the temp dir when the env mutation fails.
+			_ = gp.removeTmpDir()
 			// Wrap error to avoid OS dependent error message during testing.
 			return errors.Wrapf(
 				err,
@@ -286,6 +289,7 @@ func (gp *GoPaths) StartDryRunMode() error {
 		}
 	case gp.GOPATH != "":
 		if err := os.Setenv(keyGoPath, tmpDir); err != nil {
+			_ = gp.removeTmpDir()
 			return errors.Wrapf(
 				err,
 				"failed to set GOPATH to env variable. key: %v, value: %v",
@@ -293,18 +297,23 @@ func (gp *GoPaths) StartDryRunMode() error {
 			)
 		}
 	default:
+		_ = gp.removeTmpDir()
 		return errors.New("$GOPATH and $GOBIN is not set")
 	}
 	return nil
 }
 
-// EndDryRunMode restore the GOBIN or GOPATH settings.
+// EndDryRunMode restore the GOBIN or GOPATH settings and remove the temporary
+// directory. The temp dir is always removed, even when restoring the env
+// variable fails, so a failed restore does not leak the directory (see issue
+// #297). Any restore and removal errors are joined into the returned error.
 func (gp *GoPaths) EndDryRunMode() error {
+	var restoreErr error
 	switch {
 	case gp.GOBIN != "":
 		if err := os.Setenv(keyGoBin, gp.GOBIN); err != nil {
 			// Wrap error to avoid OS dependent error message during testing.
-			return errors.Wrapf(
+			restoreErr = errors.Wrapf(
 				err,
 				"failed to set GOBIN to env variable. key: %v, value: %v",
 				keyGoBin, gp.GOBIN,
@@ -312,20 +321,22 @@ func (gp *GoPaths) EndDryRunMode() error {
 		}
 	case gp.GOPATH != "":
 		if err := os.Setenv(keyGoPath, gp.GOPATH); err != nil {
-			return errors.Wrapf(
+			restoreErr = errors.Wrapf(
 				err,
 				"failed to set GOPATH to env variable. key: %v, value: %v",
 				keyGoPath, gp.GOPATH,
 			)
 		}
 	default:
-		return errors.New("$GOPATH and $GOBIN is not set")
+		restoreErr = errors.New("$GOPATH and $GOBIN is not set")
 	}
 
+	var removeErr error
 	if err := gp.removeTmpDir(); err != nil {
-		return errors.Wrap(err, "temporary directory for dry run remains")
+		removeErr = errors.Wrap(err, "temporary directory for dry run remains")
 	}
-	return nil
+
+	return stderrors.Join(restoreErr, removeErr)
 }
 
 // removeTmpDir remove tmporary directory for dry run

--- a/internal/goutil/goutil_test.go
+++ b/internal/goutil/goutil_test.go
@@ -813,6 +813,81 @@ func TestGoPaths_EndDryRunMode_fail_to_remove_temp_dir(t *testing.T) {
 	}
 }
 
+// TestGoPaths_EndDryRunMode_removesTmpDir_even_if_restore_fails covers the issue
+// #297 fix: when restoring the env variable fails, the temporary directory must
+// still be removed instead of being leaked.
+func TestGoPaths_EndDryRunMode_removesTmpDir_even_if_restore_fails(t *testing.T) {
+	oldKeyGoBin := keyGoBin
+	defer func() { keyGoBin = oldKeyGoBin }()
+	// An empty key name makes os.Setenv fail, so the env restore errors out.
+	keyGoBin = ""
+
+	// A real temporary directory that EndDryRunMode is expected to remove.
+	tmpDir := filepath.Join(t.TempDir(), "dryrun")
+	if err := os.MkdirAll(tmpDir, 0o750); err != nil {
+		t.Fatalf("failed to set up temp dir: %v", err)
+	}
+
+	gp := GoPaths{GOBIN: "dummy", TmpPath: tmpDir}
+
+	err := gp.EndDryRunMode()
+	if err == nil {
+		t.Fatal("EndDryRunMode() should return error when env restore fails. got: nil")
+	}
+	if !strings.Contains(err.Error(), "failed to set GOBIN to env variable") {
+		t.Errorf("error should report the restore failure. got: %v", err)
+	}
+
+	// The temp directory must be gone even though the restore failed.
+	if _, statErr := os.Stat(tmpDir); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("temp dir should be removed even when env restore fails. stat err: %v", statErr)
+	}
+}
+
+// TestGoPaths_EndDryRunMode_joins_restore_and_remove_errors verifies that when
+// both the env restore and the temp-dir removal fail, the returned error
+// reports both problems.
+func TestGoPaths_EndDryRunMode_joins_restore_and_remove_errors(t *testing.T) {
+	oldKeyGoBin := keyGoBin
+	defer func() { keyGoBin = oldKeyGoBin }()
+	keyGoBin = "" // env restore fails
+
+	gp := GoPaths{GOBIN: "dummy", TmpPath: "."} // os.RemoveAll(".") fails
+
+	err := gp.EndDryRunMode()
+	if err == nil {
+		t.Fatal("EndDryRunMode() should return error when both restore and removal fail. got: nil")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "failed to set GOBIN to env variable") {
+		t.Errorf("joined error should report the restore failure. got: %v", got)
+	}
+	if !strings.Contains(got, "temporary directory for dry run remains") {
+		t.Errorf("joined error should report the removal failure. got: %v", got)
+	}
+}
+
+// TestGoPaths_StartDryRunMode_removesTmpDir_when_setenv_fails verifies that a
+// failed env mutation during StartDryRunMode does not leak the temp directory.
+func TestGoPaths_StartDryRunMode_removesTmpDir_when_setenv_fails(t *testing.T) {
+	oldKeyGoBin := keyGoBin
+	defer func() { keyGoBin = oldKeyGoBin }()
+	keyGoBin = "" // makes os.Setenv fail after the temp dir is created
+
+	gp := GoPaths{GOBIN: "dummy"}
+
+	err := gp.StartDryRunMode()
+	if err == nil {
+		t.Fatal("StartDryRunMode() should return error when env mutation fails. got: nil")
+	}
+	if gp.TmpPath == "" {
+		t.Fatal("StartDryRunMode() should have created a temp dir before failing")
+	}
+	if _, statErr := os.Stat(gp.TmpPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("temp dir should be removed when StartDryRunMode fails. stat err: %v", statErr)
+	}
+}
+
 func TestGoPaths_StartDryRunMode_fail_to_get_temp_dir(t *testing.T) {
 	// Backup and defer restore
 	OldOsMkdirTemp := osMkdirTemp


### PR DESCRIPTION
## Summary

`gup update --dry-run` could leak its temporary directory: `EndDryRunMode` restored the env variable first and returned early on failure, so `removeTmpDir()` was never reached, and the cleanup was invoked conditionally rather than via `defer`, so a panic during the update skipped restore entirely. This hardens dry-run so the temp dir is always removed (even when the env restore fails) and cleanup runs via `defer` so it is panic-safe. Closes #297.

## Changes

- `internal/goutil/goutil.go`: rewrite `EndDryRunMode` to always run `removeTmpDir()` — it captures the restore failure instead of returning early and joins it with any removal error via `errors.Join` (imported as `stderrors`); `StartDryRunMode` now removes the temp dir if the env mutation fails so it does not leak either.
- `cmd/update.go`: give `updateWithChannels` named return values and register `EndDryRunMode` with `defer` right after `StartDryRunMode` succeeds, setting the exit code to 1 on cleanup failure; the old conditional end-block is removed.
- `cmd/import.go`: apply the same `defer`-based cleanup to `installFromConfig`, which shared the identical dry-run pattern.
- `internal/goutil/goutil_test.go`: add regression tests for the cleanup-on-error paths (temp dir removed when env restore fails, both errors joined, and `StartDryRunMode` cleanup on env-mutation failure).

## Design Decisions

The issue suggested injecting the dry-run `GOBIN`/`GOPATH` into each `exec.Cmd.Env` to drop the process-global `os.Setenv`, but that would change `Install*`/`GetVer*` signatures and rewrite ~39 test stubs for no practical gain — gup is a CLI that runs these subprocesses sequentially within one process, and dry-run installs all go to a throwaway temp dir — so the issue's accepted alternative (guarantee cleanup via `defer` and make it panic-safe) is taken and `os.Setenv` is kept. `EndDryRunMode` joins the restore and removal errors rather than dropping one, and the existing `"failed to set ..."` / `"temporary directory for dry run remains"` messages are preserved so current tests stay valid. Registering the `defer` only after `StartDryRunMode` succeeds keeps the start-failure path from calling `EndDryRunMode` while still covering panics; with named returns, the explicit `return` assigns the results and the deferred cleanup can still override the exit code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of dry-run mode by ensuring proper cleanup even if operations fail unexpectedly.
  * Enhanced error handling to prevent temporary file leakage during environment restoration failures.

* **Tests**
  * Added regression test coverage for dry-run cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->