### PR TITLE
chore: prepare v1.4.0 release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -89,7 +89,7 @@ signs:
     output: true
 nfpms:
   - maintainer: 'Naohiro CHIKAMATSU <n.chika156@gmail.com>'
-    description: 'Manage Go-installed binaries in $GOBIN: update, export/import, and migrate your toolset across machines'
+    description: 'Fast manager for Go-installed binaries in $GOBIN: update, export/import, and migrate toolsets across machines'
     homepage: https://github.com/nao1215/gup
     license: Apache License 2.0
     formats:
@@ -111,7 +111,7 @@ nfpms:
           mode: 0644
 brews:
   - name: gup
-    description: 'Manage Go-installed binaries in $GOBIN: update, export/import, and migrate your toolset across machines'
+    description: 'Fast manager for Go-installed binaries in $GOBIN: update, export/import, and migrate toolsets across machines'
     license: Apache License 2.0
     repository:
       owner: nao1215

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -89,7 +89,7 @@ signs:
     output: true
 nfpms:
   - maintainer: 'Naohiro CHIKAMATSU <n.chika156@gmail.com>'
-    description: gup - Fast parallel updater and manager for binaries installed with 'go install'
+    description: 'Manage Go-installed binaries in $GOBIN: update, export/import, and migrate your toolset across machines'
     homepage: https://github.com/nao1215/gup
     license: Apache License 2.0
     formats:
@@ -111,7 +111,7 @@ nfpms:
           mode: 0644
 brews:
   - name: gup
