### PR TITLE
feat(cmd): show concise actionable guidance when required args are missing

### DIFF
--- a/cmd/args.go
+++ b/cmd/args.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// argsGuidance builds a concise, actionable error for a missing-argument
+// situation: a one-line summary followed by one or two example invocations
+// (issue #324). It deliberately stays short and never dumps full help.
+func argsGuidance(summary string, examples ...string) error {
+	if len(examples) == 0 {
+		return fmt.Errorf("%s", summary)
+	}
+	return fmt.Errorf("%s\n\nExamples:\n  %s", summary, strings.Join(examples, "\n  "))
+}
+
+// requireMinArgs returns a cobra.PositionalArgs that requires at least minArgs
+// positional arguments and, when fewer are given, reports argsGuidance instead
+// of cobra's terse "requires at least N arg(s)" message.
+func requireMinArgs(minArgs int, summary string, examples ...string) cobra.PositionalArgs {
+	return func(_ *cobra.Command, args []string) error {
+		if len(args) < minArgs {
+			return argsGuidance(summary, examples...)
+		}
+		return nil
+	}
+}

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -41,7 +41,10 @@ Use --install to write bash/fish/zsh completion files to the user shell config p
 				return nil
 			}
 			if len(args) == 0 {
-				return fmt.Errorf("specify shell (bash|fish|zsh|powershell) or use --install to write bash/fish/zsh completion files")
+				return argsGuidance(
+					"requires a shell name (bash, fish, zsh, powershell) or --install",
+					"gup completion bash",
+					"gup completion --install")
 			}
 			switch args[0] {
 			case shellBash:

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"io"
 	"strings"
 	"testing"
 )
