### PR TITLE
feat(cmd): respect NO_COLOR and add a --no-color flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,13 @@ $ gup update --notify
 ![success](./doc/img/notify_success.png)
 ![warning](./doc/img/notify_warning.png)
 
+### Disable colorized output
+gup colorizes its output by default. To turn colors off, pass `--no-color` or set the `NO_COLOR` environment variable to a non-empty value (following the [NO_COLOR](https://no-color.org/) convention). This is useful when piping output, in CI logs, or with `NO_COLOR` set globally.
+```shell
+$ gup update --no-color
+$ NO_COLOR=1 gup update
+```
+
 
 ## Benchmark
 gup runs updates in parallel, so it finishes faster than tools that update binaries one at a time. Updating 9 binaries that each had a newer version available:
@@ -345,7 +352,7 @@ Measured on AMD Ryzen AI Max+ 395 (32 cores) / 64 GB RAM / Ubuntu 26.04 / go 1.2
 | Shell completion generation/install | Yes | No | No |
 | Force reinstall up-to-date binaries | No | Yes | Yes |
 | Failure diagnostics / next-step hints | No | Yes | No |
-| `NO_COLOR` support | No | Yes | — |
+| `NO_COLOR` support | Yes | Yes | — |
 | No extra tool required (official toolchain only) | No | No | Yes |
 
 ## Contributing

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -59,4 +61,24 @@ func getTimeoutFlag(cmd *cobra.Command) (time.Duration, error) {
 		return 0, fmt.Errorf("can not parse command line argument (--%s): must be >= 0 (use 0 to disable the timeout)", timeoutFlagName)
 	}
 	return v, nil
+}
+
+// noColorFlagName is the name of the persistent --no-color flag.
+const noColorFlagName = "no-color"
+
+// addNoColorFlag registers the persistent --no-color flag on the root command
+// so every subcommand can disable colorized output.
+func addNoColorFlag(cmd *cobra.Command) {
+	cmd.PersistentFlags().Bool(noColorFlagName, false,
+		"disable colorized output (also honored via the NO_COLOR environment variable)")
+}
+
+// applyColorPreference disables colorized output when the user requests it via
+// the --no-color flag or a non-empty NO_COLOR environment variable (following
+// https://no-color.org/). It never re-enables color, so the automatic non-TTY
+// detection that fatih/color performs at startup is preserved.
+func applyColorPreference(noColor bool) {
+	if noColor || os.Getenv("NO_COLOR") != "" {
+		color.NoColor = true
+	}
 }

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -1,11 +1,70 @@
 package cmd
 
 import (
+	"io"
 	"testing"
 	"time"
 
+	"github.com/fatih/color"
+	"github.com/nao1215/gup/internal/print"
 	"github.com/spf13/cobra"
 )
+
+// Test_applyColorPreference verifies that color is disabled by the --no-color
+// flag or a non-empty NO_COLOR environment variable, and left untouched
+// otherwise (issue #309).
+func Test_applyColorPreference(t *testing.T) {
+	tests := []struct {
+		name       string
+		noColor    bool
+		noColorEnv string
+		want       bool
+	}{
+		{name: "flag true disables color", noColor: true, noColorEnv: "", want: true},
+		{name: "NO_COLOR=1 disables color", noColor: false, noColorEnv: "1", want: true},
+		{name: "non-empty NO_COLOR disables color", noColor: false, noColorEnv: "0", want: true},
+		{name: "flag false and empty NO_COLOR keeps color", noColor: false, noColorEnv: "", want: false},
+		{name: "flag and NO_COLOR both set disable color", noColor: true, noColorEnv: "1", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldNoColor := color.NoColor
+			color.NoColor = false
+			t.Cleanup(func() { color.NoColor = oldNoColor })
+			t.Setenv("NO_COLOR", tt.noColorEnv)
+
+			applyColorPreference(tt.noColor)
+
+			if color.NoColor != tt.want {
+				t.Errorf("applyColorPreference(%v) with NO_COLOR=%q: color.NoColor=%v, want %v",
+					tt.noColor, tt.noColorEnv, color.NoColor, tt.want)
+			}
+		})
+	}
+}
+
+// Test_rootCmd_noColorFlag_disablesColorViaExecute verifies the --no-color
+// persistent flag is inherited by subcommands and applied through the root
+// PersistentPreRunE (issue #309).
+func Test_rootCmd_noColorFlag_disablesColorViaExecute(t *testing.T) {
+	oldNoColor := color.NoColor
+	color.NoColor = false
+	t.Setenv("NO_COLOR", "") // ensure the env var does not interfere
+	t.Cleanup(func() { color.NoColor = oldNoColor })
+
+	orgStdout := print.Stdout
+	print.Stdout = io.Discard // `gup version` prints via print.Info
+	t.Cleanup(func() { print.Stdout = orgStdout })
+
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"version", "--no-color"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if !color.NoColor {
+		t.Error("`gup version --no-color` should disable color via the root PersistentPreRunE")
+	}
+}
 
 func TestGetFlagBool(t *testing.T) {
 	t.Parallel()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,10 +31,19 @@ oh-my-zsh alias is disabled (e.g. $ \gup update).
 If you find gup useful, please consider sponsoring the project:
   https://github.com/sponsors/nao1215
 `,
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			noColor, err := getFlagBool(cmd, noColorFlagName)
+			if err != nil {
+				return err
+			}
+			applyColorPreference(noColor)
+			return nil
+		},
 	}
 	cmd.CompletionOptions.DisableDefaultCmd = true
 	cmd.SilenceUsage = true
 	cmd.SilenceErrors = true
+	addNoColorFlag(cmd)
 
 	cmd.AddCommand(newCheckCmd())
 	cmd.AddCommand(newCompletionCmd())

--- a/cmd/testdata/bug_report/bug_report.txt
+++ b/cmd/testdata/bug_report/bug_report.txt
@@ -8,3 +8,6 @@ Examples:
 
 Flags:
   -h, --help   help for bug-report
+
+Global Flags:
+      --no-color   disable colorized output (also honored via the NO_COLOR environment variable)


### PR DESCRIPTION
## Summary

gup colorized its output via fatih/color with no explicit way to turn colors off, which hurts piping/redirecting, CI logs, and users who set NO_COLOR globally. This adds a persistent `--no-color` flag and honors the de-facto-standard `NO_COLOR` environment variable, while keeping the existing automatic non-TTY color detection as the default. Closes #309.

## Changes

- `cmd/flags.go`: add the persistent `--no-color` flag (`addNoColorFlag`) and `applyColorPreference`, which sets `color.NoColor = true` when `--no-color` is passed or `NO_COLOR` is non-empty.
- `cmd/root.go`: register the flag and apply the preference from a root `PersistentPreRunE`, so every subcommand honors it.
- `README.md`: flip the `NO_COLOR support` cell in the feature comparison from `No` to `Yes` and add a short "Disable colorized output" usage subsection.
- `cmd/testdata/bug_report/bug_report.txt`: update the `--help` golden file to include the new `Global Flags` section.
- `cmd/flags_test.go`: cover both paths — a table test for `applyColorPreference` (flag, non-empty/empty `NO_COLOR`) and an end-to-end test running `version --no-color` through the root command.

## Design Decisions

`applyColorPreference` only ever sets `color.NoColor = true` and never back to `false`, so it layers on top of fatih/color's startup non-TTY/`NO_COLOR` detection instead of overriding it; this keeps "no color when piping" working and avoids forcing color on. The `NO_COLOR` check uses `os.Getenv("NO_COLOR") != ""` to match both the no-color.org convention and fatih/color's own `noColorIsSet`, so an empty value does not disable color. The flag is a single persistent flag on the root command applied via `PersistentPreRunE`, because no subcommand defines its own persistent pre-run, so one definition covers all of them (`update`, `check`, `list`, `remove`, `import`, `migrate`, `export`, `version`, `bug-report`, `man`). Color is also re-checked at runtime rather than relying on fatih/color's import-time evaluation, which makes the `NO_COLOR` path testable and robust.

## Limitations

The bare `gup` command (no subcommand) is not runnable and shows only help, so its `PersistentPreRunE` does not run; this is harmless because help output is uncolored. The English README is updated here, but the six translated READMEs under `doc/` are intentionally left for the separate translation-sync effort tracked in #306 (they already lag the English source by whole sections), rather than shipping unverified machine translations of the new subsection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--no-color` flag to disable colorized output across all commands
  * Color output can also be disabled via the `NO_COLOR` environment variable
  * Updated documentation with usage examples and feature comparison updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->