### PR TITLE
test(goutil): add helper-process seam and property-based tests

### DIFF
--- a/cmd/property_test.go
+++ b/cmd/property_test.go
@@ -1,0 +1,160 @@
+//nolint:paralleltest // grouped with the rest of the cmd test suite
+package cmd
+
+import (
+	"math/rand"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+	"testing/quick"
+)
+
+// Literals reused across the property tests, kept as constants to satisfy
+// goconst (which counts occurrences across the whole package).
+const (
+	testGOOSLinux = "linux"
+	testDotExe    = ".exe"
+)
+
+// binBaseName generates plausible binary base names: letters/digits with an
+// optional case-mixed ".exe"/".EXE" suffix and optional surrounding spaces. It
+// is bounded so the property checks stay fast and deterministic-ish.
+type binBaseName string
+
+// Generate implements quick.Generator for binBaseName.
+func (binBaseName) Generate(rng *rand.Rand, _ int) reflect.Value {
+	letters := []rune("abcdefABCDEF0123456789-_")
+	n := 1 + rng.Intn(8)
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.WriteRune(letters[rng.Intn(len(letters))])
+	}
+	name := sb.String()
+
+	switch rng.Intn(4) {
+	case 0:
+		name += testDotExe
+	case 1:
+		name += ".EXE"
+	case 2:
+		name += ".Exe"
+	default:
+		// no suffix
+	}
+	if rng.Intn(2) == 0 {
+		name = "  " + name + "  " // surrounding spaces to exercise TrimSpace
+	}
+	return reflect.ValueOf(binBaseName(name))
+}
+
+// TestNormalizeBinaryNameForMatch_properties asserts:
+//   - idempotency: f(f(x)) == f(x) for all inputs;
+//   - non-Windows hosts only trim whitespace (no case folding, no .exe strip);
+//   - on Windows the result is lowercase with any ".exe" suffix removed.
+//
+// normalizeBinaryNameForMatch branches on runtime.GOOS, so the OS-specific
+// assertions are gated on the host the test runs on while idempotency is
+// universal.
+func TestNormalizeBinaryNameForMatch_properties(t *testing.T) {
+	idempotent := func(a binBaseName) bool {
+		once := normalizeBinaryNameForMatch(string(a))
+		twice := normalizeBinaryNameForMatch(once)
+		return once == twice
+	}
+	if err := quick.Check(idempotent, &quick.Config{MaxCount: 500}); err != nil {
+		t.Errorf("idempotency failed: %v", err)
+	}
+
+	// Case/.exe handling is exercised through the public function with explicit
+	// inputs so the invariant is asserted regardless of the host OS via the
+	// idempotency above; here we additionally check the host-specific contract.
+	hostContract := func(a binBaseName) bool {
+		in := string(a)
+		got := normalizeBinaryNameForMatch(in)
+		trimmed := strings.TrimSpace(in)
+
+		if isWindowsHost() {
+			lower := strings.ToLower(trimmed)
+			want := strings.TrimSuffix(lower, testDotExe)
+			return got == want
+		}
+		// Non-Windows: only whitespace is trimmed; case and .exe are preserved.
+		return got == trimmed
+	}
+	if err := quick.Check(hostContract, &quick.Config{MaxCount: 500}); err != nil {
+		t.Errorf("host-specific contract failed: %v", err)
+	}
+}
+
+// importPathInput generates import paths with several path segments so the
+// derived binary name is the final element.
+type importPathInput string
+
+// Generate implements quick.Generator for importPathInput.
+func (importPathInput) Generate(rng *rand.Rand, _ int) reflect.Value {
+	letters := []rune("abcdefghij0123456789")
+	seg := func() string {
+		n := 1 + rng.Intn(6)
+		var sb strings.Builder
+		for i := 0; i < n; i++ {
+			sb.WriteRune(letters[rng.Intn(len(letters))])
+		}
+		return sb.String()
+	}
+	parts := []string{"example.com", seg()}
+	extra := rng.Intn(4)
+	for i := 0; i < extra; i++ {
+		parts = append(parts, seg())
+	}
+	return reflect.ValueOf(importPathInput(strings.Join(parts, "/")))
+}
+
+// TestBinaryNameFromImportPath_properties asserts:
+//   - the result never contains a path separator (it is always a base name);
+//   - the transform is stable for already-normalized input, i.e. running it on
+//     an import path whose base name is the previous result returns that same
+//     name (f is a fixed point on its own output), for both linux and windows.
+func TestBinaryNameFromImportPath_properties(t *testing.T) {
+	// Property: result is always a bare base name (no '/' or filepath separator).
+	noSeparator := func(p importPathInput) bool {
+		for _, goos := range []string{testGOOSLinux, goosWindows} {
+			got := binaryNameFromImportPathWith(string(p), goos, "")
+			if strings.ContainsRune(got, '/') || strings.ContainsRune(got, '\\') {
+				return false
+			}
+		}
+		return true
+	}
+	if err := quick.Check(noSeparator, &quick.Config{MaxCount: 500}); err != nil {
+		t.Errorf("no-separator property failed: %v", err)
+	}
+
+	// Property: stable for already-normalized input. Feeding the previous result
+	// back in (as a single-segment import path) yields the same binary name.
+	stable := func(p importPathInput) bool {
+		for _, goos := range []string{testGOOSLinux, goosWindows} {
+			first := binaryNameFromImportPathWith(string(p), goos, "")
+			second := binaryNameFromImportPathWith(first, goos, "")
+			if first != second {
+				return false
+			}
+		}
+		return true
+	}
+	if err := quick.Check(stable, &quick.Config{MaxCount: 500}); err != nil {
+		t.Errorf("stability property failed: %v", err)
+	}
+
+	// The default (host) wrapper must also produce a separator-free name.
+	if got := binaryNameFromImportPath("example.com/owner/cmd/tool"); strings.ContainsAny(got, "/\\") {
+		t.Errorf("binaryNameFromImportPath() leaked a separator: %q", got)
+	}
+}
+
+// isWindowsHost reports whether normalizeBinaryNameForMatch will take its
+// Windows branch on the current host. It mirrors the runtime.GOOS check in the
+// production code.
+func isWindowsHost() bool {
+	return runtime.GOOS == goosWindows
+}

