### PR TITLE
fix(goutil): classify binaries by main module, not a dotless-path heuristic

### DIFF
--- a/internal/goutil/goutil.go
+++ b/internal/goutil/goutil.go
@@ -518,16 +518,18 @@ func BinaryPathList(path string) ([]string, error) {
 	return list, nil
 }
 
-// IsStdCmd reports whether the given import path belongs to the Go standard library.
-// Standard library paths (e.g., "cmd/go", "cmd/gofmt") never contain a dot in
-// the first path segment, while third-party module paths always start with a
-// domain name that contains a dot (e.g., "github.com/user/repo").
-func IsStdCmd(importPath string) bool {
-	if importPath == "" {
-		return false
-	}
-	firstElem, _, _ := strings.Cut(importPath, "/")
-	return !strings.Contains(firstElem, ".")
+// isModuleBinary reports whether a binary was produced by
+// "go install <module>@<version>" and therefore records a main module path that
+// gup can manage. The argument is the main module path from the binary's build
+// info (debug/buildinfo's Main.Path), not its import path.
+//
+// Standard library and toolchain binaries (e.g. cmd/gofmt) record no main
+// module, as do GOPATH-mode or local "go build" binaries; those are skipped.
+// Using the recorded module instead of a "dotless first import-path element"
+// heuristic avoids misclassifying third-party binaries whose host has no dot,
+// such as localhost/... or an internal registry hostname (issue #299).
+func isModuleBinary(mainModulePath string) bool {
+	return mainModulePath != ""
 }
 
 // GetPackageInformation return golang package information including the latest
@@ -588,7 +590,7 @@ func collectPackageInformation(binList []string, goVer string) []Package {
 					print.Warn(err)
 					continue
 				}
-				if IsStdCmd(info.Path) {
+				if !isModuleBinary(info.Main.Path) {
 					continue
 				}
 				pkg := Package{

--- a/internal/goutil/goutil_test.go
+++ b/internal/goutil/goutil_test.go
@@ -640,33 +640,35 @@ func TestVersionUpToDate_golden(t *testing.T) {
 	}
 }
 
-func TestIsStdCmd(t *testing.T) {
+func Test_isModuleBinary(t *testing.T) {
+	// The argument is the binary's main module path (buildinfo Main.Path), not
+	// its import path.
 	for _, tt := range []struct {
-		name       string
-		importPath string
-		want       bool
+		name           string
+		mainModulePath string
+		want           bool
 	}{
-		{name: "cmd/go is standard", importPath: "cmd/go", want: true},
-		{name: "cmd/gofmt is standard", importPath: "cmd/gofmt", want: true},
-		{name: "cmd/vet is standard", importPath: "cmd/vet", want: true},
-		{name: "fmt is standard", importPath: "fmt", want: true},
-		{name: "github.com third-party", importPath: "github.com/nao1215/gup", want: false},
-		{name: "golang.org third-party", importPath: "golang.org/x/tools/cmd/goimports", want: false},
-		{name: "example.com third-party", importPath: "example.com/foo/bar", want: false},
-		{name: "empty string", importPath: "", want: false},
+		{name: "stdlib/toolchain has no main module", mainModulePath: "", want: false},
+		{name: "github.com third-party", mainModulePath: "github.com/nao1215/gup", want: true},
+		{name: "golang.org third-party", mainModulePath: "golang.org/x/tools", want: true},
+		// Dotless hosts are still third-party modules and must not be dropped
+		// as if they were the standard library (issue #299).
+		{name: "dotless localhost host", mainModulePath: "localhost/tool", want: true},
+		{name: "dotless internal registry host", mainModulePath: "registry/team/tool", want: true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			got := IsStdCmd(tt.importPath)
+			got := isModuleBinary(tt.mainModulePath)
 			if got != tt.want {
-				t.Errorf("IsStdCmd(%q) = %v, want %v", tt.importPath, got, tt.want)
+				t.Errorf("isModuleBinary(%q) = %v, want %v", tt.mainModulePath, got, tt.want)
 			}
 		})
 	}
 }
 
 func TestGetPackageInformation_std_cmd_filtered(t *testing.T) {
-	// Find gofmt binary, which is a standard library command (Path: "cmd/gofmt").
-	// GetPackageInformation should filter it out via IsStdCmd.
+	// Find gofmt binary, which is a standard library command (Path: "cmd/gofmt",
+	// no main module). GetPackageInformation should filter it out because it
+	// records no main module.
 	ctx := context.Background()
 	goroot, err := exec.CommandContext(ctx, "go", "env", "GOROOT").Output()
 	if err != nil {


### PR DESCRIPTION
## Summary

`IsStdCmd` treated any import path whose first element had no dot as the standard library, which misclassified third-party binaries from dotless hosts (e.g. `localhost/...` or an internal registry hostname) as stdlib, so `collectPackageInformation` silently dropped them from gup's view. This replaces that heuristic with a check on the binary's recorded main module, which standard library and toolchain binaries do not have. Closes #299.

## Changes

- `internal/goutil/goutil.go`: remove `IsStdCmd(importPath)` and add `isModuleBinary(mainModulePath)`; `collectPackageInformation` now skips a binary only when it records no main module (`info.Main.Path == ""`) instead of when its import path is dotless.
- `internal/goutil/goutil_test.go`: replace `TestIsStdCmd` with `Test_isModuleBinary` (covering dotless `localhost/tool` and `registry/team/tool` as kept third-party modules) and update the gofmt filter test's comment.

## Design Decisions

The dot heuristic was a proxy for "is this updatable", but the build info already answers that directly: a binary produced by `go install <module>@<version>` always records its main module path, while stdlib/toolchain binaries (and GOPATH-mode or local `go build` outputs) record none, so `info.Main.Path != ""` is the accurate, subprocess-free discriminator and matches how `collectPackageInformation` already fills `ModulePath` from `info.Main.Path`. `isModuleBinary` is unexported and its argument is documented as the module path (not the import path) to avoid reintroducing the import-path confusion. A `(devel)` local-module binary now stays visible and surfaces as a normal resolution error downstream rather than disappearing silently, which is the behavior the issue asked for. `IsStdCmd` was safe to delete because it lived in an internal package with that single caller.

## Limitations

Genuine standard library / toolchain binaries (no main module) are still skipped without a message, which is correct because gup cannot update them; the fix only stops third-party binaries from being dropped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed an exported utility function for command classification

* **Refactor**
  * Improved binary classification logic in package build information collection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->