@@ -21,8 +22,21 @@ func TestCompletion_NoArgsRequiresExplicitMode(t *testing.T) {
 
 	cmd := newCompletionCmd()
 	cmd.SetArgs([]string{})
-	if err := cmd.Execute(); err == nil {
-		t.Fatal("completion without args should require --install")
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("completion without args should require a shell name or --install")
+	}
+	got := err.Error()
+	for _, want := range []string{"requires a shell name", "gup completion bash", "gup completion --install"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("error should contain %q, got:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "Usage:") {
+		t.Errorf("error should be concise, not full help, got:\n%s", got)
 	}
 }
 

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -54,7 +54,9 @@ migrate is add-only: it never deletes files in AFTER_PATH, and by default it
 skips binaries that already exist there. Use --force to reinstall over them.
 
 If BINARY arguments are given, only those binaries are migrated.`,
-		Args:              cobra.MinimumNArgs(migrateMinArgs),
+		Args: requireMinArgs(migrateMinArgs,
+			"requires BEFORE_PATH and AFTER_PATH",
+			"gup migrate /old/gobin /new/gobin"),
 		ValidArgsFunction: cobra.NoFileCompletions,
 		Run: func(cmd *cobra.Command, args []string) {
 			OsExit(runMigrate(cmd, args))

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,6 +14,27 @@ import (
 	"github.com/nao1215/gup/internal/goutil"
 	"github.com/nao1215/gup/internal/print"
 )
+
+func Test_migrate_missingArgs(t *testing.T) {
+	cmd := newMigrateCmd()
+	cmd.SetArgs([]string{"only-one-path"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("migrate with fewer than two paths should fail")
+	}
+	got := err.Error()
+	for _, want := range []string{"requires BEFORE_PATH and AFTER_PATH", "gup migrate /old/gobin /new/gobin"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("error should contain %q, got:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "Usage:") {
+		t.Errorf("error should be concise, not full help, got:\n%s", got)
+	}
+}
 
 const (
 	testImportPathXY   = "github.com/x/y"

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -21,7 +21,10 @@ func newRemoveCmd() *cobra.Command {
 		Long: `Remove command in $GOPATH/bin or $GOBIN.
 If you want to specify multiple binaries at once, separate them with space.
 [e.g.] gup remove a_cmd b_cmd c_cmd`,
-		Args:              cobra.MinimumNArgs(1),
+		Args: requireMinArgs(1,
+			"requires at least one binary name",
+			"gup remove gopls",
+			"gup remove --force air"),
 		ValidArgsFunction: completePathBinaries,
 		Run: func(cmd *cobra.Command, args []string) {
 			OsExit(remove(cmd, args))
@@ -33,11 +36,6 @@ If you want to specify multiple binaries at once, separate them with space.
 }
 
 func remove(cmd *cobra.Command, args []string) int {
-	if len(args) == 0 {
-		print.Err("no command name specified")
-		return 1
-	}
-
 	force, err := getFlagBool(cmd, "force")
 	if err != nil {
 		print.Err(err)

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -178,9 +178,22 @@ func Test_remove_flagError(t *testing.T) {
 func Test_remove_noArgs(t *testing.T) {
 	t.Parallel()
 	cmd := newRemoveCmd()
-	got := remove(cmd, []string{})
-	if got != 1 {
-		t.Errorf("remove() = %v, want 1 for no args", got)
+	cmd.SetArgs([]string{})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("remove without args should fail")
+	}
+	got := err.Error()
+	for _, want := range []string{"requires at least one binary name", "gup remove gopls"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("error should contain %q, got:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "Usage:") {
+		t.Errorf("error should be concise, not full help, got:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

When a required argument is missing, gup surfaced cobra's terse default (`requires at least 1 arg(s)`) or a similarly bare error, which does not help a new or infrequent user recover. This adds short, actionable guidance — what is missing plus one or two realistic examples — for the commands that take required arguments, without dumping full help or building an error framework. Closes #324.

## Changes

- `cmd/args.go` (new): add `argsGuidance(summary, examples...)` and `requireMinArgs(minArgs, summary, examples...)`, a `cobra.PositionalArgs` validator that reports the guidance instead of cobra's default message.
- `cmd/remove.go`: use `requireMinArgs(1, "requires at least one binary name", ...)` and drop the now-unreachable in-body `len(args) == 0` check.
- `cmd/migrate.go`: use `requireMinArgs(migrateMinArgs, "requires BEFORE_PATH and AFTER_PATH", ...)`.
- `cmd/completion.go`: replace the bare "specify shell..." error with `argsGuidance("requires a shell name (bash, fish, zsh, powershell) or --install", ...)`.
- `cmd/{remove,completion,migrate}_test.go`: assert the guidance includes the summary and an example and is not full help (`Usage:`).

## Design Decisions

The guidance is just two small helpers rather than an error type or framework: `requireMinArgs` covers the positional-args commands (`remove`, `migrate`), while `completion` calls `argsGuidance` directly from `RunE` because its required input can also be satisfied by the `--install` flag, so it can't be enforced purely as a positional-args count. Concise output is already guaranteed by the root command's `SilenceUsage`/`SilenceErrors`, so the error flows through `main.go`'s `print.Err` as `gup:ERROR: <summary>` followed by the examples, with no usage block. Only `remove`, `migrate`, and `completion` require arguments; the other subcommands use `cobra.NoArgs` or accept optional args, so they need no change. The wording follows the issue's examples and the clig.dev convention of short recovery guidance.

## Limitations

This changes only human-facing stderr wording, not exit codes or command structure; a script that parsed the old `requires at least 1 arg(s)` / `specify shell...` text would need updating, which is acceptable for guidance meant for humans. The `completion` invalid-shell case (e.g. an unknown shell name) is still handled by cobra's `OnlyValidArgs` and is out of scope, since that is an invalid argument rather than a missing one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved command-line argument validation with enhanced error messages that provide clearer guidance and example invocations for the `completion`, `migrate`, and `remove` commands when required arguments are missing, replacing generic validation errors with concise, actionable feedback to help users quickly understand how to use each command correctly without full help text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->