--- a/cmd/property_test.go
+++ b/cmd/property_test.go
@@ -13,8 +13,9 @@ import (
 // Literals reused across the property tests, kept as constants to satisfy
 // goconst (which counts occurrences across the whole package).
 const (
-	testGOOSLinux = "linux"
-	testDotExe    = ".exe"
+	testGOOSLinux   = "linux"
+	testDotExe      = ".exe"
+	testDotUpperExe = ".EXE"
 )
 
 // quickConfig returns a quick.Config with a fixed RNG seed so that any failing
@@ -45,7 +46,7 @@ func (binBaseName) Generate(rng *rand.Rand, _ int) reflect.Value {
 	case 0:
 		name += testDotExe
 	case 1:
-		name += ".EXE"
+		name += testDotUpperExe
 	case 2:
 		name += ".Exe"
 	default:

--- a/cmd/property_test.go
+++ b/cmd/property_test.go
@@ -22,7 +22,7 @@ const (
 func quickConfig() *quick.Config {
 	return &quick.Config{
 		MaxCount: 500,
-		Rand:     rand.New(rand.NewSource(1)),
+		Rand:     rand.New(rand.NewSource(1)), //nolint:gosec // G404: a fixed non-crypto seed is intentional for reproducible property tests
 	}
 }
 

--- a/cmd/property_test.go
+++ b/cmd/property_test.go
@@ -17,6 +17,15 @@ const (
 	testDotExe    = ".exe"
 )
 
+// quickConfig returns a quick.Config with a fixed RNG seed so that any failing
+// input is reproducible across local and CI runs.
+func quickConfig() *quick.Config {
+	return &quick.Config{
+		MaxCount: 500,
+		Rand:     rand.New(rand.NewSource(1)),
+	}
+}
+
 // binBaseName generates plausible binary base names: letters/digits with an
 // optional case-mixed ".exe"/".EXE" suffix and optional surrounding spaces. It
 // is bounded so the property checks stay fast and deterministic-ish.
@@ -62,7 +71,7 @@ func TestNormalizeBinaryNameForMatch_properties(t *testing.T) {
 		twice := normalizeBinaryNameForMatch(once)
 		return once == twice
 	}
-	if err := quick.Check(idempotent, &quick.Config{MaxCount: 500}); err != nil {
+	if err := quick.Check(idempotent, quickConfig()); err != nil {
 		t.Errorf("idempotency failed: %v", err)
 	}
 
@@ -82,7 +91,7 @@ func TestNormalizeBinaryNameForMatch_properties(t *testing.T) {
 		// Non-Windows: only whitespace is trimmed; case and .exe are preserved.
 		return got == trimmed
 	}
-	if err := quick.Check(hostContract, &quick.Config{MaxCount: 500}); err != nil {
+	if err := quick.Check(hostContract, quickConfig()); err != nil {
 		t.Errorf("host-specific contract failed: %v", err)
 	}
 }
@@ -126,7 +135,7 @@ func TestBinaryNameFromImportPath_properties(t *testing.T) {
 		}
 		return true
 	}
-	if err := quick.Check(noSeparator, &quick.Config{MaxCount: 500}); err != nil {
+	if err := quick.Check(noSeparator, quickConfig()); err != nil {
 		t.Errorf("no-separator property failed: %v", err)
 	}
 
@@ -142,7 +151,7 @@ func TestBinaryNameFromImportPath_properties(t *testing.T) {
 		}
 		return true
 	}
-	if err := quick.Check(stable, &quick.Config{MaxCount: 500}); err != nil {
+	if err := quick.Check(stable, quickConfig()); err != nil {
 		t.Errorf("stability property failed: %v", err)
 	}
 

--- a/internal/config/property_test.go
+++ b/internal/config/property_test.go
@@ -1,0 +1,140 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"testing/quick"
+
+	"github.com/nao1215/gup/internal/goutil"
+)
+
+// validPackageSet generates a slice of packages that ReadConfFile accepts:
+// every entry has a non-empty, non-whitespace Name, ImportPath and Version.
+// It is the input domain for the write -> read round-trip property.
+type validPackageSet []goutil.Package
+
+// Generate implements quick.Generator for validPackageSet.
+func (validPackageSet) Generate(rng *rand.Rand, _ int) reflect.Value {
+	n := rng.Intn(6) // 0..5 packages, including the empty set
+	channels := []goutil.UpdateChannel{
+		goutil.UpdateChannelLatest,
+		goutil.UpdateChannelMain,
+		goutil.UpdateChannelMaster,
+		"", // exercises normalization to "latest"
+		"SNAPSHOT",
+	}
+	versions := []string{verSemver, "v0.0.1", verLatest, "v2.0.0-rc.1"}
+
+	pkgs := make(validPackageSet, 0, n)
+	for i := 0; i < n; i++ {
+		pkgs = append(pkgs, goutil.Package{
+			Name:          fmt.Sprintf("tool%d", i),
+			ImportPath:    fmt.Sprintf("example.com/owner/tool%d", i),
+			Version:       &goutil.Version{Current: versions[rng.Intn(len(versions))]},
+			UpdateChannel: channels[rng.Intn(len(channels))],
+		})
+	}
+	return reflect.ValueOf(pkgs)
+}
+
+// normalizedView is the persisted, comparable projection of a package: the
+// fields that survive a WriteConfFile -> ReadConfFile round-trip, each already
+// run through the same normalization WriteConfFile applies.
+type normalizedView struct {
+	Name       string
+	ImportPath string
+	Version    string
+	Channel    goutil.UpdateChannel
+}
+
+func viewOf(p goutil.Package) normalizedView {
+	version := verLatest
+	if p.Version != nil {
+		version = normalizeConfVersion(p.Version.Current)
+	}
+	return normalizedView{
+		Name:       p.Name,
+		ImportPath: p.ImportPath,
+		Version:    version,
+		Channel:    goutil.NormalizeUpdateChannel(string(p.UpdateChannel)),
+	}
+}
+
+func viewsOf(pkgs []goutil.Package) []normalizedView {
+	out := make([]normalizedView, 0, len(pkgs))
+	for _, p := range pkgs {
+		out = append(out, viewOf(p))
+	}
+	return out
+}
+
+// TestWriteThenReadConfFile_roundTrip is the property: for any valid package
+// set, writing it and reading it back yields an equivalent set (modulo the
+// documented normalization of version and channel performed on write).
+func TestWriteThenReadConfFile_roundTrip(t *testing.T) { //nolint:paralleltest // uses a temp file per case
+	roundTrip := func(in validPackageSet) bool {
+		var buf bytes.Buffer
+		if err := WriteConfFile(&buf, in); err != nil {
+			t.Logf("WriteConfFile() error = %v", err)
+			return false
+		}
+
+		// ReadConfFile reads from a path, so persist to a temp file.
+		path := filepath.Join(t.TempDir(), "gup.json")
+		if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+			t.Logf("failed to write temp conf file: %v", err)
+			return false
+		}
+
+		got, err := ReadConfFile(path)
+		if err != nil {
+			t.Logf("ReadConfFile() error = %v", err)
+			return false
+		}
+
+		want := viewsOf([]goutil.Package(in))
+		gotViews := viewsOf(got)
+		if !reflect.DeepEqual(want, gotViews) {
+			t.Logf("round-trip mismatch:\n want=%+v\n got =%+v", want, gotViews)
+			return false
+		}
+		return true
+	}
+
+	if err := quick.Check(roundTrip, &quick.Config{MaxCount: 300}); err != nil {
+		t.Errorf("write->read round-trip property failed: %v", err)
+	}
+}
+
+// TestWriteThenReadConfFile_roundTrip_emptySet covers the explicit empty-set
+// boundary, where ReadConfFile returns an empty (non-nil) slice.
+func TestWriteThenReadConfFile_roundTrip_emptySet(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	if err := WriteConfFile(&buf, nil); err != nil {
+		t.Fatalf("WriteConfFile() error = %v", err)
+	}
+	// The persisted form must declare zero packages.
+	if !strings.Contains(buf.String(), `"packages": []`) {
+		t.Fatalf("empty set should persist an empty packages array, got: %s", buf.String())
+	}
+
+	path := filepath.Join(t.TempDir(), "gup.json")
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatalf("failed to write temp conf file: %v", err)
+	}
+	got, err := ReadConfFile(path)
+	if err != nil {
+		t.Fatalf("ReadConfFile() error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("ReadConfFile() len = %d, want 0", len(got))
+	}
+}

--- a/internal/goutil/examples_test.go
+++ b/internal/goutil/examples_test.go
@@ -27,6 +27,8 @@ func ExampleBinaryPathList() {
 		"examples_test.go",
 		"goutil.go",
 		"goutil_test.go",
+		"helperprocess_test.go",
+		"property_test.go",
 	}
 
 	if cmp.Equal(got, want) {

--- a/internal/goutil/goutil.go
+++ b/internal/goutil/goutil.go
@@ -45,6 +45,14 @@ var (
 	keyGoPath = "GOPATH" //nolint:gochecknoglobals
 	// osMkdirTemp is a copy of os.MkdirTemp to ease testing.
 	osMkdirTemp = os.MkdirTemp //nolint:gochecknoglobals
+	// goCommandContext builds the *exec.Cmd used to run the go toolchain. It is a
+	// variable so tests can swap in the standard "helper process" pattern
+	// (re-executing the test binary) and exercise the subprocess-driven helpers
+	// deterministically without network access. Production code always uses the
+	// default, which simply runs goExe with the given arguments.
+	goCommandContext = func(ctx context.Context, args ...string) *exec.Cmd { //nolint:gochecknoglobals
+		return exec.CommandContext(ctx, goExe, args...) //#nosec G204 -- args are built internally, not from untrusted input
+	}
 )
 
 // GoPaths has $GOBIN and $GOPATH
@@ -404,7 +412,7 @@ func InstallWithContext(ctx context.Context, importPath, version string) error {
 	}
 
 	var stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, goExe, "install", fmt.Sprintf("%s@%s", importPath, version)) //#nosec
+	cmd := goCommandContext(ctx, "install", fmt.Sprintf("%s@%s", importPath, version))
 	cmd.Stderr = &stderr
 
 	err := cmd.Run()
@@ -445,7 +453,7 @@ func GetVerWithContext(ctx context.Context, modulePath, ref string) (string, err
 		ctx = context.Background()
 	}
 	var stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, goExe, "list", "-m", "-f", "{{.Version}}", modulePath+"@"+ref) //#nosec
+	cmd := goCommandContext(ctx, "list", "-m", "-f", "{{.Version}}", modulePath+"@"+ref)
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil {
@@ -643,7 +651,7 @@ var requiredAsPathRegex = regexp.MustCompile(`(?m)but was required as:\s*(\S+)`)
 // GetInstalledGoVersion return installed go version.
 func GetInstalledGoVersion() (string, error) {
 	var stdout, stderr bytes.Buffer
-	cmd := exec.CommandContext(context.Background(), goExe, "version")
+	cmd := goCommandContext(context.Background(), "version")
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 

--- a/internal/goutil/helperprocess_test.go
+++ b/internal/goutil/helperprocess_test.go
@@ -1,0 +1,320 @@
+//nolint:paralleltest,errcheck,gosec // these tests swap package-level seams (goCommandContext) and re-exec the test binary
+package goutil
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// Environment variables that select TestHelperProcess behavior. The harness
+// re-executes the test binary with -test.run=TestHelperProcess (the Go standard
+// "helper process" pattern). TestHelperProcess reads these to decide what to
+// print to stdout/stderr and which exit code to use, so the subprocess-driven
+// helpers in goutil.go can be exercised deterministically without any network
+// access or a real go toolchain.
+const (
+	envHelperProcess = "GO_WANT_HELPER_PROCESS"
+	envHelperStdout  = "GO_HELPER_STDOUT"
+	envHelperStderr  = "GO_HELPER_STDERR"
+	envHelperExit    = "GO_HELPER_EXIT"
+	// envHelperFailMain makes the helper fail only when the requested ref is
+	// "@main" and succeed otherwise. It is used to exercise the @main -> @master
+	// fallback in InstallMainOrMaster without depending on a real network.
+	envHelperFailMain = "GO_HELPER_FAIL_MAIN"
+	// envHelperFailMainStderr customizes the stderr printed for the failing
+	// "@main" attempt (e.g. to inject "unknown revision main").
+	envHelperFailMainStderr = "GO_HELPER_FAIL_MAIN_STDERR"
+)
+
+// Shared version literals used across the helper-process tests. They are
+// constants to satisfy goconst and keep the expected outputs in one place.
+const (
+	testVer123    = "v1.2.3"
+	testGoVer1224 = "go1.22.4"
+)
+
+// helperProcessConfig describes how the helper subprocess should behave.
+type helperProcessConfig struct {
+	stdout string
+	stderr string
+	exit   int
+}
+
+// withHelperProcess swaps goCommandContext so every go invocation re-executes
+// the test binary as a helper process configured by cfg. It restores the
+// previous seam on cleanup. The returned function is unused but kept symmetric
+// with other seam helpers in this package.
+func withHelperProcess(t *testing.T, cfg helperProcessConfig) {
+	t.Helper()
+	old := goCommandContext
+	t.Cleanup(func() { goCommandContext = old })
+
+	goCommandContext = func(ctx context.Context, args ...string) *exec.Cmd {
+		cs := append([]string{"-test.run=TestHelperProcess", "--"}, args...)
+		cmd := exec.CommandContext(ctx, os.Args[0], cs...) //#nosec G204 -- os.Args[0] is the test binary
+		cmd.Env = append(os.Environ(),
+			envHelperProcess+"=1",
+			envHelperStdout+"="+cfg.stdout,
+			envHelperStderr+"="+cfg.stderr,
+			envHelperExit+"="+strconv.Itoa(cfg.exit),
+		)
+		return cmd
+	}
+}
+
+// withHelperProcessMainMasterFallback swaps goCommandContext so that an "@main"
+// install/list attempt fails (with mainStderr on stderr, exit 1) while any other
+// ref succeeds. This drives the @main -> @master fallback path deterministically.
+func withHelperProcessMainMasterFallback(t *testing.T, mainStderr string) {
+	t.Helper()
+	old := goCommandContext
+	t.Cleanup(func() { goCommandContext = old })
+
+	goCommandContext = func(ctx context.Context, args ...string) *exec.Cmd {
+		cs := append([]string{"-test.run=TestHelperProcess", "--"}, args...)
+		cmd := exec.CommandContext(ctx, os.Args[0], cs...) //#nosec G204 -- os.Args[0] is the test binary
+		env := append(os.Environ(),
+			envHelperProcess+"=1",
+			envHelperFailMain+"=1",
+			envHelperFailMainStderr+"="+mainStderr,
+		)
+		cmd.Env = env
+		return cmd
+	}
+}
+
+// TestHelperProcess is not a real test. It is re-executed as a subprocess by the
+// helpers above; when GO_WANT_HELPER_PROCESS is unset it returns immediately so
+// it is a no-op during a normal "go test" run.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv(envHelperProcess) != "1" {
+		return
+	}
+
+	// Recover the original go arguments after the "--" separator.
+	args := os.Args
+	for i, a := range args {
+		if a == "--" {
+			args = args[i+1:]
+			break
+		}
+	}
+
+	// Fallback mode: fail only on the "@main" ref, succeed otherwise.
+	if os.Getenv(envHelperFailMain) == "1" {
+		if argsTargetRef(args, "main") {
+			if s := os.Getenv(envHelperFailMainStderr); s != "" {
+				fmt.Fprint(os.Stderr, s)
+			}
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
+	if s := os.Getenv(envHelperStdout); s != "" {
+		fmt.Fprint(os.Stdout, s)
+	}
+	if s := os.Getenv(envHelperStderr); s != "" {
+		fmt.Fprint(os.Stderr, s)
+	}
+	exit := 0
+	if v := os.Getenv(envHelperExit); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			exit = n
+		}
+	}
+	os.Exit(exit)
+}
+
+// argsTargetRef reports whether any argument ends with "@<ref>", i.e. whether
+// the go command was asked to operate on that ref (e.g. importpath@main).
+func argsTargetRef(args []string, ref string) bool {
+	for _, a := range args {
+		if strings.HasSuffix(a, "@"+ref) {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// GetVerWithContext / GetLatestVerWithContext
+// ---------------------------------------------------------------------------
+
+func TestGetVerWithContext_helperProcess_versionString(t *testing.T) {
+	// The go subprocess prints the resolved version with a trailing newline,
+	// which GetVerWithContext must trim.
+	withHelperProcess(t, helperProcessConfig{stdout: testVer123 + "\n"})
+
+	out, err := GetVerWithContext(context.Background(), "github.com/nao1215/gup", "latest")
+	if err != nil {
+		t.Fatalf("GetVerWithContext() unexpected error: %v", err)
+	}
+	if out != testVer123 {
+		t.Errorf("GetVerWithContext() = %q, want %q (trailing newline trimmed)", out, testVer123)
+	}
+}
+
+func TestGetLatestVerWithContext_helperProcess_versionString(t *testing.T) {
+	withHelperProcess(t, helperProcessConfig{stdout: "v0.9.0\n\n"})
+
+	out, err := GetLatestVerWithContext(context.Background(), "github.com/nao1215/gup")
+	if err != nil {
+		t.Fatalf("GetLatestVerWithContext() unexpected error: %v", err)
+	}
+	// Only trailing newlines are trimmed (strings.TrimRight on "\n").
+	if out != "v0.9.0" {
+		t.Errorf("GetLatestVerWithContext() = %q, want %q", out, "v0.9.0")
+	}
+}
+
+func TestGetVerWithContext_helperProcess_stderrBranch(t *testing.T) {
+	// Distinct stdout (empty) + stderr + non-zero exit: the error must surface
+	// the stderr text as the cause, not the empty stdout.
+	withHelperProcess(t, helperProcessConfig{
+		stderr: "go: unknown revision main\n",
+		exit:   1,
+	})
+
+	out, err := GetVerWithContext(context.Background(), "github.com/nao1215/gup", "main")
+	if err == nil {
+		t.Fatalf("GetVerWithContext() should fail when the subprocess exits non-zero. got out=%q", out)
+	}
+	if out != "" {
+		t.Errorf("GetVerWithContext() should return empty string on error. got: %q", out)
+	}
+	if !strings.Contains(err.Error(), "unknown revision main") {
+		t.Errorf("error should carry the stderr cause. got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "can't check") {
+		t.Errorf("error should report the version-check failure. got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// InstallWithContext
+// ---------------------------------------------------------------------------
+
+func TestInstallWithContext_helperProcess_success(t *testing.T) {
+	// Exit code 0 with no output: install succeeds.
+	withHelperProcess(t, helperProcessConfig{})
+
+	if err := InstallWithContext(context.Background(), "github.com/nao1215/gup", "latest"); err != nil {
+		t.Fatalf("InstallWithContext() unexpected error: %v", err)
+	}
+}
+
+func TestInstallWithContext_helperProcess_stderrBranch(t *testing.T) {
+	// Distinct stdout vs stderr vs exit-code: stdout is ignored for failures,
+	// the stderr text is reported as the cause.
+	withHelperProcess(t, helperProcessConfig{
+		stdout: "this stdout must be ignored\n",
+		stderr: "build failed: some compile error\n",
+		exit:   2,
+	})
+
+	err := InstallWithContext(context.Background(), "github.com/nao1215/gup", "latest")
+	if err == nil {
+		t.Fatal("InstallWithContext() should fail when the subprocess exits non-zero")
+	}
+	if !strings.Contains(err.Error(), "build failed: some compile error") {
+		t.Errorf("error should carry the stderr cause. got: %v", err)
+	}
+	if strings.Contains(err.Error(), "must be ignored") {
+		t.Errorf("error should not include stdout. got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// InstallMainOrMasterWithContext: @main failure -> @master fallback
+// ---------------------------------------------------------------------------
+
+func TestInstallMainOrMasterWithContext_helperProcess_masterFallbackSucceeds(t *testing.T) {
+	// @main fails with "unknown revision main"; @master then succeeds. The
+	// overall call must succeed (the @main error is swallowed).
+	withHelperProcessMainMasterFallback(t, "go: unknown revision main\n")
+
+	if err := InstallMainOrMasterWithContext(context.Background(), "github.com/example/tool"); err != nil {
+		t.Fatalf("InstallMainOrMasterWithContext() should succeed via @master fallback. got: %v", err)
+	}
+}
+
+func TestInstallMainOrMasterWithContext_helperProcess_bothFail(t *testing.T) {
+	// Both @main and @master fail (exit 1) with distinct stderr. The combined
+	// error must mention the manual-update guidance.
+	withHelperProcess(t, helperProcessConfig{
+		stderr: "go: some unrelated failure\n",
+		exit:   1,
+	})
+
+	err := InstallMainOrMasterWithContext(context.Background(), "github.com/example/tool")
+	if err == nil {
+		t.Fatal("InstallMainOrMasterWithContext() should fail when both @main and @master fail")
+	}
+	if !strings.Contains(err.Error(), "cannot update with @master or @main") {
+		t.Errorf("error should include manual-update guidance. got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "some unrelated failure") {
+		t.Errorf("error should surface the underlying stderr. got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetInstalledGoVersion
+// ---------------------------------------------------------------------------
+
+func TestGetInstalledGoVersion_helperProcess_golden(t *testing.T) {
+	// Mimic real "go version" stdout; the embedded goX.Y.Z token is extracted.
+	withHelperProcess(t, helperProcessConfig{
+		stdout: "go version " + testGoVer1224 + " linux/amd64\n",
+	})
+
+	got, err := GetInstalledGoVersion()
+	if err != nil {
+		t.Fatalf("GetInstalledGoVersion() unexpected error: %v", err)
+	}
+	if got != testGoVer1224 {
+		t.Errorf("GetInstalledGoVersion() = %q, want %q", got, testGoVer1224)
+	}
+}
+
+func TestGetInstalledGoVersion_helperProcess_commandFails(t *testing.T) {
+	// Non-zero exit with stderr: the error reports the version-check failure and
+	// carries the stderr text.
+	withHelperProcess(t, helperProcessConfig{
+		stderr: "go: cannot run version\n",
+		exit:   1,
+	})
+
+	_, err := GetInstalledGoVersion()
+	if err == nil {
+		t.Fatal("GetInstalledGoVersion() should fail when the subprocess exits non-zero")
+	}
+	if !strings.Contains(err.Error(), "can't check go version") {
+		t.Errorf("error should report the go-version failure. got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "cannot run version") {
+		t.Errorf("error should carry the stderr cause. got: %v", err)
+	}
+}
+
+func TestGetInstalledGoVersion_helperProcess_noVersionToken(t *testing.T) {
+	// Exit 0 but stdout has no goX.Y.Z token: distinct stdout/exit combination
+	// that still yields an error from the regexp-miss branch.
+	withHelperProcess(t, helperProcessConfig{
+		stdout: "not a version line\n",
+	})
+
+	_, err := GetInstalledGoVersion()
+	if err == nil {
+		t.Fatal("GetInstalledGoVersion() should fail when stdout has no go version token")
+	}
+	if !strings.Contains(err.Error(), "can't find go version string") {
+		t.Errorf("error should report the missing version token. got: %v", err)
+	}
+}

--- a/internal/goutil/property_test.go
+++ b/internal/goutil/property_test.go
@@ -1,0 +1,180 @@
+//nolint:paralleltest,goconst // keep consistent with the rest of this package's tests; version literals are clearer inline
+package goutil
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"testing"
+	"testing/quick"
+
+	"github.com/hashicorp/go-version"
+)
+
+// quickConfig is the shared testing/quick configuration. MaxCount is kept
+// bounded so the property-based tests stay fast and non-flaky.
+func quickConfig() *quick.Config {
+	return &quick.Config{MaxCount: 500}
+}
+
+// semverString is a bounded, parseable version string generator. Values it
+// produces are always accepted by version.NewVersion, which lets the properties
+// focus on comparison behavior rather than parse failures.
+type semverString string
+
+// Generate implements quick.Generator for semverString.
+func (semverString) Generate(rng *rand.Rand, _ int) reflect.Value {
+	major := rng.Intn(20)
+	minor := rng.Intn(40)
+	patch := rng.Intn(40)
+	s := fmt.Sprintf("%d.%d.%d", major, minor, patch)
+
+	switch rng.Intn(6) {
+	case 0:
+		s = "v" + s // go-style "v" prefix
+	case 1:
+		s += fmt.Sprintf("-rc.%d", rng.Intn(5)) // prerelease
+	case 2:
+		s += fmt.Sprintf("+build.%d", rng.Intn(5)) // build metadata
+	case 3:
+		s = fmt.Sprintf("%d.%d", major, minor) // shorter form
+	case 4:
+		s = fmt.Sprintf("%d.%d.%d-0.20220908165354-f7355b5d2afa", major, minor, patch) // pseudo-version-ish
+	default:
+		// keep plain "x.y.z"
+	}
+	return reflect.ValueOf(semverString(s))
+}
+
+// TestVersionUpToDate_properties asserts the order-theoretic invariants of
+// versionUpToDate for parseable inputs:
+//   - reflexivity: upToDate(a, a) == true
+//   - antisymmetry/totality: for parseable a, b at least one direction holds,
+//     and when both hold the versions compare equal.
+func TestVersionUpToDate_properties(t *testing.T) {
+	reflexive := func(a semverString) bool {
+		return versionUpToDate(string(a), string(a))
+	}
+	if err := quick.Check(reflexive, quickConfig()); err != nil {
+		t.Errorf("reflexivity failed: %v", err)
+	}
+
+	// Totality + antisymmetry: with two parseable versions, the comparison is a
+	// total order, so upToDate(a,b) || upToDate(b,a) is always true, and both
+	// can be true only when the versions are equal.
+	total := func(a, b semverString) bool {
+		ab := versionUpToDate(string(a), string(b))
+		ba := versionUpToDate(string(b), string(a))
+		if !ab && !ba {
+			return false // a total order must order every parseable pair
+		}
+		if ab && ba {
+			// Both >= each other means they must be equal under the parser.
+			va, errA := version.NewVersion(string(a))
+			vb, errB := version.NewVersion(string(b))
+			if errA != nil || errB != nil {
+				return false
+			}
+			return va.Equal(vb)
+		}
+		return true
+	}
+	if err := quick.Check(total, quickConfig()); err != nil {
+		t.Errorf("totality/antisymmetry failed: %v", err)
+	}
+
+	// Boundary pairs exercise carry/format boundaries the property generators may
+	// not hit often. Each must respect the same invariants.
+	boundaryPairs := []struct{ a, b string }{
+		{"v1.9.0", "v1.10.0"}, // numeric carry: 9 < 10
+		{"1.9.0", "1.10.0"},
+		{"v1.0", "v1.0.0"}, // short form vs full form (equal)
+		{"1.0", "1.0.0"},
+		{"v1.2.3-rc.1", "v1.2.3"},    // prerelease < release
+		{"v1.2.3+build.1", "v1.2.3"}, // build metadata ignored for ordering
+		{"v1.9.1-0.20220908165354-f7355b5d2afa", "v1.9.0"},
+	}
+	for _, p := range boundaryPairs {
+		if !versionUpToDate(p.a, p.a) {
+			t.Errorf("reflexivity boundary failed for %q", p.a)
+		}
+		ab := versionUpToDate(p.a, p.b)
+		ba := versionUpToDate(p.b, p.a)
+		if !ab && !ba {
+			t.Errorf("totality boundary failed for %q vs %q", p.a, p.b)
+		}
+	}
+}
+
+// TestGoVersionUpToDate_properties mirrors the version invariants for the Go
+// toolchain comparator, including custom-tag normalization.
+func TestGoVersionUpToDate_properties(t *testing.T) {
+	reflexive := func(a semverString) bool {
+		return goVersionUpToDate(string(a), string(a))
+	}
+	if err := quick.Check(reflexive, quickConfig()); err != nil {
+		t.Errorf("reflexivity failed: %v", err)
+	}
+
+	// Equal strings (even with custom separators) are always up to date.
+	for _, s := range []string{"1.25.0-X:nodwarf5", "1.26.0-X~tag", "go-ish"} {
+		if !goVersionUpToDate(s, s) {
+			t.Errorf("goVersionUpToDate(%q,%q) should be reflexive true", s, s)
+		}
+	}
+
+	total := func(a, b semverString) bool {
+		ab := goVersionUpToDate(string(a), string(b))
+		ba := goVersionUpToDate(string(b), string(a))
+		// For parseable, distinct semver-ish strings the comparator is total.
+		return ab || ba
+	}
+	if err := quick.Check(total, quickConfig()); err != nil {
+		t.Errorf("totality failed: %v", err)
+	}
+}
+
+// TestNormalizeGoVersionForCompare_properties asserts the key contract of the
+// normalizer: its output is always parseable by version.NewVersion when the
+// input contained at least one semver-significant character, and normalization
+// is idempotent (normalize(normalize(x)) == normalize(x)).
+func TestNormalizeGoVersionForCompare_properties(t *testing.T) {
+	idempotent := func(a goVersionInput) bool {
+		once := normalizeGoVersionForCompare(string(a))
+		twice := normalizeGoVersionForCompare(once)
+		return once == twice
+	}
+	if err := quick.Check(idempotent, quickConfig()); err != nil {
+		t.Errorf("idempotency failed: %v", err)
+	}
+
+	// Any normalized output of a real-looking Go version string must parse.
+	parseable := func(a semverString) bool {
+		out := normalizeGoVersionForCompare(string(a))
+		_, err := version.NewVersion(out)
+		return err == nil
+	}
+	if err := quick.Check(parseable, quickConfig()); err != nil {
+		t.Errorf("normalized output should be parseable: %v", err)
+	}
+
+	// Custom-tag Go versions must normalize to a parseable form.
+	for _, s := range []string{"1.25.0-X:nodwarf5", "1.26.0-X~nodwarf5", " 1.26.0-X:nodwarf5 "} {
+		out := normalizeGoVersionForCompare(s)
+		if _, err := version.NewVersion(out); err != nil {
+			t.Errorf("normalizeGoVersionForCompare(%q) = %q is not parseable: %v", s, out, err)
+		}
+	}
+}
+
+// goVersionInput generates arbitrary Go version-ish strings (including custom
+// separators like ':' and '~') to exercise normalization idempotency on a wider
+// input space than strictly-parseable semver.
+type goVersionInput string
+
+// Generate implements quick.Generator for goVersionInput.
+func (goVersionInput) Generate(rng *rand.Rand, _ int) reflect.Value {
+	base := fmt.Sprintf("%d.%d.%d", rng.Intn(30), rng.Intn(30), rng.Intn(30))
+	tags := []string{"", "-X:nodwarf5", "-X~tag", "+meta", "-rc.1", " spaced "}
+	return reflect.ValueOf(goVersionInput(base + tags[rng.Intn(len(tags))]))
+}


### PR DESCRIPTION
## Summary

This PR improves the testability of the network-dependent `internal/goutil` helpers and adds property-based tests (PBTs) for the project's pure helpers, addressing issues #301 and #305.

## Issue #301 — Helper-process test seam for goExe-based subprocess calls

Previously the subprocess-driven helpers (`GetLatestVerWithContext`, `InstallMainOrMasterWithContext`, `GetInstalledGoVersion`, etc.) could only be tested by swapping `goExe` to coarse stubs such as `echo`/`false`, which cannot model distinct stdout/stderr/exit-code combinations.

- Added a single, minimal production seam in `internal/goutil/goutil.go`: a package-level `goCommandContext` function variable that builds the `*exec.Cmd` for the go toolchain. Production code is unchanged in behavior (it still runs `goExe` with the given args); only the construction point is now injectable. The `install`, `list -m` and `version` call sites route through it.
- Added `internal/goutil/helperprocess_test.go` implementing the Go standard "helper process" pattern: tests re-exec the test binary with `-test.run=TestHelperProcess` and select stdout/stderr/exit-code behavior via environment variables. `TestHelperProcess` is a no-op during a normal `go test` run.
- New tests cover, with no network access:
  - real version-string output and trailing-newline trimming;
  - the `unknown revision main` stderr branch;
  - the `@main` failure → `@master` fallback (and the both-fail path);
  - distinct stdout vs stderr vs exit-code combinations (stdout ignored on failure, stderr surfaced as the cause);
  - `GetInstalledGoVersion` golden, command-failure, and missing-version-token branches.

A reusable helper-process harness (`withHelperProcess`, `withHelperProcessMainMasterFallback`) is now available for any goExe-based subprocess.

## Issue #305 — Property-based tests (testing/quick) for pure helpers

Added bounded, deterministic-ish `testing/quick` PBTs (MaxCount capped) so they run as part of `go test ./...` without flakiness:

1. **Version comparison** (`internal/goutil/property_test.go`): reflexivity (`upToDate(a,a)==true`), totality/antisymmetry of `versionUpToDate` and `goVersionUpToDate`, and that any output of `normalizeGoVersionForCompare` is parseable by `version.NewVersion` and idempotent. Boundary pairs include numeric carry (`v1.9.0` vs `v1.10.0`), `v1.0` vs `v1.0.0`, and prerelease/build-metadata cases.
2. **Binary-name normalization** (`cmd/property_test.go`): idempotency (`f(f(x))==f(x)`) and the host-specific case/`.exe` contract for `normalizeBinaryNameForMatch`.
3. **Config round-trip** (`internal/config/property_test.go`): for any valid package set, `WriteConfFile` → `ReadConfFile` yields an equivalent set modulo the documented version/channel normalization; plus the empty-set boundary.
4. **`binaryNameFromImportPath`** (`cmd/property_test.go`): never returns a path separator, and is stable for already-normalized input (checked for both linux and windows).

## Verification

- `gofmt -l .` — clean
- `go vet ./...` — pass
- `golangci-lint run` on the changed packages — 0 issues
- `go test ./...` — pass
- `go test -race ./internal/goutil/... ./internal/config/... ./cmd/...` — pass

Closes #301
Closes #305


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added property-based tests for version comparison/normalization, including edge cases and idempotency/ordering guarantees.
  * Added property-based tests for config round-trip serialization, including empty-set handling.
  * Added property-based tests for binary name derivation/normalization with OS-specific expectations.
  * Added a deterministic helper-process test harness to validate subprocess output trimming, error propagation, and fallback behavior.
  * Expanded example test expectations.
* **Refactor**
  * Updated subprocess command construction to be configurable for improved testability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->