-    description: gup - Fast parallel updater and manager for binaries installed with 'go install'
+    description: 'Manage Go-installed binaries in $GOBIN: update, export/import, and migrate your toolset across machines'
     license: Apache License 2.0
     repository:
       owner: nao1215

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,35 @@
+## [v1.4.0](https://github.com/nao1215/gup/compare/v1.3.1...v1.4.0) (2026-06-22)
+
+### Features
+
+* Add a top-level `--version`/`-V` flag in addition to the existing `gup version` subcommand. (#326)
+* Add a `--quiet`/`-q` output mode to `check` and `update` that hides the up-to-date lines and prints only changed/updatable binaries, failures, and a one-line summary. Errors still go to STDERR. (#290)
+* Respect the [`NO_COLOR`](https://no-color.org/) environment variable and add a `--no-color` flag to disable colorized output. (#309)
+* Show concise, actionable guidance (the correct usage line) when a required argument is missing, instead of dumping the full help. (#324)
+
+### Bug Fixes
+
+* `gup remove` now fails fast with a clear message in non-interactive execution (when stdin is not a TTY, e.g. CI or a pipe) instead of blocking on stdin or surfacing a raw `EOF`. `--force` still skips confirmation. (#323)
+* Normalize an `unknown`/`(devel)`/empty binary version to `latest` before persisting it to `gup.json`, so later `gup update` runs resolve the package correctly. (#300)
+* Classify binaries by their main module path instead of a dotless-import-path heuristic, fixing the misclassification of tools whose host has no dot (e.g. internal registries). (#299)
+
+### Documentation
+
+* Add practical examples to the root command and the major subcommands' help. (#325)
+* Sync the Benchmark, release-integrity, and Migrate sections into all five translated READMEs, and add a test that fails when a translation is missing one of these sections. (#306)
+* Document the top-level `--version` flag, the non-TTY `remove` behavior, and the `--json`/`--quiet` precedence in the README.
+
+### Tests
+
+* Add a helper-process test seam for `goExe`-based subprocess calls, plus property-based tests for version comparison, name normalization, and config round-trip. (#301, #305)
+* Cover parallel-execution invariants: result count, timeout isolation, and CPU clamping. (#304)
+* Make `config_file` rename injectable and cover the backup-swap restore-failure worst case. (#302)
+* Add a property-based test for the path-traversal guard in `gup remove`. (#303)
+
+### Others
+
+* Tidy help-text consistency (flag-description casing, `Short` punctuation, example indentation) and give the non-interactive `remove` error a labeled STDERR message.
+
 ## [v1.3.1](https://github.com/nao1215/gup/compare/v1.3.0...v1.3.1) (2026-06-21)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ gh attestation verify gup_<version>_<os>_<arch>.tar.gz --repo nao1215/gup
 ```
 
 ## How to use
+### Check the gup version
+Print the version with either the `version` subcommand or the top-level `--version`/`-V` flag.
+```shell
+$ gup --version
+$ gup version
+```
+
 ### Update all binaries
 `gup update` updates every binary under `$GOBIN`, in parallel.
 
@@ -138,6 +145,8 @@ $ gup remove --force gal
 removed /home/nao/.go/bin/gal
 ```
 
+In non-interactive execution (when stdin is not a TTY, e.g. CI or a pipe), `gup remove` no longer blocks waiting for confirmation. It fails fast with a clear message; pass `--force` to remove without confirmation.
+
 ### Check if the binary is the latest version
 If you want to know if the binary is the latest version, use the check subcommand. check subcommand checks if the binary is the latest version and displays the name of the binary that needs to be updated.
 ```shell
@@ -164,7 +173,7 @@ If you want to update binaries, the following command.
 ```
 
 ### Quiet output for large tool sets
-`check` and `update` print every binary by default, which is noisy when you have many tools installed. Pass `--quiet` (`-q`) to suppress the up-to-date lines and show only the binaries that were updated (or have an update available) plus failures, followed by a one-line summary. Errors are always written to STDERR, so they stay visible.
+`check` and `update` print every binary by default, which is noisy when you have many tools installed. Pass `--quiet` (`-q`) to suppress the up-to-date lines and show only the binaries that were updated (or have an update available) plus failures, followed by a one-line summary. Errors are always written to STDERR, so they stay visible. When `--json` is also given, `--quiet` is ignored and the full JSON array is printed.
 ```shell
 $ gup update --quiet
 github.com/nao1215/gup (v0.7.0 to v0.7.1)

--- a/cmd/bug_report.go
+++ b/cmd/bug_report.go
@@ -15,7 +15,7 @@ func newBugReportCmd() *cobra.Command {
 		Use:               "bug-report",
 		Short:             "Submit a bug report at GitHub",
 		Long:              "bug-report opens the default browser to start a bug report which will include useful system information.",
-		Example:           "   gup bug-report",
+		Example:           "  gup bug-report",
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -31,11 +31,11 @@ It does not update them.`,
 		},
 	}
 
-	cmd.Flags().IntP("jobs", "j", runtime.NumCPU(), "Specify the number of CPU cores to use")
+	cmd.Flags().IntP("jobs", "j", runtime.NumCPU(), "specify the number of CPU cores to use")
 	if err := cmd.RegisterFlagCompletionFunc("jobs", completeNCPUs); err != nil {
 		panic(err)
 	}
-	cmd.Flags().Bool("ignore-go-update", false, "Ignore updates to the Go toolchain")
+	cmd.Flags().Bool("ignore-go-update", false, "ignore updates to the Go toolchain")
 	cmd.Flags().Bool("json", false, "output result as machine-readable JSON")
 	cmd.Flags().BoolP("quiet", "q", false, "suppress up-to-date lines; show only update-available/failed binaries plus a summary")
 	addTimeoutFlag(cmd)

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -10,7 +10,7 @@ import (
 func newExportCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "export",
-		Short: "Export installed binaries and their versions under $GOPATH/bin or $GOBIN to gup.json.",
+		Short: "Export installed binaries and their versions under $GOPATH/bin or $GOBIN to gup.json",
 		Long: `Export installed binaries and their versions under $GOPATH/bin or $GOBIN to gup.json.
 
 Use export/import if you want to install the same Go binaries

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -20,7 +20,7 @@ var installByVersionCtx = goutil.InstallWithContext //nolint:gochecknoglobals //
 func newImportCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "import",
-		Short: "Install commands according to gup.json.",
+		Short: "Install commands according to gup.json",
 		Long: `Install commands according to gup.json.
 
 Use export/import if you want to install the same Go binaries
@@ -43,7 +43,7 @@ versions recorded in that gup.json.`,
 	if err := cmd.MarkFlagFilename("file", "json"); err != nil {
 		panic(err)
 	}
-	cmd.Flags().IntP("jobs", "j", runtime.NumCPU(), "Specify the number of CPU cores to use")
+	cmd.Flags().IntP("jobs", "j", runtime.NumCPU(), "specify the number of CPU cores to use")
 	if err := cmd.RegisterFlagCompletionFunc("jobs", completeNCPUs); err != nil {
 		panic(err)
 	}

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -67,7 +67,7 @@ If BINARY arguments are given, only those binaries are migrated.`,
 
 	cmd.Flags().BoolP("dry-run", "n", false, "perform the trial migration with no changes")
 	cmd.Flags().BoolP("notify", "N", false, "enable desktop notifications")
-	cmd.Flags().IntP("jobs", "j", runtime.NumCPU(), "Specify the number of CPU cores to use")
+	cmd.Flags().IntP("jobs", "j", runtime.NumCPU(), "specify the number of CPU cores to use")
 	if err := cmd.RegisterFlagCompletionFunc("jobs", completeNCPUs); err != nil {
 		panic(err)
 	}

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -32,7 +32,7 @@ If you want to specify multiple binaries at once, separate them with space.
 			OsExit(remove(cmd, args))
 		},
 	}
-	cmd.Flags().BoolP("force", "f", false, "Forcibly remove the file")
+	cmd.Flags().BoolP("force", "f", false, "forcibly remove the file")
 
 	return cmd
 }

--- a/cmd/testdata/bug_report/bug_report.txt
+++ b/cmd/testdata/bug_report/bug_report.txt
@@ -4,7 +4,7 @@ Usage:
   gup bug-report [flags]
 
 Examples:
-   gup bug-report
+  gup bug-report
 
 Flags:
   -h, --help   help for bug-report

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -65,11 +65,11 @@ using the current installed Go toolchain.`,
 		panic(err)
 	}
 	// cmd.Flags().BoolP("main-all", "M", false, "update all binaries by @main or @master (delimiter: ',')")
-	cmd.Flags().IntP("jobs", "j", runtime.NumCPU(), "Specify the number of CPU cores to use")
+	cmd.Flags().IntP("jobs", "j", runtime.NumCPU(), "specify the number of CPU cores to use")
 	if err := cmd.RegisterFlagCompletionFunc("jobs", completeNCPUs); err != nil {
 		panic(err)
 	}
-	cmd.Flags().Bool("ignore-go-update", false, "Ignore updates to the Go toolchain")
+	cmd.Flags().Bool("ignore-go-update", false, "ignore updates to the Go toolchain")
 	cmd.Flags().Bool("json", false, "output result as machine-readable JSON")
 	cmd.Flags().BoolP("quiet", "q", false, "suppress up-to-date lines; show only updated/failed binaries plus a summary")
 	addTimeoutFlag(cmd)

--- a/internal/print/print.go
+++ b/internal/print/print.go
@@ -70,7 +70,7 @@ func Question(ask string) bool {
 			if strings.Contains(err.Error(), "expected newline") {
 				return true
 			}
-			fmt.Fprint(os.Stderr, err.Error())
+			Err(err)
 			return false
 		}
 


### PR DESCRIPTION
## Overview

Release-preparation PR for **v1.4.0** (minor bump from v1.3.1). Since v1.3.1, several backward-compatible features and fixes have landed (top-level `--version`, `--quiet`, `NO_COLOR`/`--no-color`, actionable arg errors, plus #299/#300 fixes and a large test/doc sweep), which warrants a minor version per SemVer.

A full code + docs review of the unreleased changes was done first; no release blockers were found. This PR bundles the CHANGELOG, doc updates, and the low-risk cleanups surfaced by that review.

## Changes

### CHANGELOG
- Add the `v1.4.0` section (Features / Bug Fixes / Documentation / Tests / Others) summarizing all 45 unreleased commits.

### Documentation (README)
- Document the top-level `--version`/`-V` flag.
- Document the non-interactive (`non-TTY`) `gup remove` fail-fast behavior.
- Note that `--json` takes precedence over `--quiet`.

### Help-text cleanups (review findings)
- `bug-report` Example indentation 3→2 spaces to match every other subcommand (golden updated).
- Lowercase the flag descriptions that started with a capital (`jobs`, `ignore-go-update`, `force`) to match cobra convention and the rest of gup.
- Drop the trailing period from `export`/`import` `Short` strings for consistency.

### Small fix
- `print.Question`: on a scan error, emit the error via `print.Err` (labeled, newline-terminated on STDERR) instead of a raw, unlabeled `fmt.Fprint(os.Stderr, ...)`. This matters more now that non-TTY `remove` routes through the confirmation path.

## Out of scope (follow-up issue)
Translating the newer English-README sections (`--quiet`, `--json`, `NO_COLOR`, `@main`/`@master`/`@latest`, Feature comparison) into the six translated READMEs is a larger effort and will be tracked separately.

## Verification
- `gofmt -l .` clean, `go vet ./...` clean
- `golangci-lint run ./...` → 0 issues
- `go test ./...` (incl. `-race`) all green

No version constant needs bumping: the version is injected via goreleaser ldflags from the git tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--version`/`-V`, `--quiet`/`-q`, and `--no-color`
* **Bug Fixes**
  * Improved `remove` in non-interactive runs (fails fast with guidance)
  * Corrected JSON/output precedence and fixed a binary classification issue
  * Normalized version handling before saving; improved error reporting formatting
* **Documentation**
  * Updated README with version-check usage and clarified quiet/JSON behavior
* **Style**
  * Standardized CLI help text formatting across commands
* **Chores**
  * Updated changelog; added/updated related tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->