### PR TITLE
fix(cmd): disable per-package timeout by default and name the command on timeout

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -46,7 +46,7 @@ const timeoutFlagName = "timeout"
 // go subprocesses (update, check, import, migrate).
 func addTimeoutFlag(cmd *cobra.Command) {
 	cmd.Flags().Duration(timeoutFlagName, defaultGoOpTimeout,
-		"per-package timeout for go operations (e.g. 90s, 5m); 0 disables the timeout")
+		"per-package timeout for go operations (e.g. 90s, 5m); default 0 means no timeout, so a slow go install is never killed")
 }
 
 // getTimeoutFlag reads the shared --timeout flag.

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -114,7 +114,7 @@ func TestGetFlagStringSlice(t *testing.T) {
 func TestGetTimeoutFlag(t *testing.T) {
 	t.Parallel()
 
-	t.Run("default", func(t *testing.T) {
+	t.Run("default is disabled (no timeout)", func(t *testing.T) {
 		t.Parallel()
 		cmd := &cobra.Command{}
 		addTimeoutFlag(cmd)
@@ -122,8 +122,10 @@ func TestGetTimeoutFlag(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if v != defaultGoOpTimeout {
-			t.Errorf("got %v, want %v", v, defaultGoOpTimeout)
+		// The default must be 0 so a slow "go install" is never killed
+		// (issue #318). This restores the pre-v1.3.0 behavior.
+		if v != 0 {
+			t.Errorf("default timeout should be 0 (disabled), got %v", v)
 		}
 	})
 

--- a/cmd/precheck.go
+++ b/cmd/precheck.go
@@ -12,10 +12,12 @@ import (
 )
 
 // defaultGoOpTimeout bounds a single package's go operations (version lookup
-// and install). It guards against unbounded hangs caused by bad network,
-// proxy, or registry states. Users can override it with --timeout, and
-// --timeout 0 disables the bound entirely.
-const defaultGoOpTimeout = 5 * time.Minute
+// and install). The default is 0, which disables the bound: a normal
+// "go install" may compile for an arbitrary amount of time, so gup must not
+// kill it (see issue #318). Signal-based cancellation (Ctrl-C) still aborts
+// in-flight work. Users can opt in to a bound with --timeout (e.g. --timeout
+// 5m) to guard against unbounded hangs from bad network/proxy/registry states.
+const defaultGoOpTimeout time.Duration = 0
 
 func ensureGoCommandAvailable() error {
 	if err := goutil.CanUseGoCmd(); err != nil {

--- a/internal/goutil/goutil.go
+++ b/internal/goutil/goutil.go
@@ -411,7 +411,7 @@ func InstallWithContext(ctx context.Context, importPath, version string) error {
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			if errors.Is(ctxErr, context.DeadlineExceeded) {
-				return fmt.Errorf("install of %s timed out: %w", importPath, ctxErr)
+				return fmt.Errorf("install of %s timed out; run `go install %s@%s` manually or raise --timeout (0 disables it): %w", importPath, importPath, version, ctxErr)
 			}
 			return fmt.Errorf("install of %s canceled: %w", importPath, ctxErr)
 		}
@@ -451,7 +451,7 @@ func GetVerWithContext(ctx context.Context, modulePath, ref string) (string, err
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			if errors.Is(ctxErr, context.DeadlineExceeded) {
-				return "", fmt.Errorf("version check of %s timed out: %w", modulePath, ctxErr)
+				return "", fmt.Errorf("version check of %s timed out; run `go list -m %s@%s` manually or raise --timeout (0 disables it): %w", modulePath, modulePath, ref, ctxErr)
 			}
 			return "", fmt.Errorf("version check of %s canceled: %w", modulePath, ctxErr)
 		}

--- a/internal/goutil/goutil_test.go
+++ b/internal/goutil/goutil_test.go
@@ -1421,6 +1421,17 @@ func TestInstallWithContext_Timeout(t *testing.T) {
 	if !strings.Contains(err.Error(), "timed out") {
 		t.Errorf("error should report a timeout, got: %v", err)
 	}
+	// The timeout error must name the runnable command and the --timeout hint
+	// so users can rerun or relax the limit (issue #318).
+	if !strings.Contains(err.Error(), "go install "+timeoutTestImportPath+"@latest") {
+		t.Errorf("error should include the runnable go install command, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--timeout") {
+		t.Errorf("error should hint at the --timeout flag, got: %v", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("error should wrap context.DeadlineExceeded, got: %v", err)
+	}
 }
 
 func TestInstallWithContext_Cancel(t *testing.T) {
@@ -1440,6 +1451,17 @@ func TestGetLatestVerWithContext_Timeout(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "timed out") {
 		t.Errorf("error should report a timeout, got: %v", err)
+	}
+	// The version-check timeout uses "go list" (not "go install") and hints at
+	// the --timeout flag (issue #318).
+	if !strings.Contains(err.Error(), "go list -m "+timeoutTestImportPath+"@latest") {
+		t.Errorf("error should include the runnable go list command, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--timeout") {
+		t.Errorf("error should hint at the --timeout flag, got: %v", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("error should wrap context.DeadlineExceeded, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

v1.3.0 added a per-package `--timeout` that defaults to 5 minutes, which kills a perfectly healthy `go install` whose compile simply takes longer than that (large dependency trees, slow machines, a cold module cache), so `gup update` reports `install timed out: context deadline exceeded` where v1.2.0 always succeeded. This restores the v1.2.0 behavior by making the default no timeout (`0`), keeping `--timeout` as an opt-in bound, and makes the timeout error name the exact command to run and how to relax the limit. ref #318

## Changes

- `cmd/precheck.go`: change `defaultGoOpTimeout` to `time.Duration(0)` (no timeout by default) and update its doc comment; the explicit type keeps the `time` import in use.
- `cmd/flags.go`: update the `--timeout` help text to say the default `0` means no timeout.
- `internal/goutil/goutil.go`: on timeout, `InstallWithContext` now includes `go install <path>@<version>` and `GetVerWithContext` includes `go list -m <module>@<ref>`, both with a `--timeout` hint, while still wrapping the context error with `%w`.
- `cmd/flags_test.go`: assert the default timeout is `0` explicitly so re-introducing a non-zero default is caught.
- `internal/goutil/goutil_test.go`: assert the timeout errors carry the runnable command, the `--timeout` hint, and `context.DeadlineExceeded`.

## Design Decisions

A default timeout on `go install` is fundamentally fragile because compile time is unbounded and machine-dependent, so any fixed default eventually kills legitimate builds; disabling it by default matches v1.2.0 exactly and is a behavior restoration rather than a new risk. Signal-based cancellation (Ctrl-C) is independent of `--timeout`, so an actually stuck subprocess can still be aborted, and users who want a hard bound (CI, flaky proxies) keep it via `--timeout 5m`. The error improvement lives in `internal/goutil` because that is where the user-facing message is already built and where both the import path/version and module/ref are in scope; only the timeout branch is touched (cancel is user-initiated, and the empty-stderr case was handled separately). The cancel branch and the generic failure message are intentionally left unchanged. CHANGELOG.md is not touched here because this repository updates it during release preparation, and the `fix(cmd):` commit prefix feeds the generated GitHub release notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `--timeout` flag help text to clarify that a default value of `0` disables the timeout completely.

* **Bug Fixes**
  * Improved timeout error messages to include concrete manual command suggestions and guidance on the `--timeout` flag for resolving timeout issues.

* **Chores**
  * Changed the default timeout from 5 minutes to disabled (0).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->