### PR TITLE
fix: surface a cause when a killed go subprocess has empty stderr

### DIFF
--- a/internal/goutil/goutil.go
+++ b/internal/goutil/goutil.go
@@ -415,7 +415,13 @@ func InstallWithContext(ctx context.Context, importPath, version string) error {
 			}
 			return fmt.Errorf("install of %s canceled: %w", importPath, ctxErr)
 		}
-		return fmt.Errorf("can't install %s:\n%s", importPath, stderr.String())
+		// A killed subprocess (e.g. SIGKILL) often writes nothing to stderr, so
+		// fall back to err (e.g. "signal: killed") to always name a cause.
+		detail := stderr.String()
+		if strings.TrimSpace(detail) == "" {
+			detail = err.Error()
+		}
+		return fmt.Errorf("can't install %s:\n%s", importPath, detail)
 	}
 	return nil
 }
@@ -449,7 +455,13 @@ func GetVerWithContext(ctx context.Context, modulePath, ref string) (string, err
 			}
 			return "", fmt.Errorf("version check of %s canceled: %w", modulePath, ctxErr)
 		}
-		return "", fmt.Errorf("can't check %s:\n%s", modulePath, stderr.String())
+		// A killed subprocess (e.g. SIGKILL) often writes nothing to stderr, so
+		// fall back to err (e.g. "signal: killed") to always name a cause.
+		detail := stderr.String()
+		if strings.TrimSpace(detail) == "" {
+			detail = err.Error()
+		}
+		return "", fmt.Errorf("can't check %s:\n%s", modulePath, detail)
 	}
 	return strings.TrimRight(string(out), "\n"), nil
 }

--- a/internal/goutil/goutil_test.go
+++ b/internal/goutil/goutil_test.go
@@ -1453,6 +1453,56 @@ func TestGetLatestVerWithContext_Cancel(t *testing.T) {
 	}
 }
 
+// errorCauseAfterPrefix returns the part of the error message after the
+// "<prefix>:\n" header, trimmed. It is empty when the error carries no cause.
+func errorCauseAfterPrefix(t *testing.T, err error, prefix string) string {
+	t.Helper()
+	return strings.TrimSpace(strings.TrimPrefix(err.Error(), prefix+":"))
+}
+
+// TestInstallWithContext_EmptyStderrFallback covers issue #298: when the go
+// subprocess fails without writing to stderr (as a killed process does), the
+// error must still name a cause (from err.Error()) instead of being empty.
+func TestInstallWithContext_EmptyStderrFallback(t *testing.T) {
+	oldGoExe := goExe
+	defer func() { goExe = oldGoExe }()
+	// A missing command fails on every OS while leaving stderr empty, and with
+	// context.Background() ctx.Err() is nil so the fallback branch is reached.
+	goExe = "gup-nonexistent-go-command-for-test"
+
+	err := InstallWithContext(context.Background(), timeoutTestImportPath, "latest")
+	if err == nil {
+		t.Fatal("InstallWithContext should fail when the go command is missing")
+	}
+	if !strings.Contains(err.Error(), "can't install") {
+		t.Errorf("error should report the install failure, got: %v", err)
+	}
+	prefix := fmt.Sprintf("can't install %s", timeoutTestImportPath)
+	if errorCauseAfterPrefix(t, err, prefix) == "" {
+		t.Errorf("error should include a non-empty cause when stderr is empty, got: %v", err)
+	}
+}
+
+// TestGetVerWithContext_EmptyStderrFallback is the GetVerWithContext counterpart
+// of TestInstallWithContext_EmptyStderrFallback (issue #298).
+func TestGetVerWithContext_EmptyStderrFallback(t *testing.T) {
+	oldGoExe := goExe
+	defer func() { goExe = oldGoExe }()
+	goExe = "gup-nonexistent-go-command-for-test"
+
+	_, err := GetVerWithContext(context.Background(), timeoutTestImportPath, "latest")
+	if err == nil {
+		t.Fatal("GetVerWithContext should fail when the go command is missing")
+	}
+	if !strings.Contains(err.Error(), "can't check") {
+		t.Errorf("error should report the version-check failure, got: %v", err)
+	}
+	prefix := fmt.Sprintf("can't check %s", timeoutTestImportPath)
+	if errorCauseAfterPrefix(t, err, prefix) == "" {
+		t.Errorf("error should include a non-empty cause when stderr is empty, got: %v", err)
+	}
+}
+
 // benchBinarySources are real Go binaries (with build info) used to populate
 // synthetic GOBIN directories for benchmarks.
 func benchBinarySources(b *testing.B) []string {


### PR DESCRIPTION
## Summary

When a `go install` or `go list` subprocess is killed (for example by a context timeout that sends SIGKILL), the child often writes nothing to stderr, so the user saw `can't install <path>:` with no reason, making timeouts and kills hard to diagnose. This makes both `InstallWithContext` and `GetVerWithContext` fall back to the process error (e.g. `signal: killed`) when stderr is empty, so the message always names a cause. Closes #298.

## Changes

- `internal/goutil/goutil.go`: in the `ctx.Err() == nil` error branch of `InstallWithContext` and `GetVerWithContext`, use `stderr.String()` as the detail but fall back to `err.Error()` when it is blank.
- `internal/goutil/goutil_test.go`: add `TestInstallWithContext_EmptyStderrFallback` and `TestGetVerWithContext_EmptyStderrFallback`, which run with a missing `go` command so the subprocess fails with empty stderr, plus a small `errorCauseAfterPrefix` helper.

## Design Decisions

The fallback is gated on `strings.TrimSpace(stderr.String()) == ""` so a subprocess that writes only whitespace still gets a real cause, while the common case (real toolchain output on stderr) is unchanged byte-for-byte. The timeout/cancel branch already returns its own wrapped message before this point, so it is untouched, and the error is interpolated with `%s` rather than `%w` because no caller inspects these errors with `errors.Is/As`. The scope is kept to the two functions named in the issue; `GetInstalledGoVersion` shares the same shape but is out of scope here. The tests use a non-existent command name rather than `false`, which is absent on Windows, matching the existing cross-platform pattern already used in this package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced installation failure error messages to display meaningful details when standard error output is unavailable.
  * Improved version-check error reporting to include fallback error details when standard error output is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->