### PR TITLE
fix(config): normalize "unknown" version to latest before persisting

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -171,9 +171,16 @@ func WriteConfFile(file io.Writer, pkgs []goutil.Package) error {
 	return nil
 }
 
+// normalizeConfVersion is the single place that decides which version string is
+// persisted to gup.json. Placeholder versions that are not real, installable
+// versions ("", "(devel)"/"devel", and "unknown") are normalized to "latest".
+// Persisting "unknown" would make versionUpToDate never match it and force a
+// needless reinstall on every run (see issue #300). All gup.json writes go
+// through WriteConfFile, which calls this, so the behavior can't diverge by
+// path.
 func normalizeConfVersion(version string) string {
 	version = strings.TrimSpace(version)
-	if version == "" || version == "(devel)" || version == "devel" {
+	if version == "" || version == "(devel)" || version == "devel" || version == "unknown" {
 		return "latest"
 	}
 	return version

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -104,6 +104,63 @@ func TestWriteConfFile(t *testing.T) {
 	}
 }
 
+const (
+	verLatest  = "latest"
+	verUnknown = "unknown"
+	verDevel   = "(devel)"
+	verSemver  = "v1.2.3"
+)
+
+func Test_normalizeConfVersion(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty becomes latest", in: "", want: verLatest},
+		{name: "whitespace becomes latest", in: "   ", want: verLatest},
+		{name: "(devel) becomes latest", in: verDevel, want: verLatest},
+		{name: "devel becomes latest", in: "devel", want: verLatest},
+		{name: "unknown becomes latest", in: verUnknown, want: verLatest},
+		{name: "unknown with whitespace becomes latest", in: "  unknown  ", want: verLatest},
+		{name: "latest stays latest", in: verLatest, want: verLatest},
+		{name: "real version is kept", in: verSemver, want: verSemver},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := normalizeConfVersion(tt.in); got != tt.want {
+				t.Errorf("normalizeConfVersion(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// Test_WriteConfFile_normalizesUnknownVersion verifies that "unknown" never
+// reaches gup.json: it is normalized to "latest" like "(devel)" (issue #300).
+func Test_WriteConfFile_normalizesUnknownVersion(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	pkgs := []goutil.Package{
+		{
+			Name:       "tool",
+			ImportPath: "example.com/tool",
+			Version:    &goutil.Version{Current: verUnknown},
+		},
+	}
+	if err := WriteConfFile(&buf, pkgs); err != nil {
+		t.Fatalf("WriteConfFile() error = %v", err)
+	}
+	if strings.Contains(buf.String(), verUnknown) {
+		t.Errorf("gup.json must not persist %q, got:\n%s", verUnknown, buf.String())
+	}
+	if !strings.Contains(buf.String(), `"version": "latest"`) {
+		t.Errorf("%q should be normalized to %q, got:\n%s", verUnknown, verLatest, buf.String())
+	}
+}
+
 func TestReadConfFile(t *testing.T) { //nolint:paralleltest // modifies xdg globals
 	cleanup := withTempXDG(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary

When `go version` or a binary's build info can't be read, gup stamps the version as `"unknown"`, and that placeholder could be written into `gup.json`. On the next run `versionUpToDate` never matches `"unknown"`, so the binary is reinstalled every time. This normalizes `"unknown"` to `"latest"` in the one place that already normalizes `(devel)`/`devel`, so it can never be persisted. Closes #300.

## Changes

- `internal/config/config.go`: add `"unknown"` to the placeholder set in `normalizeConfVersion` (now `""`/`(devel)`/`devel`/`unknown` -> `latest`) and document that it is the single normalization point for gup.json writes.
- `internal/config/config_test.go`: add `Test_normalizeConfVersion` (table covering the placeholders and a real version) and `Test_WriteConfFile_normalizesUnknownVersion` (an `unknown` Current is written as `"version": "latest"`).

## Design Decisions

Every gup.json write already routes through `WriteConfFile`, which calls `normalizeConfVersion` on each package's version, so adding `"unknown"` there is enough to guarantee it never reaches the file from any path (update persistence, `gup export`, or `gup export -o`); no extra wiring in `cmd` is needed. `persistedVersion`'s existing `latest != "unknown"` check is left in place because it is selection logic, not normalization: it prefers a known current version over an unknown latest, and removing it would discard the known version. `sanitizeConfigPackage` and `ReadConfFile` are likewise unchanged because any intermediate `"unknown"` is corrected by `WriteConfFile` at write time, so an existing `gup.json` containing `"unknown"` self-heals on the next write. The match is an exact string compare, so legitimate versions that merely contain the word (e.g. `v1.0.0-unknown`) are not affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration files now properly normalize unknown version identifiers to ensure consistency across application runs, preventing configuration mismatches.

* **Tests**
  * Added comprehensive test coverage for configuration version normalization and persistence, validating how different version formats are handled when saving configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->