### PR TITLE
feat(cmd): harden gup remove confirmation and path-traversal guard

### DIFF
--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -55,6 +55,9 @@ func remove(cmd *cobra.Command, args []string) int {
 
 const goosWindows = "windows"
 
+// exeSuffix is the Windows executable file extension.
+const exeSuffix = ".exe"
+
 // GOOS is wrapper for runtime.GOOS variable. It's for unit test.
 var GOOS = runtime.GOOS //nolint:gochecknoglobals
 
@@ -121,7 +124,7 @@ func normalizeExecSuffix(goos, goExe string) string {
 
 	goExe = strings.TrimSpace(goExe)
 	if goExe == "" {
-		return ".exe"
+		return exeSuffix
 	}
 	return goExe
 }

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -58,6 +58,16 @@ const goosWindows = "windows"
 // GOOS is wrapper for runtime.GOOS variable. It's for unit test.
 var GOOS = runtime.GOOS //nolint:gochecknoglobals
 
+// stdinIsTerminal reports whether os.Stdin is connected to a terminal (TTY).
+// It is a package-level variable so that it can be overridden in unit tests.
+var stdinIsTerminal = func() bool { //nolint:gochecknoglobals
+	info, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (info.Mode() & os.ModeCharDevice) != 0
+}
+
 func removeLoop(gobin string, force bool, target []string) int {
 	result := 0
 	for _, v := range target {
@@ -82,6 +92,11 @@ func removeLoop(gobin string, force bool, target []string) int {
 			continue
 		}
 		if !force {
+			if !stdinIsTerminal() {
+				print.Err(fmt.Errorf("gup remove requires confirmation, but stdin is not a TTY.\nUse --force to skip confirmation"))
+				result = 1
+				continue
+			}
 			if !print.Question(fmt.Sprintf("remove %s?", target)) {
 				print.Info("cancel removal " + target)
 				continue

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -14,6 +14,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	whitespaceOnly = "   "
+	goplsExe       = "gopls.exe"
+	dotExe         = ".exe"
+	abcLiteral     = "abc"
+)
+
 func Test_removeLoop(t *testing.T) {
 	type args struct {
 		gobin  string
@@ -136,7 +143,7 @@ func Test_removeLoop(t *testing.T) {
 			if runtime.GOOS != goosWindows && tt.name == "windows environment and suffix is mismatch" {
 				GOOS = goosWindows
 				defer func() { GOOS = runtime.GOOS }()
-				t.Setenv("GOEXE", ".exe")
+				t.Setenv("GOEXE", dotExe)
 			}
 
 			if got := removeLoop(tt.args.gobin, tt.args.force, tt.args.target); got != tt.want {
@@ -237,7 +244,7 @@ func Test_removeLoop_windowsSuffixCaseInsensitive(t *testing.T) {
 	origGOOS := GOOS
 	GOOS = goosWindows
 	t.Cleanup(func() { GOOS = origGOOS })
-	t.Setenv("GOEXE", ".exe")
+	t.Setenv("GOEXE", dotExe)
 
 	gobin := t.TempDir()
 	binaryPath := filepath.Join(gobin, "gopls.EXE")
@@ -284,7 +291,7 @@ func Test_isSafeBinaryName(t *testing.T) {
 		{name: "simple name", input: testBinMytool, want: true},
 		{name: "with extension", input: testBinMytoolExe, want: true},
 		{name: "empty", input: "", want: false},
-		{name: "whitespace only", input: "   ", want: false},
+		{name: "whitespace only", input: whitespaceOnly, want: false},
 		{name: "leading and trailing whitespace", input: " mytool ", want: false},
 		{name: "absolute path", input: "/usr/bin/tool", want: false},
 		{name: "forward slash", input: "sub/tool", want: false},
@@ -305,6 +312,7 @@ func Test_isSafeBinaryName(t *testing.T) {
 	}
 }
 
+//nolint:paralleltest // mutates package-level stdinIsTerminal
 func Test_removeLoop_nonTTYWithoutForceFailsFast(t *testing.T) {
 	// Not parallel: this test mutates the package-level stdinIsTerminal,
 	// which is also mutated by Test_removeLoop.
@@ -337,6 +345,7 @@ func Test_removeLoop_nonTTYWithoutForceFailsFast(t *testing.T) {
 	}
 }
 
+//nolint:paralleltest // mutates package-level stdinIsTerminal
 func Test_removeLoop_nonTTYWithForceStillRemoves(t *testing.T) {
 	// Not parallel: this test mutates the package-level stdinIsTerminal,
 	// which is also mutated by Test_removeLoop.
@@ -388,29 +397,29 @@ func Test_isSafeBinaryName_propertyStaysInGobin(t *testing.T) {
 
 	// Adversarial inputs that quick may not easily generate.
 	adversarial := []string{
-		"",                // empty
-		"   ",             // whitespace only
-		" tool ",          // surrounding whitespace
-		".",               // current dir
-		"..",              // parent dir
-		"../escape",       // parent traversal
-		"../../escape",    // deeper traversal
-		"/abs/path",       // absolute
-		`C:\Windows\tool`, // windows absolute
-		"C:tool",          // windows drive-relative (colon)
-		"sub/tool",        // forward slash
-		`sub\tool`,        // backslash
-		"tool\x00.exe",    // embedded NUL
-		"tool\nname",      // embedded newline (control char)
-		"tool\tname",      // embedded tab (control char)
-		"a",               // exact-length minimal name (len 1)
-		"e",               // len(s) shorter than typical suffix
-		"gopls",           // plain valid name
-		"gopls.exe",       // valid name with extension
-		"ｇｏｐｌｓ",           // unicode full-width look-alike
-		"tool/../escape",  // traversal hidden mid-string
-		"./tool",          // dot-slash prefix
-		"‮" + "exe.sh",    // right-to-left override look-alike
+		"",                  // empty
+		whitespaceOnly,      // whitespace only
+		" tool ",            // surrounding whitespace
+		".",                 // current dir
+		"..",                // parent dir
+		"../escape",         // parent traversal
+		"../../escape",      // deeper traversal
+		"/abs/path",         // absolute
+		`C:\Windows\tool`,   // windows absolute
+		"C:tool",            // windows drive-relative (colon)
+		"sub/tool",          // forward slash
+		`sub\tool`,          // backslash
+		"tool\x00.exe",      // embedded NUL
+		"tool\nname",        // embedded newline (control char)
+		"tool\tname",        // embedded tab (control char)
+		"a",                 // exact-length minimal name (len 1)
+		"e",                 // len(s) shorter than typical suffix
+		"gopls",             // plain valid name
+		goplsExe,            // valid name with extension
+		"ｇｏｐｌｓ",             // unicode full-width look-alike
+		"tool/../escape",    // traversal hidden mid-string
+		"./tool",            // dot-slash prefix
+		"\u202e" + "exe.sh", // right-to-left override look-alike
 	}
 	for _, s := range adversarial {
 		if !invariant(s) {
@@ -427,19 +436,19 @@ func Test_hasSuffixFold(t *testing.T) {
 		suffix string
 		want   bool
 	}{
-		{name: "exact match same case", s: ".exe", suffix: ".exe", want: true},
-		{name: "case-insensitive match", s: "gopls.EXE", suffix: ".exe", want: true},
-		{name: "case-insensitive match reversed", s: "gopls.exe", suffix: ".EXE", want: true},
-		{name: "suffix present lowercase", s: "tool.exe", suffix: ".exe", want: true},
-		{name: "no suffix match", s: "tool.bin", suffix: ".exe", want: false},
-		{name: "s shorter than suffix", s: "ex", suffix: ".exe", want: false},
-		{name: "s one char shorter than suffix", s: ".ex", suffix: ".exe", want: false},
+		{name: "exact match same case", s: dotExe, suffix: dotExe, want: true},
+		{name: "case-insensitive match", s: "gopls.EXE", suffix: dotExe, want: true},
+		{name: "case-insensitive match reversed", s: goplsExe, suffix: ".EXE", want: true},
+		{name: "suffix present lowercase", s: "tool.exe", suffix: dotExe, want: true},
+		{name: "no suffix match", s: "tool.bin", suffix: dotExe, want: false},
+		{name: "s shorter than suffix", s: "ex", suffix: dotExe, want: false},
+		{name: "s one char shorter than suffix", s: ".ex", suffix: dotExe, want: false},
 		{name: "empty suffix matches anything", s: "tool", suffix: "", want: true},
 		{name: "empty suffix and empty s", s: "", suffix: "", want: true},
-		{name: "empty s nonempty suffix", s: "", suffix: ".exe", want: false},
-		{name: "equal length match", s: "abc", suffix: "abc", want: true},
-		{name: "equal length mismatch", s: "abc", suffix: "xyz", want: false},
-		{name: "suffix in middle only", s: ".exe.bin", suffix: ".exe", want: false},
+		{name: "empty s nonempty suffix", s: "", suffix: dotExe, want: false},
+		{name: "equal length match", s: abcLiteral, suffix: abcLiteral, want: true},
+		{name: "equal length mismatch", s: abcLiteral, suffix: "xyz", want: false},
+		{name: "suffix in middle only", s: ".exe.bin", suffix: dotExe, want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"testing/quick"
 
 	"github.com/nao1215/gup/internal/fileutil"
 	"github.com/spf13/cobra"
@@ -125,6 +126,12 @@ func Test_removeLoop(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer funcDefer()
+
+			// mockStdin replaces os.Stdin with a regular file, which is not a TTY.
+			// Pretend stdin is a terminal so the interactive confirmation path runs.
+			origStdinIsTerminal := stdinIsTerminal
+			stdinIsTerminal = func() bool { return true }
+			defer func() { stdinIsTerminal = origStdinIsTerminal }()
 
 			if runtime.GOOS != goosWindows && tt.name == "windows environment and suffix is mismatch" {
 				GOOS = goosWindows
@@ -293,6 +300,152 @@ func Test_isSafeBinaryName(t *testing.T) {
 			got := isSafeBinaryName(tt.input)
 			if got != tt.want {
 				t.Errorf("isSafeBinaryName(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_removeLoop_nonTTYWithoutForceFailsFast(t *testing.T) {
+	// Not parallel: this test mutates the package-level stdinIsTerminal,
+	// which is also mutated by Test_removeLoop.
+	gobin := t.TempDir()
+	binaryPath := filepath.Join(gobin, testBinPosixer)
+	if err := os.WriteFile(binaryPath, []byte("dummy"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	target := testBinPosixer
+	if GOOS == goosWindows {
+		target += normalizeExecSuffix(GOOS, os.Getenv("GOEXE"))
+		if err := os.Rename(binaryPath, filepath.Join(gobin, target)); err != nil {
+			t.Fatal(err)
+		}
+		binaryPath = filepath.Join(gobin, target)
+	}
+
+	origStdinIsTerminal := stdinIsTerminal
+	stdinIsTerminal = func() bool { return false }
+	t.Cleanup(func() { stdinIsTerminal = origStdinIsTerminal })
+
+	// Without --force and without a TTY, removeLoop must fail fast (exit 1)
+	// and must NOT attempt interactive confirmation nor remove the file.
+	if got := removeLoop(gobin, false, []string{target}); got != 1 {
+		t.Fatalf("removeLoop() = %v, want 1 for non-TTY without --force", got)
+	}
+	if !fileutil.IsFile(binaryPath) {
+		t.Fatalf("file must not be removed when confirmation is required but stdin is not a TTY: %s", binaryPath)
+	}
+}
+
+func Test_removeLoop_nonTTYWithForceStillRemoves(t *testing.T) {
+	// Not parallel: this test mutates the package-level stdinIsTerminal,
+	// which is also mutated by Test_removeLoop.
+	gobin := t.TempDir()
+	target := testBinPosixer
+	if GOOS == goosWindows {
+		target += normalizeExecSuffix(GOOS, os.Getenv("GOEXE"))
+	}
+	binaryPath := filepath.Join(gobin, target)
+	if err := os.WriteFile(binaryPath, []byte("dummy"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	origStdinIsTerminal := stdinIsTerminal
+	stdinIsTerminal = func() bool { return false }
+	t.Cleanup(func() { stdinIsTerminal = origStdinIsTerminal })
+
+	// --force must skip confirmation regardless of TTY state.
+	if got := removeLoop(gobin, true, []string{target}); got != 0 {
+		t.Fatalf("removeLoop() = %v, want 0 for non-TTY with --force", got)
+	}
+	if fileutil.IsFile(binaryPath) {
+		t.Fatalf("file must be removed with --force: %s", binaryPath)
+	}
+}
+
+// Test_isSafeBinaryName_propertyStaysInGobin is a property-based test asserting
+// the security invariant: any name accepted by isSafeBinaryName can only resolve
+// to a file located directly inside $GOBIN, i.e.
+//
+//	isSafeBinaryName(s) == true  =>  filepath.Dir(filepath.Join(gobin, s)) == gobin
+//
+// This is the last line of defense against path traversal in `gup remove`.
+func Test_isSafeBinaryName_propertyStaysInGobin(t *testing.T) {
+	t.Parallel()
+
+	gobin := filepath.Clean(t.TempDir())
+
+	invariant := func(s string) bool {
+		if !isSafeBinaryName(s) {
+			return true // property only constrains accepted names
+		}
+		return filepath.Dir(filepath.Join(gobin, s)) == gobin
+	}
+
+	if err := quick.Check(invariant, &quick.Config{MaxCount: 100000}); err != nil {
+		t.Errorf("isSafeBinaryName property violated: %v", err)
+	}
+
+	// Adversarial inputs that quick may not easily generate.
+	adversarial := []string{
+		"",                // empty
+		"   ",             // whitespace only
+		" tool ",          // surrounding whitespace
+		".",               // current dir
+		"..",              // parent dir
+		"../escape",       // parent traversal
+		"../../escape",    // deeper traversal
+		"/abs/path",       // absolute
+		`C:\Windows\tool`, // windows absolute
+		"C:tool",          // windows drive-relative (colon)
+		"sub/tool",        // forward slash
+		`sub\tool`,        // backslash
+		"tool\x00.exe",    // embedded NUL
+		"tool\nname",      // embedded newline (control char)
+		"tool\tname",      // embedded tab (control char)
+		"a",               // exact-length minimal name (len 1)
+		"e",               // len(s) shorter than typical suffix
+		"gopls",           // plain valid name
+		"gopls.exe",       // valid name with extension
+		"ｇｏｐｌｓ",           // unicode full-width look-alike
+		"tool/../escape",  // traversal hidden mid-string
+		"./tool",          // dot-slash prefix
+		"‮" + "exe.sh",    // right-to-left override look-alike
+	}
+	for _, s := range adversarial {
+		if !invariant(s) {
+			t.Errorf("invariant violated for adversarial input %q: accepted name resolves outside gobin", s)
+		}
+	}
+}
+
+func Test_hasSuffixFold(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		s      string
+		suffix string
+		want   bool
+	}{
+		{name: "exact match same case", s: ".exe", suffix: ".exe", want: true},
+		{name: "case-insensitive match", s: "gopls.EXE", suffix: ".exe", want: true},
+		{name: "case-insensitive match reversed", s: "gopls.exe", suffix: ".EXE", want: true},
+		{name: "suffix present lowercase", s: "tool.exe", suffix: ".exe", want: true},
+		{name: "no suffix match", s: "tool.bin", suffix: ".exe", want: false},
+		{name: "s shorter than suffix", s: "ex", suffix: ".exe", want: false},
+		{name: "s one char shorter than suffix", s: ".ex", suffix: ".exe", want: false},
+		{name: "empty suffix matches anything", s: "tool", suffix: "", want: true},
+		{name: "empty suffix and empty s", s: "", suffix: "", want: true},
+		{name: "empty s nonempty suffix", s: "", suffix: ".exe", want: false},
+		{name: "equal length match", s: "abc", suffix: "abc", want: true},
+		{name: "equal length mismatch", s: "abc", suffix: "xyz", want: false},
+		{name: "suffix in middle only", s: ".exe.bin", suffix: ".exe", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := hasSuffixFold(tt.s, tt.suffix); got != tt.want {
+				t.Errorf("hasSuffixFold(%q, %q) = %v, want %v", tt.s, tt.suffix, got, tt.want)
 			}
 		})
 	}

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -18,6 +18,7 @@ const (
 	whitespaceOnly = "   "
 	goplsExe       = "gopls.exe"
 	dotExe         = ".exe"
+	dotUpperExe    = ".EXE"
 	abcLiteral     = "abc"
 )
 
@@ -438,7 +439,7 @@ func Test_hasSuffixFold(t *testing.T) {
 	}{
 		{name: "exact match same case", s: dotExe, suffix: dotExe, want: true},
 		{name: "case-insensitive match", s: "gopls.EXE", suffix: dotExe, want: true},
-		{name: "case-insensitive match reversed", s: goplsExe, suffix: ".EXE", want: true},
+		{name: "case-insensitive match reversed", s: goplsExe, suffix: dotUpperExe, want: true},
 		{name: "suffix present lowercase", s: "tool.exe", suffix: dotExe, want: true},
 		{name: "no suffix match", s: "tool.bin", suffix: dotExe, want: false},
 		{name: "s shorter than suffix", s: "ex", suffix: dotExe, want: false},

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -513,7 +513,7 @@ func binaryNameFromImportPathWith(importPath, goos, goExe string) string {
 	if goos == goosWindows {
 		goExe = strings.TrimSpace(goExe)
 		if goExe == "" {
-			goExe = ".exe"
+			goExe = exeSuffix
 		}
 		if !strings.HasSuffix(strings.ToLower(binName), strings.ToLower(goExe)) {
 			return binName + goExe


### PR DESCRIPTION
## Summary

This PR hardens the `gup remove` command against two distinct issues.

### #323 — Fail fast when confirmation is required in non-interactive execution

Previously, `gup remove` (without `--force`) routed confirmation through `print.Question()`, which reads stdin via `fmt.Scanln()` without checking whether stdin is a TTY. In CI or piped execution this could block, expose a raw EOF, or otherwise behave unreliably.

Now, in `removeLoop`, when `--force` is not specified **and** stdin is not a TTY, the command fails fast with a clear message and never attempts interactive confirmation:

```
gup remove requires confirmation, but stdin is not a TTY.
Use --force to skip confirmation.
```

- The TTY check uses only the standard library (`os.Stdin.Stat()` with `os.ModeCharDevice`) — no new dependency added.
- The check is a package-level `stdinIsTerminal` function variable so it is injectable for unit tests.
- On a real TTY the interactive prompt is unchanged; `--force` still skips confirmation; the change stays small and local to remove confirmation handling.

### #303 — Property-based test for the path-traversal guard

`gup remove` validates binary names with `isSafeBinaryName` right before `os.Remove` — the last line of defense against path traversal. Added:

1. A `testing/quick` property-based test asserting the invariant
   `isSafeBinaryName(s) == true ⇒ filepath.Dir(filepath.Join(gobin, s)) == gobin`,
   plus adversarial inputs (NUL/control chars, Unicode look-alikes, RTL override, empty/whitespace, exact match, `len(s) < len(suffix)`, traversal variants).
2. A focused table test for `hasSuffixFold` covering boundary cases (equal length, shorter-than-suffix, empty suffix, case-insensitive folding, mid-string suffix).

## Verification

- `gofmt -l .` clean
- `go vet ./...` clean
- `go test -race ./cmd/... ./internal/print/...` pass
- `go test ./...` pass

Closes #303
Closes #323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The remove command now behaves safely in non-interactive contexts: when stdin isn’t a terminal and `--force` isn’t provided, the command fails fast and skips interactive confirmation.
  * Added additional automated coverage to ensure removals only occur with `--force` in non-TTY scenarios, and that binary name validation stays constrained to the intended directory.  
  * Improved Windows executable suffix handling for update/remove logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->