### PR TITLE
test(cmd): make config_file rename injectable and cover backup-swap worst case

### DIFF
--- a/cmd/config_file.go
+++ b/cmd/config_file.go
@@ -14,6 +14,8 @@ import (
 
 var writeConfFile = config.WriteConfFile //nolint:gochecknoglobals // swapped in tests
 
+var renameFunc = os.Rename //nolint:gochecknoglobals // swapped in tests to simulate rename failures
+
 func writeConfigFile(path string, pkgs []goutil.Package) (err error) {
 	path = filepath.Clean(path)
 	dir := filepath.Dir(path)
@@ -57,7 +59,7 @@ func writeConfigFile(path string, pkgs []goutil.Package) (err error) {
 }
 
 func renameWithReplace(src, dst string) error {
-	if err := os.Rename(src, dst); err != nil {
+	if err := renameFunc(src, dst); err != nil {
 		// Windows cannot overwrite an existing file with os.Rename.
 		// Retry via destination backup swap when the destination likely exists.
 		if !shouldRetryRenameWithReplace(err, dst) {
@@ -74,11 +76,11 @@ func renameWithBackupSwap(src, dst string) error {
 		return err
 	}
 
-	if err = os.Rename(dst, backupPath); err != nil {
+	if err = renameFunc(dst, backupPath); err != nil {
 		return err
 	}
-	if err = os.Rename(src, dst); err != nil {
-		if restoreErr := os.Rename(backupPath, dst); restoreErr != nil {
+	if err = renameFunc(src, dst); err != nil {
+		if restoreErr := renameFunc(backupPath, dst); restoreErr != nil {
 			return errors.Join(err, fmt.Errorf("can't restore original file %s after failed update: %w", dst, restoreErr))
 		}
 		return err

--- a/cmd/config_file_test.go
+++ b/cmd/config_file_test.go
@@ -1,10 +1,14 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
+
+	"github.com/nao1215/gup/internal/goutil"
 )
 
 func TestRenameWithBackupSwap_Success(t *testing.T) {
@@ -98,5 +102,151 @@ func Test_renameWithReplace_errorWhenSrcMissing(t *testing.T) {
 
 	if err := renameWithReplace(src, dst); err == nil {
 		t.Fatal("renameWithReplace() should return error when source file does not exist")
+	}
+}
+
+func Test_writeConfigFile_success(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gup.json")
+
+	pkgs := []goutil.Package{
+		{
+			Name:       "air",
+			ImportPath: "github.com/cosmtrek/air/cmd/air",
+			Version:    &goutil.Version{Current: "v1.2.3"},
+		},
+	}
+
+	if err := writeConfigFile(path, pkgs); err != nil {
+		t.Fatalf("writeConfigFile() error = %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("config file should exist: %v", err)
+	}
+	if !strings.Contains(string(got), "github.com/cosmtrek/air/cmd/air") {
+		t.Fatalf("config file content = %q, want it to contain the import path", string(got))
+	}
+
+	assertNoTempFiles(t, dir, filepath.Base(path))
+}
+
+func Test_writeConfigFile_idempotentOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gup.json")
+
+	pkgs := []goutil.Package{
+		{
+			Name:       "air",
+			ImportPath: "github.com/cosmtrek/air/cmd/air",
+			Version:    &goutil.Version{Current: "v1.2.3"},
+		},
+	}
+
+	if err := writeConfigFile(path, pkgs); err != nil {
+		t.Fatalf("first writeConfigFile() error = %v", err)
+	}
+	first, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writeConfigFile(path, pkgs); err != nil {
+		t.Fatalf("second writeConfigFile() error = %v", err)
+	}
+	second, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(first) != string(second) {
+		t.Fatalf("overwrite changed content: first = %q, second = %q", string(first), string(second))
+	}
+
+	assertNoTempFiles(t, dir, filepath.Base(path))
+}
+
+func Test_renameWithBackupSwap_restoreFailure(t *testing.T) {
+	origRename := renameFunc
+	t.Cleanup(func() { renameFunc = origRename })
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "gup.json.tmp")
+	dst := filepath.Join(dir, "gup.json")
+
+	if err := os.WriteFile(src, []byte("new"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	updateErr := errors.New("forced update rename failure")
+	restoreErr := errors.New("forced restore rename failure")
+
+	// First call (dst -> backup) succeeds, second (src -> dst) fails,
+	// third (backup -> dst restore) also fails: the config-loss worst case.
+	calls := 0
+	renameFunc = func(oldpath, newpath string) error {
+		calls++
+		switch calls {
+		case 1:
+			return origRename(oldpath, newpath)
+		case 2:
+			return updateErr
+		default:
+			return restoreErr
+		}
+	}
+
+	err := renameWithBackupSwap(src, dst)
+	if err == nil {
+		t.Fatal("renameWithBackupSwap() should return error on restore failure")
+	}
+	if !errors.Is(err, updateErr) {
+		t.Fatalf("error = %v, want it to wrap the update error", err)
+	}
+	if !errors.Is(err, restoreErr) {
+		t.Fatalf("error = %v, want it to wrap the restore error", err)
+	}
+}
+
+func Test_writeConfigFile_noStrayFilesOnRenameFailure(t *testing.T) {
+	origRename := renameFunc
+	t.Cleanup(func() { renameFunc = origRename })
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gup.json")
+
+	renameFunc = func(_, _ string) error {
+		return errors.New("forced rename failure")
+	}
+
+	err := writeConfigFile(path, []goutil.Package{{Name: "dummy"}})
+	if err == nil {
+		t.Fatal("writeConfigFile() should return error when rename fails")
+	}
+
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("config file should not exist after failed write, stat err = %v", statErr)
+	}
+	assertNoTempFiles(t, dir, filepath.Base(path))
+}
+
+// assertNoTempFiles fails if any leftover temporary or backup files matching the
+// config file's temp/backup naming pattern remain in dir.
+func assertNoTempFiles(t *testing.T, dir, base string) {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("failed to read dir: %v", err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.HasPrefix(name, base+".tmp-") || strings.HasPrefix(name, base+".bak-") {
+			t.Fatalf("stray temp/backup file left behind: %s", name)
+		}
 	}
 }

--- a/cmd/config_file_test.go
+++ b/cmd/config_file_test.go
@@ -11,6 +11,11 @@ import (
 	"github.com/nao1215/gup/internal/goutil"
 )
 
+// oldImport is the import path used by config-file tests that exercise the
+// air package rename. It is defined at package level so the literal is not
+// duplicated across test cases (goconst).
+const oldImport = "github.com/cosmtrek/air/cmd/air"
+
 func TestRenameWithBackupSwap_Success(t *testing.T) {
 	t.Parallel()
 
@@ -106,13 +111,15 @@ func Test_renameWithReplace_errorWhenSrcMissing(t *testing.T) {
 }
 
 func Test_writeConfigFile_success(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	path := filepath.Join(dir, "gup.json")
 
 	pkgs := []goutil.Package{
 		{
 			Name:       "air",
-			ImportPath: "github.com/cosmtrek/air/cmd/air",
+			ImportPath: oldImport,
 			Version:    &goutil.Version{Current: "v1.2.3"},
 		},
 	}
@@ -125,7 +132,7 @@ func Test_writeConfigFile_success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("config file should exist: %v", err)
 	}
-	if !strings.Contains(string(got), "github.com/cosmtrek/air/cmd/air") {
+	if !strings.Contains(string(got), oldImport) {
 		t.Fatalf("config file content = %q, want it to contain the import path", string(got))
 	}
 
@@ -133,13 +140,15 @@ func Test_writeConfigFile_success(t *testing.T) {
 }
 
 func Test_writeConfigFile_idempotentOverwrite(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	path := filepath.Join(dir, "gup.json")
 
 	pkgs := []goutil.Package{
 		{
 			Name:       "air",
-			ImportPath: "github.com/cosmtrek/air/cmd/air",
+			ImportPath: oldImport,
 			Version:    &goutil.Version{Current: "v1.2.3"},
 		},
 	}
@@ -167,6 +176,7 @@ func Test_writeConfigFile_idempotentOverwrite(t *testing.T) {
 	assertNoTempFiles(t, dir, filepath.Base(path))
 }
 
+//nolint:paralleltest // mutates package-level renameFunc
 func Test_renameWithBackupSwap_restoreFailure(t *testing.T) {
 	origRename := renameFunc
 	t.Cleanup(func() { renameFunc = origRename })
@@ -212,6 +222,7 @@ func Test_renameWithBackupSwap_restoreFailure(t *testing.T) {
 	}
 }
 
+//nolint:paralleltest // mutates package-level renameFunc
 func Test_writeConfigFile_noStrayFilesOnRenameFailure(t *testing.T) {
 	origRename := renameFunc
 	t.Cleanup(func() { renameFunc = origRename })


### PR DESCRIPTION
## Overview

Addresses #302. `cmd/config_file.go` previously called `os.Rename` directly, leaving the most dangerous failure mode of the config write untestable on Linux.

## Changes

- Introduce a package-level `var renameFunc = os.Rename` and route every rename in `writeConfigFile` / `renameWithReplace` / `renameWithBackupSwap` through it, so tests can inject rename failures without OS-specific tricks. No behavior change.
- Add tests covering:
  - the full success path of `writeConfigFile` (Sync/Close/rename succeed),
  - idempotent overwrite,
  - the `renameWithBackupSwap` worst case (update rename fails **and** restore-from-backup fails → `errors.Join`), which risks losing the user's config,
  - no stray temp/backup files remain after a failed write.

## Verification

- `gofmt -l .` clean
- `go vet ./...` clean
- `go test -race ./cmd/...` and `go test ./...` all green

Closes #302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for config file update operations, including edge cases such as rename failures and idempotent overwrites to improve reliability and ensure configuration handling behaves correctly under various conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->