### PR TITLE
feat(cmd): add top-level --version flag and help examples

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -17,6 +17,8 @@ func newCheckCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "check",
 		Short: "Check the latest version of the binary installed by 'go install'",
+		Example: `  gup check
+  gup check --quiet`,
 		Long: `Check the latest version and build toolchain of the binary installed by 'go install'
 
 check subcommand checks if the binary is the latest version

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -22,6 +22,8 @@ func newCompletionCmd() *cobra.Command {
 		Long: `Generate shell completions (bash, fish, zsh, powershell) for the gup command.
 With a shell name as argument, output completion for the shell to standard output.
 Use --install to write bash/fish/zsh completion files to the user shell config paths.`,
+		Example: `  gup completion bash
+  gup completion --install`,
 		Args:      cobra.MatchAll(cobra.MaximumNArgs(1), cobra.OnlyValidArgs),
 		ValidArgs: []string{shellBash, "fish", "zsh", "powershell"},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -17,6 +17,8 @@ Use export/import if you want to install the same Go binaries
 across multiple systems. This sub-command writes gup.json
 (default: $XDG_CONFIG_HOME/gup/gup.json), and the target system can
 apply it with 'gup import'.`,
+		Example: `  gup export
+  gup export --output > gup.json`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -28,6 +28,8 @@ across multiple systems.
 First, run 'gup export' on the source environment and copy gup.json.
 Then run 'gup import' on the target environment to install the
 versions recorded in that gup.json.`,
+		Example: `  gup import
+  gup import --file gup.json`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -12,9 +12,11 @@ import (
 
 func newListCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:               "list",
-		Short:             "List command names with package path and version under $GOPATH/bin or $GOBIN",
-		Long:              `List command names with package path and version under $GOPATH/bin or $GOBIN`,
+		Use:   "list",
+		Short: "List command names with package path and version under $GOPATH/bin or $GOBIN",
+		Long:  `List command names with package path and version under $GOPATH/bin or $GOBIN`,
+		Example: `  gup list
+  gup list --json`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -54,6 +54,8 @@ migrate is add-only: it never deletes files in AFTER_PATH, and by default it
 skips binaries that already exist there. Use --force to reinstall over them.
 
 If BINARY arguments are given, only those binaries are migrated.`,
