### PR TITLE
docs: prepare v1.3.1 release (changelog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [v1.3.1](https://github.com/nao1215/gup/compare/v1.3.0...v1.3.1) (2026-06-21)
+
+### Bug Fixes
+
+* The per-package `--timeout` added in v1.3.0 is now opt-in and disabled by default (default `0`), so a slow but healthy `go install` is no longer killed as a timeout; this restores the pre-v1.3.0 behavior. Pass `--timeout 5m` (or any duration) to re-enable a bound. (#318)
+* When a `--timeout` bound is hit, the error now names the exact command to rerun (`go install <path>@<version>` or `go list -m <module>@<ref>`) and hints at `--timeout`, so a slow build is easy to diagnose. (#318)
+* `gup update` now decides whether to skip a package using its resolved update channel, so binaries tracked on `@main`/`@master` are no longer skipped or updated based on `@latest`. (#292)
+* `gup update --json` keeps STDOUT valid JSON when `--exclude` is used, instead of leaking a human-readable "Exclude ..." line that broke machine-readable output. (#291)
+* When the installed Go version cannot be detected, gup disables the Go-version comparison for that run (and warns once) instead of treating every binary as outdated and reinstalling all of them. (#296)
+* Dry-run mode now always removes its temporary directory, even when restoring `GOBIN`/`GOPATH` fails, and runs cleanup via `defer` so it is panic-safe. (#297)
+* A killed `go install`/`go list` subprocess that writes nothing to stderr now reports a cause (e.g. `signal: killed`) instead of an empty error message. (#298)
+
 ## [v1.3.0](https://github.com/nao1215/gup/compare/v1.2.0...v1.3.0) (2026-06-21)
 
 ### Features


### PR DESCRIPTION
## Summary

Prepare the v1.3.1 patch release. Every change merged since v1.3.0 is a bug fix (no new features), so this bumps the patch version and adds a `v1.3.1` CHANGELOG entry. The headline fix reverts the v1.3.0 default per-package timeout, which was killing healthy but slow `go install` runs.

## Changes

- `CHANGELOG.md`: add the `v1.3.1` section summarizing the six bug fixes merged since v1.3.0 (#318, #292, #291, #296, #297, #298).

## Design Decisions

The version is `v1.3.1` rather than `v1.4.0` because everything since v1.3.0 is a `fix:` change and no new feature or flag was added; the timeout default change restores pre-v1.3.0 behavior (a regression fix), which is a backwards-compatible patch under SemVer. The release version itself is injected from the git tag via ldflags (see `internal/cmdinfo`), so no source constant needs bumping — merging this PR and pushing the `v1.3.1` tag is enough to trigger the goreleaser release workflow. Following the existing release flow, only `CHANGELOG.md` is touched (README/GIF updates are reserved for feature releases like v1.3.0).

## Limitations

The `v1.3.1` tag must be pushed by the maintainer after merge to trigger `.github/workflows/release.yml`; this PR only stages the changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for v1.3.1

* **Bug Fixes**
  * Improved timeout configuration handling
  * Enhanced error messaging for timeout events
  * Fixed JSON output formatting with exclusions
  * Improved handling of version detection edge cases
  * Enhanced error reporting for subprocess failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->