### PR TITLE
feat(cmd): add --quiet output mode to check and update

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,21 @@ If you want to update binaries, the following command.
            $ gup update mimixbox
 ```
 
+### Quiet output for large tool sets
+`check` and `update` print every binary by default, which is noisy when you have many tools installed. Pass `--quiet` (`-q`) to suppress the up-to-date lines and show only the binaries that were updated (or have an update available) plus failures, followed by a one-line summary. Errors are always written to STDERR, so they stay visible.
+```shell
+$ gup update --quiet
+github.com/nao1215/gup (v0.7.0 to v0.7.1)
+gup: 1 updated, 8 up-to-date, 0 failed
+
+$ gup check -q
+github.com/nao1215/gup (current: v0.7.0, latest: v0.7.1 / go1.22.4)
+
+If you want to update binaries, run the following command.
+           $ gup update gup
+gup: 1 update available, 8 up-to-date, 0 failed
+```
+
 ### Machine-readable JSON output (for scripting / CI)
 `list`, `check`, and `update` accept `--json`, printing a JSON array instead of the human-readable output (which stays the default).
 

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -35,6 +35,7 @@ It does not update them.`,
 	}
 	cmd.Flags().Bool("ignore-go-update", false, "Ignore updates to the Go toolchain")
 	cmd.Flags().Bool("json", false, "output result as machine-readable JSON")
+	cmd.Flags().BoolP("quiet", "q", false, "suppress up-to-date lines; show only update-available/failed binaries plus a summary")
 	addTimeoutFlag(cmd)
 
 	return cmd
@@ -60,6 +61,12 @@ func check(cmd *cobra.Command, args []string) int {
 	}
 
 	jsonOut, err := getFlagBool(cmd, "json")
+	if err != nil {
+		print.Err(err)
+		return 1
+	}
+
+	quiet, err := getFlagBool(cmd, "quiet")
 	if err != nil {
 		print.Err(err)
 		return 1
@@ -91,7 +98,7 @@ func check(cmd *cobra.Command, args []string) int {
 	if jsonOut {
 		return doCheckJSON(pkgs, cpus, timeout, ignoreGoUpdate)
 	}
-	return doCheck(pkgs, cpus, timeout, ignoreGoUpdate)
+	return doCheck(pkgs, cpus, timeout, ignoreGoUpdate, quiet)
 }
 
 // applyCheckChannels resolves the saved per-package update channel from
@@ -117,20 +124,20 @@ func applyCheckChannels(pkgs []goutil.Package) []goutil.Package {
 	return applySavedChannels(pkgs, confPkgs)
 }
 
-func doCheck(pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpdate bool) int {
-	return doCheckWith(pkgs, cpus, timeout, ignoreGoUpdate, false)
+func doCheck(pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpdate, quiet bool) int {
+	return doCheckWith(pkgs, cpus, timeout, ignoreGoUpdate, quiet, false)
 }
 
 // doCheckJSON runs the same check as doCheck but emits a JSON array of package
 // records to STDOUT instead of human-readable progress lines.
 func doCheckJSON(pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpdate bool) int {
-	return doCheckWith(pkgs, cpus, timeout, ignoreGoUpdate, true)
+	return doCheckWith(pkgs, cpus, timeout, ignoreGoUpdate, false, true)
 }
 
-func doCheckWith(pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpdate, jsonOut bool) int {
+func doCheckWith(pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpdate, quiet, jsonOut bool) int {
 	verCache := newLatestVerCache()
 
-	if !jsonOut {
+	if !jsonOut && !quiet {
 		print.Info("check binary under $GOPATH/bin or $GOBIN")
 	}
 
@@ -176,6 +183,14 @@ func doCheckWith(pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreG
 	var onResult func(prefix string, v updateResult)
 	if !jsonOut {
 		onResult = func(prefix string, v updateResult) {
+			if quiet {
+				// In quiet mode show only binaries with an available update,
+				// without the [i/n] progress counter (which would be sparse).
+				if v.status == statusUpdateAvailable {
+					print.Info(fmt.Sprintf("%s (%s)", v.pkg.ImportPath, v.pkg.VersionCheckResultStr()))
+				}
+				return
+			}
 			print.Info(fmt.Sprintf("%s %s (%s)", prefix, v.pkg.ImportPath, v.pkg.VersionCheckResultStr()))
 		}
 	}
@@ -191,6 +206,9 @@ func doCheckWith(pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreG
 	}
 
 	printUpdatablePkgInfo(collectNeedUpdatePkgs(results))
+	if quiet {
+		print.Info(summarizeResults(results, true))
+	}
 	return result
 }
 

--- a/cmd/check_channel_test.go
+++ b/cmd/check_channel_test.go
@@ -166,7 +166,7 @@ func Test_doCheck_respectsSavedChannels(t *testing.T) {
 	}
 
 	out := captureCheckOutput(t, func() int {
-		return doCheck(pkgs, 1, 0, true)
+		return doCheck(pkgs, 1, 0, true, false)
 	})
 
 	idx := strings.Index(out, "$ gup update ")

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -442,7 +442,7 @@ func Test_doCheck_modulePathChanged(t *testing.T) {
 			},
 		},
 	}
-	got := doCheck(pkgs, 1, 0, true)
+	got := doCheck(pkgs, 1, 0, true, false)
 
 	pw.Close()
 	print.Stdout = orgStdout
@@ -492,7 +492,7 @@ func Test_doCheck_customGoBuildTag_noFalsePositiveUpdate(t *testing.T) {
 			},
 		},
 	}
-	got := doCheck(pkgs, 1, 0, false)
+	got := doCheck(pkgs, 1, 0, false, false)
 
 	if err := pw.Close(); err != nil {
 		t.Fatal(err)
@@ -552,7 +552,7 @@ func Test_doCheck_customGoBuildTag_goVersionDiffColor(t *testing.T) {
 		},
 	}
 
-	got := doCheck(pkgs, 1, 0, false)
+	got := doCheck(pkgs, 1, 0, false, false)
 	if err := pw.Close(); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/jsonout_test.go
+++ b/cmd/jsonout_test.go
@@ -253,7 +253,7 @@ func Test_updateWithChannels_jsonOutput(t *testing.T) {
 	var recs []jsonPackage
 	var result int
 	out := captureCheckOutput(t, func() int {
-		result, _, _ = updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, true)
+		result, _, _ = updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, true, false)
 		return result
 	})
 