+		Example: `  gup migrate /old/gobin /new/gobin
+  gup migrate /old/gobin /new/gobin gopls`,
 		Args: requireMinArgs(migrateMinArgs,
 			"requires BEFORE_PATH and AFTER_PATH",
 			"gup migrate /old/gobin /new/gobin"),

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -21,6 +21,8 @@ func newRemoveCmd() *cobra.Command {
 		Long: `Remove command in $GOPATH/bin or $GOBIN.
 If you want to specify multiple binaries at once, separate them with space.
 [e.g.] gup remove a_cmd b_cmd c_cmd`,
+		Example: `  gup remove gopls
+  gup remove --force air`,
 		Args: requireMinArgs(1,
 			"requires at least one binary name",
 			"gup remove gopls",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"strconv"
 
+	"github.com/nao1215/gup/internal/cmdinfo"
 	"github.com/nao1215/gup/internal/completion"
 	"github.com/spf13/cobra"
 )
@@ -31,6 +32,9 @@ oh-my-zsh alias is disabled (e.g. $ \gup update).
 If you find gup useful, please consider sponsoring the project:
   https://github.com/sponsors/nao1215
 `,
+		Example: `  gup update
+  gup update --dry-run
+  gup list`,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			noColor, err := getFlagBool(cmd, noColorFlagName)
 			if err != nil {
@@ -44,6 +48,13 @@ If you find gup useful, please consider sponsoring the project:
 	cmd.SilenceUsage = true
 	cmd.SilenceErrors = true
 	addNoColorFlag(cmd)
+
+	// Support the standard top-level "gup --version" / "gup -V" while keeping
+	// the "gup version" subcommand. The template reuses cmdinfo.GetVersion() so
+	// both paths print identical output (issue #325).
+	cmd.Version = cmdinfo.GetVersion()
+	cmd.SetVersionTemplate("{{.Version}}\n")
+	cmd.Flags().BoolP("version", "V", false, "version for gup")
 
 	cmd.AddCommand(newCheckCmd())
 	cmd.AddCommand(newCompletionCmd())

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -342,6 +342,46 @@ func TestExecute_Version(t *testing.T) {
 	}
 }
 
+// TestExecute_RootVersionFlag verifies the top-level --version / -V flag prints
+// the same version information as the "gup version" subcommand (issue #325).
+func TestExecute_RootVersionFlag(t *testing.T) {
+	for _, arg := range []string{"--version", "-V"} {
+		t.Run(arg, func(t *testing.T) {
+			b := bytes.NewBufferString("")
+			c := newRootCmd()
+			c.SetOut(b)
+			c.SetArgs([]string{arg})
+			if err := c.Execute(); err != nil {
+				t.Fatalf("Execute(%s) error = %v", arg, err)
+			}
+			got := strings.TrimRight(b.String(), "\n")
+			if got != cmdinfo.GetVersion() {
+				t.Errorf("gup %s = %q, want %q", arg, got, cmdinfo.GetVersion())
+			}
+		})
+	}
+}
+
+// TestSubcommandExamples verifies the root command and every subcommand ship
+// copy-paste-friendly Example help mentioning the command (issue #326).
+func TestSubcommandExamples(t *testing.T) {
+	root := newRootCmd()
+	if root.Example == "" {
+		t.Error("root command should define an Example")
+	}
+
+	subs := root.Commands()
+	if len(subs) == 0 {
+		t.Fatal("expected the root command to have subcommands")
+	}
+	for _, sub := range subs {
+		want := "gup " + sub.Name()
+		if !strings.Contains(sub.Example, want) {
+			t.Errorf("%q Example = %q, want it to contain %q", sub.Name(), sub.Example, want)
+		}
+	}
+}
+
 func TestExecute_List(t *testing.T) {
 	setupXDGBase(t)
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -33,6 +33,9 @@ func newUpdateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update binaries installed by 'go install'",
+		Example: `  gup update
+  gup update --dry-run
+  gup update --exclude foo,bar`,
 		Long: `Update binaries installed by 'go install'
 
 If you execute '$ gup update', gup gets the package path of all commands

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -10,6 +10,7 @@ func newVersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:               "version",
 		Short:             "Show " + cmdinfo.Name + " command version information",
+		Example:           "  gup version",
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
## Summary

Add the standard top-level `gup --version` / `gup -V` flag while keeping the `gup version` subcommand, and add short practical examples to the root command and major subcommand help. Both are small CLI UX improvements that touch the cobra command definitions. Closes #325. Closes #326.

## Changes

- `cmd/root.go`: set `cmd.Version = cmdinfo.GetVersion()` with a `{{.Version}}` template so `--version`/`-V` print the same string as `gup version`; register `-V` and add a root `Example`.
- `cmd/{check,update,list,export,import,remove,migrate,completion,version}.go`: add a concise `Example` (real flags only); `man` and `bug-report` keep their existing examples.
- `cmd/root_test.go`: add `TestExecute_RootVersionFlag` (`--version`/`-V` match `cmdinfo.GetVersion()`) and `TestSubcommandExamples` (root and every subcommand ship a `gup <name>` example).

## Design Decisions

For #325 the version string is sourced from the existing `cmdinfo.GetVersion()` and rendered via `SetVersionTemplate`, so `gup --version`, `gup -V`, and `gup version` produce byte-identical output without adding a second format or a new cmdinfo getter. Pre-registering the `version` bool flag with the `-V` shorthand makes cobra reuse it instead of auto-adding `--version`/`-v`, and because cobra handles the version flag before the runnable/PersistentPreRun checks, it works even though the root command is not runnable. The flag is a local (non-persistent) root flag, so it does not leak into subcommand "Global Flags" and the `bug-report --help` golden stays unchanged. For #326 each example is a single short, copy-paste-friendly line per command rather than embedded documentation, so help stays compact and does not duplicate the README.

## Limitations

The two issues are combined in one PR because both are help/UX changes centered on `cmd/root.go`; they are otherwise independent. `bug-report` keeps its existing 3-space example indent (the new examples use 2 spaces); aligning all of them is out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `gup --version` and `gup -V` flags to display version information directly from the command line.

* **Documentation**
  * Updated help text with comprehensive usage examples for all commands (check, completion, export, import, list, migrate, remove, update, version).

* **Tests**
  * Added tests to validate version flag functionality and command example documentation completeness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->