### PR TITLE
docs: sync Benchmark, release-integrity, and Migrate sections into all translated READMEs

### DIFF
--- a/doc/es/README.md
+++ b/doc/es/README.md
@@ -64,6 +64,30 @@ nix profile install nixpkgs#gogup
 ### Instalar desde Paquete o Binario
 [La página de releases](https://github.com/nao1215/gup/releases) contiene paquetes en formatos .deb, .rpm y .apk. El comando gup usa el comando go internamente, por lo que se requiere la instalación de golang.
 
+## Verificar la integridad del release
+Cada release incluye metadatos de cadena de suministro para que puedas verificar lo que descargas:
+
+- **Checksums firmados** — `checksums.txt` se firma con [cosign](https://github.com/sigstore/cosign) (sin clave), produciendo `checksums.txt.sig` y `checksums.txt.pem`.
+- **SBOM** — se adjunta un SPDX Software Bill of Materials a cada archivo del release.
+- **Procedencia de la compilación** — la procedencia de compilación SLSA se atestigua mediante GitHub OIDC.
+
+Verifica los checksums firmados (luego comprueba tu archivo contra `checksums.txt`):
+
+```shell
+cosign verify-blob \
+  --certificate checksums.txt.pem \
+  --signature checksums.txt.sig \
+  --certificate-identity-regexp 'https://github.com/nao1215/gup/\.github/workflows/release\.yml@refs/tags/.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  checksums.txt
+sha256sum --check --ignore-missing checksums.txt
+```
+
+Verifica la procedencia de compilación de un artefacto descargado con la CLI de GitHub:
+
+```shell
+gh attestation verify gup_<version>_<os>_<arch>.tar.gz --repo nao1215/gup
+```
 
 ## Cómo usar
 ### Actualizar todos los binarios
@@ -207,6 +231,49 @@ $ gup export --output > gup.json
 $ gup import --file=gup.json
 ```
 
+### Migrar binarios a un nuevo $GOBIN
+
+```shell
+gup migrate BEFORE_PATH AFTER_PATH [BINARY...]
+```
+
+`gup migrate` reinstala los binarios de Go bajo `BEFORE_PATH` en `AFTER_PATH`,
+usando el `import path@version` exacto registrado en la build info de cada binario
+(nunca actualiza silenciosamente a `@latest`). Internamente solo establece `GOBIN`
+en `AFTER_PATH` y ejecuta el flujo normal de `go install`, por lo que los binarios
+se recompilan con el toolchain de Go actualmente en uso.
+
+#### Por qué es útil (p. ej. con `mise`)
+
+Cuando gestionas Go con [`mise`](https://mise.jdx.dev/), actualizar Go puede cambiar
+la ruta real de `$GOBIN` por cada versión de Go. Como resultado, las herramientas que
+instalaste bajo el `$GOBIN` anterior dejan de ser visibles para el nuevo Go.
+`gup migrate` te permite reinstalar el mismo conjunto de herramientas de Go desde el
+`$GOBIN` antiguo en el nuevo:
+
+```shell
+# Reinstalar todas las herramientas go-install del GOBIN antiguo en el GOBIN nuevo
+$ gup migrate ~/.local/share/mise/installs/go/1.24.0/bin ~/.local/share/mise/installs/go/1.25.0/bin
+
+# Migrar solo binarios específicos
+$ gup migrate /old/gobin /new/gobin gopls air
+```
+
+`migrate` es solo de adición (add-only):
+
+- Nunca elimina ni limpia archivos en `AFTER_PATH`.
+- Los binarios que ya existen en `AFTER_PATH` se omiten por defecto. Usa
+  `--force` para reinstalarlos por encima.
+- `AFTER_PATH` se crea automáticamente cuando no existe.
+- `BEFORE_PATH` y `AFTER_PATH` deben ser directorios diferentes.
+
+Los binarios cuyo import path o versión no se puede resolver, y las compilaciones de
+desarrollo (`devel` / `(devel)`), se omiten en lugar de actualizarse, de modo que las
+compilaciones locales o no reproducibles nunca se rompen.
+
+Flags soportados: `--dry-run` (`-n`), `--notify` (`-N`), `--jobs` (`-j`),
+`--force`.
+
 ### Generar páginas de manual (para linux, mac)
 El subcomando man genera páginas de manual bajo /usr/share/man/man1.
 ```shell
@@ -248,6 +315,17 @@ $ gup update --notify
 ![success](../img/notify_success.png)
 ![warning](../img/notify_warning.png)
 
+
+## Benchmark
+gup ejecuta las actualizaciones en paralelo, por lo que termina más rápido que las herramientas que actualizan los binarios de uno en uno. Actualizando 9 binarios que tenían una versión más reciente disponible:
+
+| Herramienta                                                   | Estrategia | Tiempo |
+| ------------------------------------------------------------- | ---------- | -----: |
+| gup update                                                    | paralelo   |   0.7s |
+| [go-global-update](https://github.com/Gelio/go-global-update) | secuencial |   2.9s |
+| bucle `go install`                                            | secuencial |   2.9s |
+
+Medido en AMD Ryzen AI Max+ 395 (32 núcleos) / 64 GB RAM / Ubuntu 26.04 / go 1.26.4, mediana de 5 ejecuciones con la caché de módulos de Go en caliente. Los tiempos dependen del tiempo de compilación de cada binario y de tu CPU.
 
 ## Contribuir
 En primer lugar, ¡gracias por tomarte el tiempo de contribuir! ❤️  Ve [CONTRIBUTING.md](../../CONTRIBUTING.md) para más información.

--- a/doc/fr/README.md
+++ b/doc/fr/README.md
@@ -64,6 +64,30 @@ nix profile install nixpkgs#gogup
 ### Installer depuis un package ou un binaire
 [La page de release](https://github.com/nao1215/gup/releases) contient des packages aux formats .deb, .rpm et .apk. La commande gup utilise la commande go en interne, donc l'installation de golang est requise.
 
+## Vérifier l'intégrité de la release
+Chaque release est accompagnée de métadonnées de chaîne d'approvisionnement afin que vous puissiez vérifier ce que vous téléchargez :
+
+- **Sommes de contrôle signées** — `checksums.txt` est signé avec [cosign](https://github.com/sigstore/cosign) (sans clé), produisant `checksums.txt.sig` et `checksums.txt.pem`.
+- **SBOM** — un SPDX Software Bill of Materials est joint à chaque archive de release.
+- **Provenance de build** — la provenance de build SLSA est attestée via GitHub OIDC.
+
+Vérifiez les sommes de contrôle signées (puis comparez votre archive à `checksums.txt`) :
+
+```shell
+cosign verify-blob \
+  --certificate checksums.txt.pem \
+  --signature checksums.txt.sig \
+  --certificate-identity-regexp 'https://github.com/nao1215/gup/\.github/workflows/release\.yml@refs/tags/.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  checksums.txt
+sha256sum --check --ignore-missing checksums.txt
+```
+
+Vérifiez la provenance de build d'un artefact téléchargé avec la CLI GitHub :
+
+```shell
+gh attestation verify gup_<version>_<os>_<arch>.tar.gz --repo nao1215/gup
+```
 
 ## Comment utiliser
 ### Mettre à jour tous les binaires
@@ -207,6 +231,49 @@ $ gup export --output > gup.json
 $ gup import --file=gup.json
 ```
 
+### Migrer les binaires vers un nouveau $GOBIN
+
+```shell
+gup migrate BEFORE_PATH AFTER_PATH [BINARY...]
+```
+
+`gup migrate` réinstalle les binaires Go situés sous `BEFORE_PATH` dans `AFTER_PATH`,
+en utilisant le `import path@version` exact enregistré dans la build info de chaque
+binaire (il ne met jamais silencieusement à niveau vers `@latest`). En interne, il
+définit simplement `GOBIN` sur `AFTER_PATH` et exécute le flux normal de `go install`,
+de sorte que les binaires sont recompilés avec la toolchain Go actuellement utilisée.
+
+#### Pourquoi c'est utile (par exemple avec `mise`)
+
+Lorsque vous gérez Go avec [`mise`](https://mise.jdx.dev/), mettre à jour Go peut
+changer le chemin réel de `$GOBIN` pour chaque version de Go. Par conséquent, les
+outils que vous avez installés sous le `$GOBIN` précédent ne sont plus visibles pour
+le nouveau Go. `gup migrate` vous permet de réinstaller le même ensemble d'outils Go
+de l'ancien `$GOBIN` vers le nouveau :
+
+```shell
+# Réinstaller tous les outils go-install de l'ancien GOBIN vers le nouveau GOBIN
+$ gup migrate ~/.local/share/mise/installs/go/1.24.0/bin ~/.local/share/mise/installs/go/1.25.0/bin
+
+# Migrer uniquement des binaires spécifiques
+$ gup migrate /old/gobin /new/gobin gopls air
+```
+
+`migrate` fonctionne uniquement en ajout (add-only) :
+
+- Il ne supprime ni ne nettoie jamais les fichiers dans `AFTER_PATH`.
+- Les binaires qui existent déjà dans `AFTER_PATH` sont ignorés par défaut. Utilisez
+  `--force` pour les réinstaller par-dessus.
+- `AFTER_PATH` est créé automatiquement lorsqu'il n'existe pas.
+- `BEFORE_PATH` et `AFTER_PATH` doivent être des répertoires différents.
+
+Les binaires dont l'import path ou la version ne peut pas être résolu, ainsi que les
+builds de développement (`devel` / `(devel)`), sont ignorés au lieu d'être mis à
+niveau, de sorte que les builds locaux ou non reproductibles ne sont jamais cassés.
+
+Flags pris en charge : `--dry-run` (`-n`), `--notify` (`-N`), `--jobs` (`-j`),
+`--force`.
+
 ### Générer les pages de manuel (pour linux, mac)
 La sous-commande man génère les pages de manuel sous /usr/share/man/man1.
 ```shell
@@ -248,6 +315,17 @@ $ gup update --notify
 ![success](../img/notify_success.png)
 ![warning](../img/notify_warning.png)
 
+
+## Benchmark
+gup exécute les mises à jour en parallèle, il termine donc plus vite que les outils qui mettent à jour les binaires un par un. Mise à jour de 9 binaires pour lesquels une version plus récente était disponible :
+
+| Outil                                                         | Stratégie    | Temps |
+| ------------------------------------------------------------- | ------------ | ----: |
+| gup update                                                    | parallèle    |  0.7s |
+| [go-global-update](https://github.com/Gelio/go-global-update) | séquentielle |  2.9s |
+| boucle `go install`                                           | séquentielle |  2.9s |
+
+Mesuré sur AMD Ryzen AI Max+ 395 (32 cœurs) / 64 Go de RAM / Ubuntu 26.04 / go 1.26.4, médiane de 5 exécutions avec un cache de modules Go chaud. Les temps dépendent du temps de build de chaque binaire et de votre CPU.
 
 ## Contribuer
 Tout d'abord, merci de prendre le temps de contribuer ! ❤️  Voir [CONTRIBUTING.md](../../CONTRIBUTING.md) pour plus d'informations.

--- a/doc/ko/README.md
+++ b/doc/ko/README.md
@@ -64,6 +64,30 @@ nix profile install nixpkgs#gogup
 ### 패키지 또는 바이너리에서 설치
 [릴리스 페이지](https://github.com/nao1215/gup/releases)에는 .deb, .rpm, .apk 형식의 패키지가 포함되어 있습니다. gup 명령어는 내부적으로 go 명령어를 사용하므로 golang 설치가 필요합니다.
 
+## 릴리스 무결성 검증
+모든 릴리스에는 다운로드한 항목을 검증할 수 있도록 공급망 메타데이터가 함께 제공됩니다.
+
+- **서명된 체크섬** — `checksums.txt`는 [cosign](https://github.com/sigstore/cosign)(키리스)으로 서명되어 `checksums.txt.sig`와 `checksums.txt.pem`을 생성합니다.
+- **SBOM** — 각 릴리스 아카이브에 SPDX 소프트웨어 자재 명세서(Software Bill of Materials)가 첨부됩니다.
+- **빌드 출처** — SLSA 빌드 출처(provenance)는 GitHub OIDC를 통해 증명됩니다.
+
+서명된 체크섬을 검증하세요(그런 다음 아카이브를 `checksums.txt`와 대조하세요).
+
+```shell
+cosign verify-blob \
+  --certificate checksums.txt.pem \
+  --signature checksums.txt.sig \
+  --certificate-identity-regexp 'https://github.com/nao1215/gup/\.github/workflows/release\.yml@refs/tags/.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  checksums.txt
+sha256sum --check --ignore-missing checksums.txt
+```
+
+GitHub CLI로 다운로드한 아티팩트의 빌드 출처를 검증하세요.
+
+```shell
+gh attestation verify gup_<version>_<os>_<arch>.tar.gz --repo nao1215/gup
+```
 
 ## 사용 방법
 ### 모든 바이너리 업데이트
@@ -206,6 +230,47 @@ $ gup export --output > gup.json
 $ gup import --file=gup.json
 ```
 
+### 바이너리를 새 $GOBIN으로 마이그레이션
+
+```shell
+gup migrate BEFORE_PATH AFTER_PATH [BINARY...]
+```
+
+`gup migrate`는 각 바이너리의 빌드 정보에 기록된 정확한 `import path@version`을
+사용하여 `BEFORE_PATH` 아래의 Go 바이너리를 `AFTER_PATH`로 다시 설치합니다
+(절대로 조용히 `@latest`로 업그레이드하지 않습니다). 내부적으로는 단순히
+`GOBIN`을 `AFTER_PATH`로 설정하고 일반적인 `go install` 경로를 실행하므로,
+바이너리는 현재 사용 중인 Go 툴체인으로 다시 빌드됩니다.
+
+#### 이것이 유용한 이유 (예: `mise`와 함께)
+
+[`mise`](https://mise.jdx.dev/)로 Go를 관리할 때, Go를 업데이트하면 Go 버전마다
+`$GOBIN`의 실제 경로가 바뀔 수 있습니다. 그 결과 이전 `$GOBIN` 아래에 설치한
+도구들이 새 Go에서는 더 이상 보이지 않게 됩니다. `gup migrate`를 사용하면
+이전 `$GOBIN`의 동일한 Go 도구 세트를 새 `$GOBIN`으로 다시 설치할 수 있습니다.
+
+```shell
+# 이전 GOBIN의 모든 go-install 도구를 새 GOBIN으로 다시 설치
+$ gup migrate ~/.local/share/mise/installs/go/1.24.0/bin ~/.local/share/mise/installs/go/1.25.0/bin
+
+# 특정 바이너리만 마이그레이션
+$ gup migrate /old/gobin /new/gobin gopls air
+```
+
+`migrate`는 추가 전용(add-only)입니다.
+
+- `AFTER_PATH`의 파일을 삭제하거나 정리하지 않습니다.
+- `AFTER_PATH`에 이미 존재하는 바이너리는 기본적으로 건너뜁니다. 덮어쓰며 다시
+  설치하려면 `--force`를 사용하세요.
+- `AFTER_PATH`가 존재하지 않으면 자동으로 생성됩니다.
+- `BEFORE_PATH`와 `AFTER_PATH`는 서로 다른 디렉터리여야 합니다.
+
+import path 또는 버전을 확인할 수 없는 바이너리와 개발 빌드(`devel` / `(devel)`)는
+업그레이드되지 않고 건너뛰므로, 로컬 또는 재현 불가능한 빌드는 절대 깨지지 않습니다.
+
+지원되는 플래그: `--dry-run` (`-n`), `--notify` (`-N`), `--jobs` (`-j`),
+`--force`.
+
 ### man 페이지 생성 (linux, mac용)
 man 하위 명령어는 /usr/share/man/man1 아래에 man 페이지를 생성합니다.
 ```shell
@@ -247,6 +312,17 @@ $ gup update --notify
 ![success](../img/notify_success.png)
 ![warning](../img/notify_warning.png)
 
+
+## 벤치마크
+gup은 업데이트를 병렬로 실행하므로 바이너리를 하나씩 업데이트하는 도구보다 더 빠르게 완료됩니다. 각각 새 버전이 제공되는 9개의 바이너리를 업데이트한 경우:
+
+| 도구                                                          | 전략     | 시간 |
+| ------------------------------------------------------------- | -------- | ---: |
+| gup update                                                    | 병렬     | 0.7s |
+| [go-global-update](https://github.com/Gelio/go-global-update) | 순차     | 2.9s |
+| `go install` 루프                                             | 순차     | 2.9s |
+
+AMD Ryzen AI Max+ 395(32코어) / 64GB RAM / Ubuntu 26.04 / go 1.26.4에서 측정했으며, Go 모듈 캐시를 워밍업한 상태로 5회 실행한 중앙값입니다. 시간은 각 바이너리의 빌드 시간과 CPU에 따라 달라집니다.
 
 ## 기여하기
 먼저 기여할 시간을 내주셔서 감사합니다! ❤️ 자세한 내용은 [CONTRIBUTING.md](../../CONTRIBUTING.md)를 참조하세요.

--- a/doc/ru/README.md
+++ b/doc/ru/README.md
@@ -64,6 +64,30 @@ nix profile install nixpkgs#gogup
 ### Установка из пакета или бинарного файла
 [Страница релизов](https://github.com/nao1215/gup/releases) содержит пакеты в форматах .deb, .rpm и .apk. Команда gup использует команду go внутренне, поэтому требуется установка golang.
 
+## Проверка целостности релиза
+Каждый релиз поставляется с метаданными цепочки поставок, чтобы вы могли проверить то, что скачиваете:
+
+- **Подписанные контрольные суммы** — `checksums.txt` подписан с помощью [cosign](https://github.com/sigstore/cosign) (без ключей), создавая `checksums.txt.sig` и `checksums.txt.pem`.
+- **SBOM** — к каждому архиву релиза прикреплена SPDX Software Bill of Materials.
+- **Происхождение сборки** — происхождение сборки SLSA удостоверяется через GitHub OIDC.
+
+Проверьте подписанные контрольные суммы (затем сверьте свой архив с `checksums.txt`):
+
+```shell
+cosign verify-blob \
+  --certificate checksums.txt.pem \
+  --signature checksums.txt.sig \
+  --certificate-identity-regexp 'https://github.com/nao1215/gup/\.github/workflows/release\.yml@refs/tags/.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  checksums.txt
+sha256sum --check --ignore-missing checksums.txt
+```
+
+Проверьте происхождение сборки скачанного артефакта с помощью GitHub CLI:
+
+```shell
+gh attestation verify gup_<version>_<os>_<arch>.tar.gz --repo nao1215/gup
+```
 
 ## Как использовать
 ### Обновить все бинарные файлы
@@ -207,6 +231,49 @@ $ gup export --output > gup.json
 $ gup import --file=gup.json
 ```
 
+### Перенос бинарных файлов в новый $GOBIN
+
+```shell
+gup migrate BEFORE_PATH AFTER_PATH [BINARY...]
+```
+
+`gup migrate` переустанавливает Go-бинарные файлы из `BEFORE_PATH` в `AFTER_PATH`,
+используя точный `import path@version`, записанный в build info каждого бинарного
+файла (он никогда не выполняет тихое обновление до `@latest`). Внутренне он просто
+устанавливает `GOBIN` в `AFTER_PATH` и запускает обычный путь `go install`, поэтому
+бинарные файлы пересобираются с текущим используемым тулчейном Go.
+
+#### Чем это полезно (например, с `mise`)
+
+Когда вы управляете Go с помощью [`mise`](https://mise.jdx.dev/), обновление Go
+может изменить реальный путь `$GOBIN` для каждой версии Go. В результате
+инструменты, установленные под предыдущим `$GOBIN`, больше не видны новому Go.
+`gup migrate` позволяет переустановить тот же набор Go-инструментов из старого
+`$GOBIN` в новый:
+
+```shell
+# Переустановить все go-install инструменты из старого GOBIN в новый GOBIN
+$ gup migrate ~/.local/share/mise/installs/go/1.24.0/bin ~/.local/share/mise/installs/go/1.25.0/bin
+
+# Перенести только указанные бинарные файлы
+$ gup migrate /old/gobin /new/gobin gopls air
+```
+
+`migrate` работает только на добавление:
+
+- Он никогда не удаляет и не очищает файлы в `AFTER_PATH`.
+- Бинарные файлы, которые уже существуют в `AFTER_PATH`, по умолчанию пропускаются.
+  Используйте `--force`, чтобы переустановить их поверх.
+- `AFTER_PATH` создаётся автоматически, если он не существует.
+- `BEFORE_PATH` и `AFTER_PATH` должны быть разными каталогами.
+
+Бинарные файлы, чей import path или версию невозможно определить, а также
+сборки для разработки (`devel` / `(devel)`), пропускаются, а не обновляются,
+поэтому локальные или невоспроизводимые сборки никогда не ломаются.
+
+Поддерживаемые флаги: `--dry-run` (`-n`), `--notify` (`-N`), `--jobs` (`-j`),
+`--force`.
+
 ### Генерировать man-страницы (для linux, mac)
 Подкоманда man генерирует man-страницы в /usr/share/man/man1.
 ```shell
@@ -248,6 +315,17 @@ $ gup update --notify
 ![success](../img/notify_success.png)
 ![warning](../img/notify_warning.png)
 
+
+## Бенчмарк
+gup выполняет обновления параллельно, поэтому завершает работу быстрее, чем инструменты, обновляющие бинарные файлы по одному. Обновление 9 бинарных файлов, для каждого из которых была доступна более новая версия:
+
+| Инструмент                                                    | Стратегия    | Время |
+| ------------------------------------------------------------- | ------------ | ----: |
+| gup update                                                    | параллельно  |  0.7s |
+| [go-global-update](https://github.com/Gelio/go-global-update) | последовательно | 2.9s |
+| цикл `go install`                                             | последовательно | 2.9s |
+
+Измерено на AMD Ryzen AI Max+ 395 (32 ядра) / 64 ГБ ОЗУ / Ubuntu 26.04 / go 1.26.4, медиана из 5 запусков с прогретым кешем модулей Go. Время зависит от времени сборки каждого бинарного файла и вашего CPU.
 
 ## Участие в проекте
 Прежде всего, спасибо за то, что уделяете время участию! ❤️  Смотрите [CONTRIBUTING.md](../../CONTRIBUTING.md) для получения дополнительной информации.

--- a/doc/zh-cn/README.md
+++ b/doc/zh-cn/README.md
@@ -64,6 +64,30 @@ nix profile install nixpkgs#gogup
 ### 从包或二进制文件安装
 [发布页面](https://github.com/nao1215/gup/releases)包含 .deb、.rpm 和 .apk 格式的包。gup 命令内部使用 go 命令，因此需要安装 golang。
 
+## 验证发布完整性
+每个发布版本都附带供应链元数据，以便您验证所下载的内容：
+
+- **已签名的校验和** — `checksums.txt` 使用 [cosign](https://github.com/sigstore/cosign)（无密钥）签名，生成 `checksums.txt.sig` 和 `checksums.txt.pem`。
+- **SBOM** — 每个发布归档都附有 SPDX 软件物料清单（Software Bill of Materials）。
+- **构建溯源** — 通过 GitHub OIDC 对 SLSA 构建溯源进行证明。
+
+验证已签名的校验和（然后将您的归档与 `checksums.txt` 进行核对）：
+
+```shell
+cosign verify-blob \
+  --certificate checksums.txt.pem \
+  --signature checksums.txt.sig \
+  --certificate-identity-regexp 'https://github.com/nao1215/gup/\.github/workflows/release\.yml@refs/tags/.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  checksums.txt
+sha256sum --check --ignore-missing checksums.txt
+```
+
+使用 GitHub CLI 验证已下载工件的构建溯源：
+
+```shell
+gh attestation verify gup_<version>_<os>_<arch>.tar.gz --repo nao1215/gup
+```
 
 ## 如何使用
 ### 更新所有二进制文件
@@ -207,6 +231,48 @@ $ gup export --output > gup.json
 $ gup import --file=gup.json
 ```
 
+### 将二进制文件迁移到新的 $GOBIN
+
+```shell
+gup migrate BEFORE_PATH AFTER_PATH [BINARY...]
+```
+
+`gup migrate` 会将 `BEFORE_PATH` 下的 Go 二进制文件重新安装到 `AFTER_PATH`，
+使用每个二进制文件构建信息中记录的精确 `import path@version`
+（它绝不会悄悄升级到 `@latest`）。在内部，它只是将 `GOBIN` 设置为
+`AFTER_PATH` 并运行常规的 `go install` 流程，因此这些二进制文件会
+使用当前正在使用的 Go 工具链重新构建。
+
+#### 为什么这很有用（例如配合 `mise`）
+
+当您使用 [`mise`](https://mise.jdx.dev/) 管理 Go 时，更新 Go 可能会
+改变每个 Go 版本对应的 `$GOBIN` 实际路径。结果，您在之前的
+`$GOBIN` 下安装的工具对新的 Go 不再可见。`gup migrate`
+让您可以将相同的 Go 工具集从旧的 `$GOBIN` 重新安装到新的 `$GOBIN`：
+
+```shell
+# 将所有 go-install 工具从旧的 GOBIN 重新安装到新的 GOBIN
+$ gup migrate ~/.local/share/mise/installs/go/1.24.0/bin ~/.local/share/mise/installs/go/1.25.0/bin
+
+# 仅迁移特定的二进制文件
+$ gup migrate /old/gobin /new/gobin gopls air
+```
+
+`migrate` 是仅追加的：
+
+- 它绝不会删除或清理 `AFTER_PATH` 中的文件。
+- `AFTER_PATH` 中已存在的二进制文件默认会被跳过。使用
+  `--force` 可以覆盖重新安装它们。
+- 当 `AFTER_PATH` 不存在时会自动创建。
+- `BEFORE_PATH` 和 `AFTER_PATH` 必须是不同的目录。
+
+无法解析 import path 或版本的二进制文件，以及开发版构建
+（`devel` / `(devel)`），会被跳过而不是被升级，因此本地或
+不可复现的构建永远不会被破坏。
+
+支持的标志：`--dry-run` (`-n`)、`--notify` (`-N`)、`--jobs` (`-j`)、
+`--force`。
+
 ### 生成手册页（适用于 linux、mac）
 man 子命令在 /usr/share/man/man1 下生成手册页。
 ```shell
@@ -248,6 +314,17 @@ $ gup update --notify
 ![success](../img/notify_success.png)
 ![warning](../img/notify_warning.png)
 
+
+## 基准测试
+gup 并行运行更新，因此比一次更新一个二进制文件的工具完成得更快。更新 9 个各自都有新版本可用的二进制文件：
+
+| 工具                                                          | 策略     | 时间 |
+| ------------------------------------------------------------- | -------- | ---: |
+| gup update                                                    | 并行     | 0.7s |
+| [go-global-update](https://github.com/Gelio/go-global-update) | 顺序     | 2.9s |
+| `go install` 循环                                             | 顺序     | 2.9s |
+
+在 AMD Ryzen AI Max+ 395（32 核）/ 64 GB 内存 / Ubuntu 26.04 / go 1.26.4 上测量，5 次运行的中位数，Go 模块缓存已预热。时间取决于每个二进制文件的构建时间和您的 CPU。
 
 ## 贡献
 首先，感谢您抽出时间来贡献！❤️ 更多信息请查看 [CONTRIBUTING.md](../../CONTRIBUTING.md)。

--- a/doc_sync_test.go
+++ b/doc_sync_test.go
@@ -52,6 +52,66 @@ func Test_englishReadme_hasRequiredSections(t *testing.T) {
 	}
 }
 
+// Test_translatedReadmes_haveRequiredSections asserts that every section the
+// English README carries (issue #306: Benchmark, release integrity, Migrate) is
+// also present in each translation, keyed off language-independent content so a
+// missing section is caught even though headings are translated.
+func Test_translatedReadmes_haveRequiredSections(t *testing.T) {
+	t.Parallel()
+	// requiredSectionMarkers maps a human-readable section name to a set of
+	// language-independent strings that the section's content always carries
+	// verbatim, regardless of the translation language. Section HEADINGS are fully
+	// translated (e.g. "## Benchmark" becomes "## 基准测试" / "## Бенчмарк"), so we
+	// cannot key the presence check off heading text. Instead we key off the
+	// stable, untranslated payload each section is built around: shell commands,
+	// URLs, tool names, and the literal command synopsis. These are identical in
+	// every README, so their presence is a robust proxy for "this section exists,
+	// translated, in this file". The test fails if any translation drops one of the
+	// sections the English README carries (issue #306).
+	requiredSectionMarkers := map[string][]string{
+		// Benchmark: the comparison table and measurement note.
+		"Benchmark": {
+			"https://github.com/Gelio/go-global-update", // benchmarked competitor (table row)
+			"AMD Ryzen AI Max+ 395",                     // measurement environment note
+		},
+		// Verifying release integrity: the cosign / SLSA verification commands.
+		"Verifying release integrity": {
+			"cosign verify-blob",                  // signed-checksum verification command
+			"gh attestation verify gup_<version>", // SLSA build-provenance command
+		},
+		// Migrate: the command synopsis and the mise rationale link.
+		"Migrate": {
+			"gup migrate BEFORE_PATH AFTER_PATH [BINARY...]", // command synopsis
+			"https://mise.jdx.dev/",                          // "why this is useful" link
+		},
+	}
+	translatedREADMEs := []string{
+		"doc/ja/README.md",
+		"doc/es/README.md",
+		"doc/fr/README.md",
+		"doc/ko/README.md",
+		"doc/ru/README.md",
+		"doc/zh-cn/README.md",
+	}
+	for _, path := range translatedREADMEs {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+			raw, err := os.ReadFile(path) //nolint:gosec // fixed in-repo doc path
+			if err != nil {
+				t.Fatalf("failed to read %s: %v", path, err)
+			}
+			content := string(raw)
+			for section, markers := range requiredSectionMarkers {
+				for _, marker := range markers {
+					if !strings.Contains(content, marker) {
+						t.Errorf("%s is missing the %q section: expected to find %q", path, section, marker)
+					}
+				}
+			}
+		})
+	}
+}
+
 func Test_translatedReadmes_haveSyncBanner(t *testing.T) {
 	t.Parallel()
 	// translatedREADMEs are the localized READMEs that must stay in sync with, or


### PR DESCRIPTION
## Overview

Addresses #306. Several sections present in the English `README.md` were missing entirely from the five translated READMEs (`doc/ru`, `doc/zh-cn`, `doc/ko`, `doc/es`, `doc/fr`), so the strongest selling points were unreadable for most of gup's (majority non-English) audience.

## Changes

- Translate and insert the three missing sections into all five translations, at the same relative position as in the English README:
  - **Benchmark** (parallel-update speed comparison)
  - **Verifying release integrity** (cosign / SBOM / SLSA)
  - **Migrate** (detailed `gup migrate` explanation)
  - Code blocks, commands, table structure, and technical terms (cosign, SBOM, SLSA) are kept intact; prose is translated into each target language.
- Extend `doc_sync_test.go` with `Test_translatedReadmes_haveRequiredSections`, which fails when a translation is missing one of these sections. Because section headings are fully translated (no stable anchors), the check keys off language-independent payload each section always carries verbatim (e.g. `cosign verify-blob`, `gup migrate BEFORE_PATH AFTER_PATH [BINARY...]`, the benchmark table identifiers), documented in a comment.

## Verification

- `golangci-lint run ./...` → 0 issues
- `gofmt -l .` clean, `go vet ./...` clean
- `go test ./...` all green (new test: all subtests pass across ja/es/fr/ko/ru/zh-cn)

Closes #306