--- a/cmd/parallel.go
+++ b/cmd/parallel.go
@@ -48,6 +48,12 @@ func collectResults(ch <-chan updateResult, total int, onResult func(prefix stri
 // per-package results. isCheck selects the check wording (update-available)
 // over the update wording (updated). Failures are counted first because a
 // failed result may still carry a non-error status.
+//
+// The status cases below cover every non-failed result that check and update
+// produce: check sets statusUpToDate or statusUpdateAvailable, and update sets
+// statusUpToDate or statusUpdated. statusError is reached only with v.err set
+// (counted as failed above), and statusInstalled is list-only, so neither needs
+// a status case here. summarizeResults is not used by other commands.
 func summarizeResults(results []updateResult, isCheck bool) string {
 	var updated, upToDate, available, failed int
 	for _, v := range results {

--- a/cmd/parallel.go
+++ b/cmd/parallel.go
@@ -44,6 +44,30 @@ func collectResults(ch <-chan updateResult, total int, onResult func(prefix stri
 	return result, results
 }
 
+// summarizeResults builds the one-line summary printed in --quiet mode from the
+// per-package results. isCheck selects the check wording (update-available)
+// over the update wording (updated). Failures are counted first because a
+// failed result may still carry a non-error status.
+func summarizeResults(results []updateResult, isCheck bool) string {
+	var updated, upToDate, available, failed int
+	for _, v := range results {
+		switch {
+		case v.err != nil:
+			failed++
+		case v.status == statusUpdateAvailable:
+			available++
+		case v.status == statusUpdated:
+			updated++
+		case v.status == statusUpToDate:
+			upToDate++
+		}
+	}
+	if isCheck {
+		return fmt.Sprintf("gup: %d update available, %d up-to-date, %d failed", available, upToDate, failed)
+	}
+	return fmt.Sprintf("gup: %d updated, %d up-to-date, %d failed", updated, upToDate, failed)
+}
+
 // executePackages runs worker over each package with signal-based cancellation
 // and a per-package timeout, then reports results via collectResults. It is the
 // shared operation engine used by update, check, import, and migrate. It returns

--- a/cmd/quiet_test.go
+++ b/cmd/quiet_test.go
@@ -1,0 +1,177 @@
+//nolint:paralleltest // these tests mutate global stub variables
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/gup/internal/goutil"
+)
+
+const (
+	quietImportUpdated  = "github.com/example/updated"
+	quietImportUpToDate = "github.com/example/uptodate"
+	quietNameUpdated    = "updated"
+	quietNameUpToDate   = "uptodate"
+)
+
+// quietMixedPkgs returns one package that needs an update and one that is
+// already up to date, so the quiet-mode filtering and summary can be exercised.
+func quietMixedPkgs() []goutil.Package {
+	return []goutil.Package{
+		{
+			Name:       quietNameUpdated,
+			ImportPath: quietImportUpdated,
+			ModulePath: quietImportUpdated,
+			Version:    &goutil.Version{Current: testVersionOne},
+			GoVersion:  &goutil.Version{Current: testGoVersion1224, Latest: testGoVersion1224},
+		},
+		{
+			Name:       quietNameUpToDate,
+			ImportPath: quietImportUpToDate,
+			ModulePath: quietImportUpToDate,
+			Version:    &goutil.Version{Current: testVersionNine},
+			GoVersion:  &goutil.Version{Current: testGoVersion1224, Latest: testGoVersion1224},
+		},
+	}
+}
+
+func Test_updateWithChannels_quiet(t *testing.T) {
+	origGetLatest := getLatestVer
+	origInstallLatest := installLatest
+	defer func() {
+		getLatestVer = origGetLatest
+		installLatest = origInstallLatest
+	}()
+	getLatestVer = func(string) (string, error) { return testVersionNine, nil }
+	installLatest = func(string) error { return nil }
+
+	pkgs := quietMixedPkgs()
+	channelMap := map[string]goutil.UpdateChannel{
+		quietNameUpdated:  goutil.UpdateChannelLatest,
+		quietNameUpToDate: goutil.UpdateChannelLatest,
+	}
+
+	var got int
+	out := captureCheckOutput(t, func() int {
+		got, _, _ = updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false, true)
+		return got
+	})
+	if got != 0 {
+		t.Fatalf("updateWithChannels() = %d, want 0", got)
+	}
+
+	if strings.Contains(out, "update binary under") {
+		t.Errorf("quiet mode should suppress the header, got:\n%s", out)
+	}
+	if strings.Contains(out, quietImportUpToDate) {
+		t.Errorf("quiet mode should not print up-to-date binaries, got:\n%s", out)
+	}
+	if !strings.Contains(out, quietImportUpdated) {
+		t.Errorf("quiet mode should print the updated binary, got:\n%s", out)
+	}
+	if !strings.Contains(out, "gup: 1 updated, 1 up-to-date, 0 failed") {
+		t.Errorf("quiet mode should print a summary, got:\n%s", out)
+	}
+}
+
+func Test_updateWithChannels_quiet_failed(t *testing.T) {
+	origGetLatest := getLatestVer
+	origInstallLatest := installLatest
+	defer func() {
+		getLatestVer = origGetLatest
+		installLatest = origInstallLatest
+	}()
+	getLatestVer = func(string) (string, error) { return testVersionNine, nil }
+	installLatest = func(string) error { return errors.New("install failed") }
+
+	pkgs := []goutil.Package{
+		{
+			Name:       quietNameUpdated,
+			ImportPath: quietImportUpdated,
+			ModulePath: quietImportUpdated,
+			Version:    &goutil.Version{Current: testVersionOne},
+			GoVersion:  &goutil.Version{Current: testGoVersion1224, Latest: testGoVersion1224},
+		},
+	}
+	channelMap := map[string]goutil.UpdateChannel{quietNameUpdated: goutil.UpdateChannelLatest}
+
+	var got int
+	out := captureCheckOutput(t, func() int {
+		got, _, _ = updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false, true)
+		return got
+	})
+	if got != 1 {
+		t.Fatalf("updateWithChannels() = %d, want 1 (one package failed)", got)
+	}
+	// The failure is counted in the summary and the error is still surfaced
+	// (captureCheckOutput merges STDOUT and STDERR).
+	if !strings.Contains(out, "gup: 0 updated, 0 up-to-date, 1 failed") {
+		t.Errorf("quiet summary should count the failure, got:\n%s", out)
+	}
+	if !strings.Contains(out, "install failed") {
+		t.Errorf("the failure cause should still be printed, got:\n%s", out)
+	}
+}
+
+func Test_doCheck_quiet(t *testing.T) {
+	origGetLatest := getLatestVer
+	defer func() { getLatestVer = origGetLatest }()
+	getLatestVer = func(string) (string, error) { return testVersionNine, nil }
+
+	pkgs := quietMixedPkgs()
+
+	var got int
+	out := captureCheckOutput(t, func() int {
+		got = doCheck(pkgs, 1, 0, true, true)
+		return got
+	})
+	if got != 0 {
+		t.Fatalf("doCheck() = %d, want 0", got)
+	}
+
+	if strings.Contains(out, "check binary under") {
+		t.Errorf("quiet mode should suppress the header, got:\n%s", out)
+	}
+	if strings.Contains(out, quietImportUpToDate) {
+		t.Errorf("quiet mode should not print up-to-date binaries, got:\n%s", out)
+	}
+	if !strings.Contains(out, quietImportUpdated) {
+		t.Errorf("quiet mode should print the update-available binary, got:\n%s", out)
+	}
+	// The "$ gup update <names>" hint is kept (it is the actionable output).
+	if !strings.Contains(out, "$ gup update "+quietNameUpdated) {
+		t.Errorf("quiet mode should keep the update hint, got:\n%s", out)
+	}
+	if !strings.Contains(out, "gup: 1 update available, 1 up-to-date, 0 failed") {
+		t.Errorf("quiet mode should print a summary, got:\n%s", out)
+	}
+}
+
+// Test_updateWithChannels_jsonQuiet verifies that --json takes precedence over
+// --quiet: STDOUT stays a valid JSON array with no summary line mixed in.
+func Test_updateWithChannels_jsonQuiet(t *testing.T) {
+	origGetLatest := getLatestVer
+	origInstallLatest := installLatest
+	defer func() {
+		getLatestVer = origGetLatest
+		installLatest = origInstallLatest
+	}()
+	getLatestVer = func(string) (string, error) { return testVersionNine, nil }
+	installLatest = func(string) error { return nil }
+
+	pkgs := quietMixedPkgs()
+	channelMap := map[string]goutil.UpdateChannel{
+		quietNameUpdated:  goutil.UpdateChannelLatest,
+		quietNameUpToDate: goutil.UpdateChannelLatest,
+	}
+
+	recs := readJSON(t, func() int {
+		got, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, true, true)
+		return got
+	})
+	if len(recs) != 2 {
+		t.Fatalf("expected 2 JSON records, got %d", len(recs))
+	}
+}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -68,6 +68,7 @@ using the current installed Go toolchain.`,
 	}
 	cmd.Flags().Bool("ignore-go-update", false, "Ignore updates to the Go toolchain")
 	cmd.Flags().Bool("json", false, "output result as machine-readable JSON")
+	cmd.Flags().BoolP("quiet", "q", false, "suppress up-to-date lines; show only updated/failed binaries plus a summary")
 	addTimeoutFlag(cmd)
 
 	return cmd
@@ -107,6 +108,12 @@ func gup(cmd *cobra.Command, args []string) int {
 	}
 
 	jsonOut, err := getFlagBool(cmd, "json")
+	if err != nil {
+		print.Err(err)
+		return 1
+	}
+
+	quiet, err := getFlagBool(cmd, "quiet")
 	if err != nil {
 		print.Err(err)
 		return 1
@@ -182,7 +189,7 @@ func gup(cmd *cobra.Command, args []string) int {
 		return 1
 	}
 
-	result, succeededPkgs, renamedPkgs := updateWithChannels(pkgs, dryRun, notify, cpus, ignoreGoUpdate, channelMap, timeout, jsonOut)
+	result, succeededPkgs, renamedPkgs := updateWithChannels(pkgs, dryRun, notify, cpus, ignoreGoUpdate, channelMap, timeout, jsonOut, quiet)
 
 	if !dryRun && (shouldPersistChannels(mainPkgNames, masterPkgNames, latestPkgNames) || len(renamedPkgs) > 0) {
 		merged := mergeConfigPackages(confPkgs, succeededPkgs, channelMap, renamedPkgs)
@@ -243,12 +250,12 @@ type updateResult struct {
 	status      string // machine-readable status for --json output (see jsonout.go)
 }
 
-func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus int, ignoreGoUpdate bool, channelMap map[string]goutil.UpdateChannel, timeout time.Duration, jsonOut bool) (exitCode int, succeeded []goutil.Package, renamed map[string]string) {
+func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus int, ignoreGoUpdate bool, channelMap map[string]goutil.UpdateChannel, timeout time.Duration, jsonOut, quiet bool) (exitCode int, succeeded []goutil.Package, renamed map[string]string) {
 	dryRunManager := goutil.NewGoPaths()
 
 	verCache := newLatestVerCache()
 
-	if !jsonOut {
+	if !jsonOut && !quiet {
 		print.Info("update binary under $GOPATH/bin or $GOBIN")
 	}
 	if dryRun {
@@ -372,6 +379,14 @@ func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus i
 	var onResult func(prefix string, v updateResult)
 	if !jsonOut {
 		onResult = func(prefix string, v updateResult) {
+			if quiet {
+				// In quiet mode show only binaries that were actually updated,
+				// without the [i/n] progress counter (which would be sparse).
+				if v.updated {
+					print.Info(fmt.Sprintf("%s (%s)", v.pkg.ImportPath, v.pkg.CurrentToLatestStr()))
+				}
+				return
+			}
 			print.Info(fmt.Sprintf("%s %s (%s)", prefix, v.pkg.ImportPath, v.pkg.CurrentToLatestStr()))
 		}
 	}
@@ -384,6 +399,8 @@ func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus i
 			print.Err(err)
 			result = 1
 		}
+	} else if quiet {
+		print.Info(summarizeResults(results, false))
 	}
 
 	desktopNotifyIfNeeded(result, notification)

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -865,7 +865,7 @@ func Test_update_modulePathChangedOnGetLatest(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinAir: goutil.UpdateChannelLatest}
-	if got, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false); got != 0 {
+	if got, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false, false); got != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", got)
 	}
 	if diff := cmp.Diff([]string{oldModule, newModule}, latestCalls); diff != "" {
@@ -934,7 +934,7 @@ func Test_update_modulePathChangedOnInstall(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinAir: goutil.UpdateChannelLatest}
-	if got, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false); got != 0 {
+	if got, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false, false); got != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", got)
 	}
 	if diff := cmp.Diff([]string{oldImport, newImport}, installCalls); diff != "" {
@@ -1390,7 +1390,7 @@ func Test_updateWithChannels_emptyImportPath(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false)
+	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false, false)
 	if result != 1 {
 		t.Fatalf("updateWithChannels() = %d, want 1 (empty import path)", result)
 	}
@@ -1412,7 +1412,7 @@ func Test_updateWithChannels_alreadyUpToDate(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, succeeded, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false)
+	result, succeeded, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
@@ -1469,7 +1469,7 @@ func Test_updateWithChannels_alreadyUpToDate_customGoBuildTag(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, succeeded, _ := updateWithChannels(pkgs, false, false, 1, false, channelMap, 0, false)
+	result, succeeded, _ := updateWithChannels(pkgs, false, false, 1, false, channelMap, 0, false, false)
 
 	if err := pw.Close(); err != nil {
 		t.Fatal(err)
@@ -1546,7 +1546,7 @@ func Test_updateWithChannels_customGoBuildTag_goVersionDiffColor(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, false, channelMap, 0, false)
+	result, _, _ := updateWithChannels(pkgs, false, false, 1, false, channelMap, 0, false, false)
 	if err := pw.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -1586,7 +1586,7 @@ func Test_updateWithChannels_emptyModulePath(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false)
+	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
@@ -1610,7 +1610,7 @@ func Test_updateWithChannels_getLatestVerError(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false)
+	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false, false)
 	if result != 1 {
 		t.Fatalf("updateWithChannels() = %d, want 1", result)
 	}
@@ -1643,7 +1643,7 @@ func Test_updateWithChannels_masterChannel(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelMaster}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false)
+	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
@@ -1694,7 +1694,7 @@ func Test_updateWithChannels_masterChannel_skipDecisionUsesChannel(t *testing.T)
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelMaster}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false)
+	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
@@ -1744,7 +1744,7 @@ func Test_updateWithChannels_masterChannel_latestMovedButMasterSame(t *testing.T
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelMaster}
-	result, succeeded, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false)
+	result, succeeded, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
@@ -1791,7 +1791,7 @@ func Test_updateWithChannels_mainChannel_skipDecisionUsesChannel(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelMain}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false)
+	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
@@ -1864,7 +1864,7 @@ func Test_updateWithChannels_notify(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(pkgs, false, true, 1, true, channelMap, 0, false)
+	result, _, _ := updateWithChannels(pkgs, false, true, 1, true, channelMap, 0, false, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() with notify = %d, want 0", result)
 	}
@@ -1892,7 +1892,7 @@ func Test_updateWithChannels_installError(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false)
+	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false, false)
 	if result != 1 {
 		t.Fatalf("updateWithChannels() = %d, want 1", result)
 	}
@@ -1933,7 +1933,7 @@ func Test_updateWithChannels_mainChannel(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelMain}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false)
+	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, 0, false, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}


### PR DESCRIPTION
## Summary

`gup check` and `gup update` print a line for every binary, which is noisy for users with many tools installed. This adds a `--quiet`/`-q` flag to both commands that suppresses the header and up-to-date lines, shows only the binaries that were updated (or have an update available) plus failures, and prints a one-line summary. Closes #290.

## Changes

- `cmd/update.go`: add the `--quiet`/`-q` flag, thread it through `updateWithChannels`, suppress the header and (in quiet mode) print only actually-updated binaries without the `[i/n]` counter, then print a summary.
- `cmd/check.go`: add the same flag, thread it through `doCheck`/`doCheckWith`, suppress the header and per-package lines in quiet mode while keeping the existing `$ gup update ...` hint, then print a summary.
- `cmd/parallel.go`: add `summarizeResults`, which counts updated/up-to-date/update-available/failed from the per-package results (failures counted first).
- `cmd/quiet_test.go`: new tests for update/check quiet output, the failure path, and `--json` precedence over `--quiet`; existing call sites in `update_test.go`/`check_test.go`/`jsonout_test.go`/`check_channel_test.go` follow the new signatures.
- `README.md`: add a "Quiet output for large tool sets" subsection.

## Design Decisions

The issue proposed several flags (`--quiet`, `--only-updates`, `--only-errors`, summary), but a single `--quiet` that shows updates/failures plus a summary covers the acceptance criteria, so the extra flags were dropped to keep the CLI surface small. The default (verbose) output and the JSON output are left byte-for-byte unchanged; the summary and line filtering only apply when `--quiet` is set and `--json` is not, so `--json` keeps precedence and STDOUT stays pure JSON. Errors are not suppressed because they already go to STDERR via `collectResults`, so they remain visible in quiet mode and `gup update -q 2>/dev/null` still prints only the successful updates and the summary. The `[i/n]` progress counter is omitted in quiet mode because filtering would make it sparse and confusing. `summarizeResults` counts a failed result first because a failed check can still carry a non-error status, which avoids double-counting.

## Limitations

The summary appears only in `--quiet` mode; the default output is intentionally not given a trailing summary to avoid changing existing behavior. `--only-updates`/`--only-errors` are not implemented; redirecting streams (`-q 2>/dev/null` for successes only, `-q >/dev/null` for failures only) covers those use cases without extra flags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--quiet` / `-q` to `gup check` and `gup update`, reducing output by hiding up-to-date entries, showing only update-available/updated results, failures, and a one-line summary.

* **Documentation**
  * Updated README with quiet-mode behavior details and example commands/output.

* **Tests**
  * Added quiet-mode coverage for both update and check flows, including handling of failures and ensuring JSON output still takes precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->