### PR TITLE
fix(config): harden gup.json channel resolution across check/update/export (#340, #341, #342)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Unreleased
+
+### Features
+
+* Add a `--file`/`-f` flag to `check` and `update` to select which `gup.json` to read saved update channels from (and write back to, for `update`), consistent with `import`/`export`. (#342)
+
+### Bug Fixes
+
+* `gup update --main` and `check` now fall back from `@main` to `@master` only when the `main` branch does not exist. Build, network, proxy, authentication, timeout, and cancellation failures on `@main` are surfaced as-is instead of silently installing `@master`. (#340)
+* `gup export` now preserves each package's saved update channel (`latest`/`main`/`master`) regardless of `--file`/`--output`. Channels are always resolved from the canonical user-level `gup.json`, matched by `import_path` first (with Windows `.exe` name differences normalized), so exporting to a new destination no longer resets channels to `latest`. (#341)
+* `gup check` and `gup update` now fail fast when both the user-level `gup.json` and `./gup.json` exist and `--file` is omitted, instead of silently picking one — matching the existing `gup import` behavior. (#342)
+
 ## [v1.4.0](https://github.com/nao1215/gup/compare/v1.3.1...v1.4.0) (2026-06-22)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -114,9 +114,11 @@ $ gup update --exclude=gopls,golangci-lint    //--exclude or -e, this example wi
 
 ### Update binaries with @main, @master, or @latest
 If you want to control update source per binary, use the following options:
-- `--main` (`-m`): update by `@main` (fallback to `@master`)
+- `--main` (`-m`): update by `@main` (falls back to `@master` only when the repository has no `main` branch)
 - `--master`: update by `@master`
 - `--latest`: update by `@latest`
+
+The `@main` → `@master` fallback applies only to a missing `main` branch. Build, network, authentication, timeout, and cancellation failures are reported as-is and never silently install `@master`.
 
 The selected channel is saved to `gup.json` and reused by future `gup update` runs.
 ```shell
@@ -238,11 +240,13 @@ Use export/import when you want to install the same Go binaries across multiple 
 
 By default:
 - `gup export` writes to `$XDG_CONFIG_HOME/gup/gup.json`
-- `gup import` auto-detects config path in this order:
+- `gup import`, `gup check`, and `gup update` auto-detect the config path in this order:
   1) `$XDG_CONFIG_HOME/gup/gup.json` (if exists)
   2) `./gup.json` (if exists)
 
-You can always override the path with `--file`.
+If **both** the user-level `gup.json` and `./gup.json` exist, `import`, `check`, and `update` fail fast and ask you to disambiguate with `--file`, instead of silently picking one. You can always override the path with `--file` (`-f`).
+
+`gup export` always resolves saved update channels from the canonical user-level `gup.json`; `--file`/`--output` only change the export destination, so exporting to a new file never resets a package's channel back to `latest`.
 
 ```shell
 ※ Environments A (e.g. ubuntu)

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -38,6 +38,10 @@ It does not update them.`,
 	cmd.Flags().Bool("ignore-go-update", false, "ignore updates to the Go toolchain")
 	cmd.Flags().Bool("json", false, "output result as machine-readable JSON")
 	cmd.Flags().BoolP("quiet", "q", false, "suppress up-to-date lines; show only update-available/failed binaries plus a summary")
+	cmd.Flags().StringP("file", "f", "", "specify gup.json file path to read saved update channels from")
+	if err := cmd.MarkFlagFilename("file", "json"); err != nil {
+		panic(err)
+	}
 	addTimeoutFlag(cmd)
 
 	return cmd
@@ -80,6 +84,12 @@ func check(cmd *cobra.Command, args []string) int {
 		return 1
 	}
 
+	confFile, err := getFlagString(cmd, "file")
+	if err != nil {
+		print.Err(err)
+		return 1
+	}
+
 	pkgs, goVersionAvailable, err := getPackageInfoByTargets(args)
 	if err != nil {
 		print.Err(err)
@@ -96,7 +106,11 @@ func check(cmd *cobra.Command, args []string) int {
 		return 1
 	}
 
-	pkgs = applyCheckChannels(pkgs)
+	pkgs, err = applyCheckChannels(pkgs, confFile)
+	if err != nil {
+		print.Err(err)
+		return 1
+	}
 	if jsonOut {
 		return doCheckJSON(pkgs, cpus, timeout, ignoreGoUpdate)
 	}
@@ -106,15 +120,14 @@ func check(cmd *cobra.Command, args []string) int {
 // applyCheckChannels resolves the saved per-package update channel from
 // gup.json so that 'gup check' compares each binary against the same source
 // 'gup update' would install from. The config is located with the same
-// resolution rules used by import/update; when no config exists every package
-// keeps the default @latest behavior.
-func applyCheckChannels(pkgs []goutil.Package) []goutil.Package {
-	confReadPath, resolveErr := config.ResolveImportFilePath("")
-	if resolveErr != nil {
-		// check only reads the config for channel hints and is not the command
-		// targeted by the ambiguity check, so fall back to the user-level config
-		// instead of failing.
-		confReadPath = config.FilePath()
+// resolution rules used by import/update; when both the user-level config and
+// ./gup.json exist and no --file is given, the choice is ambiguous and an error
+// is returned so check fails fast instead of silently picking one (#342). When
+// no config exists every package keeps the default @latest behavior.
+func applyCheckChannels(pkgs []goutil.Package, confFile string) ([]goutil.Package, error) {
+	confReadPath, err := config.ResolveImportFilePath(confFile)
+	if err != nil {
+		return nil, err
 	}
 
 	confPkgs, err := readConfFileIfExists(confReadPath)
@@ -123,7 +136,7 @@ func applyCheckChannels(pkgs []goutil.Package) []goutil.Package {
 		confPkgs = []goutil.Package{}
 	}
 
-	return applySavedChannels(pkgs, confPkgs)
+	return applySavedChannels(pkgs, confPkgs), nil
 }
 
 func doCheck(pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpdate, quiet bool) int {

--- a/cmd/check_channel_test.go
+++ b/cmd/check_channel_test.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/nao1215/gup/internal/config"
 	"github.com/nao1215/gup/internal/goutil"
 	"github.com/nao1215/gup/internal/print"
 )
@@ -132,6 +134,39 @@ func Test_fetchVerForChannel_mainNoFallbackOnContextError(t *testing.T) {
 	}
 }
 
+// Test_fetchVerForChannel_mainNoFallbackOnGenericError verifies the #340
+// contract for the version-resolution path: when @main fails for a reason other
+// than a missing branch, fetchVerForChannel must surface that error and must NOT
+// fall back to @master (which would resolve a wrong-branch version).
+func Test_fetchVerForChannel_mainNoFallbackOnGenericError(t *testing.T) {
+	origRef := getVerByRefCtx
+	t.Cleanup(func() { getVerByRefCtx = origRef })
+
+	var refCalls []string
+	getVerByRefCtx = func(_ context.Context, _ string, ref string) (string, error) {
+		refCalls = append(refCalls, ref)
+		switch ref {
+		case refMain:
+			return "", errors.New("build failed: some compile error")
+		case refMaster:
+			return testVerMaster, nil
+		default:
+			return "", fmt.Errorf("unexpected ref %q", ref)
+		}
+	}
+
+	_, err := fetchVerForChannel(context.Background(), "example.com/mod", goutil.UpdateChannelMain)
+	if err == nil {
+		t.Fatal("fetchVerForChannel() must not fall back to @master on a non-branch @main failure")
+	}
+	if !strings.Contains(err.Error(), "build failed") {
+		t.Fatalf("fetchVerForChannel() should surface the @main error, got: %v", err)
+	}
+	if len(refCalls) != 1 || refCalls[0] != refMain {
+		t.Fatalf("expected only the @main attempt on a non-branch failure, got %v", refCalls)
+	}
+}
+
 func Test_doCheck_respectsSavedChannels(t *testing.T) {
 	origLatest := getLatestVerCtx
 	origRef := getVerByRefCtx
@@ -182,6 +217,74 @@ func Test_doCheck_respectsSavedChannels(t *testing.T) {
 	}
 	if strings.Contains(hint, testBinMasterTool) {
 		t.Fatalf("%s should be up-to-date against @master, got hint:\n%s", testBinMasterTool, hint)
+	}
+}
+
+// Test_applyCheckChannels_ambiguousConfig verifies the #342 contract: when both
+// the user-level config and ./gup.json exist and no --file is given, check fails
+// fast with the same ambiguity error import uses, instead of silently picking
+// one config.
+func Test_applyCheckChannels_ambiguousConfig(t *testing.T) {
+	setupXDGBase(t)
+	chdirToTemp(t)
+
+	if err := os.MkdirAll(config.DirPath(), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(config.FilePath(), []byte(validImportConf), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(config.LocalFilePath(), []byte(validImportConf), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	pkgs := []goutil.Package{newCheckPkg(testBinLatestTool, testVersionOne, goutil.UpdateChannelLatest)}
+
+	// No --file: must error.
+	if _, err := applyCheckChannels(pkgs, ""); err == nil {
+		t.Fatal("applyCheckChannels() should fail when both config candidates exist and no --file is given")
+	} else if !strings.Contains(err.Error(), "multiple gup.json") || !strings.Contains(err.Error(), "--file") {
+		t.Fatalf("error should mention the ambiguity and --file, got: %v", err)
+	}
+
+	// Explicit --file resolves the ambiguity.
+	if _, err := applyCheckChannels(pkgs, config.LocalFilePath()); err != nil {
+		t.Fatalf("applyCheckChannels() with explicit --file should succeed, got: %v", err)
+	}
+}
+
+// Test_check_ambiguousConfigFailsFast verifies the whole check command exits
+// non-zero (and never reaches the network) when the config is ambiguous (#342).
+func Test_check_ambiguousConfigFailsFast(t *testing.T) {
+	gobin, err := filepath.Abs(filepath.Join("testdata", "check_success"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	setupXDGBase(t)
+	chdirToTemp(t)
+	t.Setenv("GOBIN", gobin)
+
+	if err := os.MkdirAll(config.DirPath(), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(config.FilePath(), []byte(validImportConf), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(config.LocalFilePath(), []byte(validImportConf), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var got int
+	out := captureCheckOutput(t, func() int {
+		got = check(newCheckCmd(), []string{})
+		return got
+	})
+
+	if got != 1 {
+		t.Errorf("check() = %d, want 1", got)
+	}
+	if !strings.Contains(out, "multiple gup.json") || !strings.Contains(out, "--file") {
+		t.Errorf("expected ambiguity error mentioning --file, got: %s", out)
 	}
 }
 

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/nao1215/gup/internal/config"
 	"github.com/nao1215/gup/internal/goutil"
 	"github.com/nao1215/gup/internal/print"
@@ -58,9 +60,13 @@ func export(cmd *cobra.Command, _ []string) int {
 		return 1
 	}
 	pkgs = validPkgInfo(pkgs)
-	confPkgs, err := readConfFileIfExists(configPath)
+	// The source of truth for saved channels is always the canonical user-level
+	// config; --file/--output only change the export destination, not where
+	// channels are read from (#341).
+	channelSource := config.FilePath()
+	confPkgs, err := readConfFileIfExists(channelSource)
 	if err != nil {
-		print.Warn("failed to read " + configPath + ": " + err.Error())
+		print.Warn("failed to read " + channelSource + ": " + err.Error())
 		confPkgs = []goutil.Package{}
 	}
 	pkgs = applySavedChannels(pkgs, confPkgs)
@@ -101,20 +107,38 @@ func validPkgInfo(pkgs []goutil.Package) []goutil.Package {
 	return result
 }
 
+// applySavedChannels copies each package's saved update channel from confPkgs.
+// Matching prefers import_path (the stable identifier) and falls back to the
+// binary name with the Windows ".exe" suffix normalized, so a channel is not
+// silently reset to @latest across binary renames or cross-OS name differences
+// (#341). Packages with no saved entry default to @latest.
 func applySavedChannels(pkgs, confPkgs []goutil.Package) []goutil.Package {
+	channelByImportPath := make(map[string]goutil.UpdateChannel, len(confPkgs))
 	channelByName := make(map[string]goutil.UpdateChannel, len(confPkgs))
 	for _, p := range confPkgs {
-		channelByName[p.Name] = goutil.NormalizeUpdateChannel(string(p.UpdateChannel))
+		channel := goutil.NormalizeUpdateChannel(string(p.UpdateChannel))
+		if p.ImportPath != "" {
+			channelByImportPath[p.ImportPath] = channel
+		}
+		channelByName[normalizeBinName(p.Name)] = channel
 	}
 
 	result := make([]goutil.Package, 0, len(pkgs))
 	for _, p := range pkgs {
-		channel, ok := channelByName[p.Name]
-		if !ok {
-			channel = goutil.UpdateChannelLatest
+		channel := goutil.UpdateChannelLatest
+		if c, ok := channelByImportPath[p.ImportPath]; ok {
+			channel = c
+		} else if c, ok := channelByName[normalizeBinName(p.Name)]; ok {
+			channel = c
 		}
 		p.UpdateChannel = channel
 		result = append(result, p)
 	}
 	return result
+}
+
+// normalizeBinName strips the Windows ".exe" suffix so a binary name compares
+// equal regardless of the OS it was exported from.
+func normalizeBinName(name string) string {
+	return strings.TrimSuffix(name, ".exe")
 }

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -20,6 +20,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// testImportPathPosixer is the import path of the posixer fixture binary under
+// testdata/check_success, shared across the export channel-preservation tests.
+const testImportPathPosixer = "github.com/nao1215/posixer"
+
 func Test_validPkgInfo(t *testing.T) {
 	type args struct {
 		pkgs []goutil.Package
@@ -211,6 +215,94 @@ func Test_export(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// Test_applySavedChannels_prefersImportPath verifies that the saved channel is
+// matched by import_path first (#341), so a binary keeps its channel even when
+// its name differs from the saved entry.
+func Test_applySavedChannels_prefersImportPath(t *testing.T) {
+	confPkgs := []goutil.Package{
+		{Name: "old-name", ImportPath: "example.com/foo/cmd/foo", UpdateChannel: goutil.UpdateChannelMain},
+	}
+	pkgs := []goutil.Package{
+		{Name: "new-name", ImportPath: "example.com/foo/cmd/foo"},
+	}
+
+	got := applySavedChannels(pkgs, confPkgs)
+	if len(got) != 1 || got[0].UpdateChannel != goutil.UpdateChannelMain {
+		t.Fatalf("channel should be matched by import_path; got %+v", got)
+	}
+}
+
+// Test_applySavedChannels_normalizesExeSuffix verifies that name-based fallback
+// matching ignores the Windows ".exe" suffix difference (#341).
+func Test_applySavedChannels_normalizesExeSuffix(t *testing.T) {
+	confPkgs := []goutil.Package{
+		// Saved on Windows with the .exe suffix and no import path to force the
+		// name-based fallback.
+		{Name: "foo.exe", UpdateChannel: goutil.UpdateChannelMaster},
+	}
+	pkgs := []goutil.Package{
+		{Name: "foo", ImportPath: "example.com/foo"},
+	}
+
+	got := applySavedChannels(pkgs, confPkgs)
+	if len(got) != 1 || got[0].UpdateChannel != goutil.UpdateChannelMaster {
+		t.Fatalf("channel should match across .exe suffix difference; got %+v", got)
+	}
+}
+
+// Test_export_preservesChannelsFromCanonicalConfig verifies the #341 contract:
+// --file changes only the export destination, while saved channels are always
+// resolved from the canonical user-level config. The destination here is a fresh
+// file that has no channel data, so a wrong implementation would reset the
+// channel to "latest".
+func Test_export_preservesChannelsFromCanonicalConfig(t *testing.T) {
+	if err := goutil.CanUseGoCmd(); err != nil {
+		t.Skip("go command is not available")
+	}
+
+	origConfigHome := xdg.ConfigHome
+	t.Cleanup(func() { xdg.ConfigHome = origConfigHome })
+	xdg.ConfigHome = t.TempDir()
+
+	// Canonical user-level config records posixer as tracked on @main.
+	if err := os.MkdirAll(config.DirPath(), 0o750); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+	canonical := `{"schema_version":1,"packages":[{"name":"posixer","import_path":"` + testImportPathPosixer + `","version":"v0.1.0","channel":"main"}]}` + "\n"
+	if err := os.WriteFile(config.FilePath(), []byte(canonical), 0o600); err != nil {
+		t.Fatalf("failed to seed canonical config: %v", err)
+	}
+
+	t.Setenv("GOBIN", filepath.Join("testdata", "check_success"))
+
+	dest := filepath.Join(t.TempDir(), "exported.json")
+	cmd := newExportCmd()
+	if err := cmd.Flags().Set("file", dest); err != nil {
+		t.Fatalf("failed to set --file: %v", err)
+	}
+
+	if got := export(cmd, []string{}); got != 0 {
+		t.Fatalf("export() = %d, want 0", got)
+	}
+
+	exported, err := config.ReadConfFile(dest)
+	if err != nil {
+		t.Fatalf("failed to read exported config: %v", err)
+	}
+	var found bool
+	for _, p := range exported {
+		if p.ImportPath == testImportPathPosixer {
+			found = true
+			if p.UpdateChannel != goutil.UpdateChannelMain {
+				t.Fatalf("posixer channel = %q, want %q (preserved from canonical config)", p.UpdateChannel, goutil.UpdateChannelMain)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("posixer not found in exported config: %+v", exported)
 	}
 }
 

--- a/cmd/jsonout_test.go
+++ b/cmd/jsonout_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nao1215/gup/internal/config"
 	"github.com/nao1215/gup/internal/goutil"
 	"github.com/nao1215/gup/internal/print"
 	"github.com/spf13/cobra"
@@ -345,6 +346,52 @@ func Test_list_jsonFlag(t *testing.T) {
 	for _, r := range recs {
 		if r.Status != statusInstalled {
 			t.Errorf("list record %q status = %q, want %q", r.Name, r.Status, statusInstalled)
+		}
+	}
+}
+
+// Test_list_jsonFlag_ambiguousConfigFallsBack verifies that list --json is
+// read-only and is NOT subject to the #342 ambiguity hard-error: when both the
+// user-level config and ./gup.json exist, list still succeeds and resolves
+// channel hints from the canonical user-level config.
+func Test_list_jsonFlag_ambiguousConfigFallsBack(t *testing.T) {
+	gobin, err := filepath.Abs(filepath.Join("testdata", "check_success"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	setupXDGBase(t)
+	chdirToTemp(t)
+	t.Setenv("GOBIN", gobin)
+
+	if err := os.MkdirAll(config.DirPath(), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// Canonical config records posixer on @main; ./gup.json makes the auto
+	// detection ambiguous.
+	canonical := `{"schema_version":1,"packages":[{"name":"posixer","import_path":"` + testImportPathPosixer + `","version":"v0.1.0","channel":"main"}]}` + "\n"
+	if err := os.WriteFile(config.FilePath(), []byte(canonical), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(config.LocalFilePath(), []byte(canonical), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newListCmd()
+	if err := cmd.Flags().Set("json", "true"); err != nil {
+		t.Fatalf("failed to set json flag: %v", err)
+	}
+
+	var got int
+	recs := readJSON(t, func() int {
+		got = list(cmd, []string{})
+		return got
+	})
+	if got != 0 {
+		t.Fatalf("list --json should succeed despite ambiguous config, got %d", got)
+	}
+	for _, r := range recs {
+		if r.ImportPath == testImportPathPosixer && r.Channel != string(goutil.UpdateChannelMain) {
+			t.Errorf("posixer channel = %q, want main (from canonical config fallback)", r.Channel)
 		}
 	}
 }

--- a/cmd/jsonout_test.go
+++ b/cmd/jsonout_test.go
@@ -367,12 +367,14 @@ func Test_list_jsonFlag_ambiguousConfigFallsBack(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Canonical config records posixer on @main; ./gup.json makes the auto
-	// detection ambiguous.
+	// detection ambiguous and records a DIFFERENT channel (@master), so the test
+	// fails if list reads the local file instead of the canonical config.
 	canonical := `{"schema_version":1,"packages":[{"name":"posixer","import_path":"` + testImportPathPosixer + `","version":"v0.1.0","channel":"main"}]}` + "\n"
+	local := `{"schema_version":1,"packages":[{"name":"posixer","import_path":"` + testImportPathPosixer + `","version":"v0.1.0","channel":"master"}]}` + "\n"
 	if err := os.WriteFile(config.FilePath(), []byte(canonical), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(config.LocalFilePath(), []byte(canonical), 0o600); err != nil {
+	if err := os.WriteFile(config.LocalFilePath(), []byte(local), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -389,10 +391,17 @@ func Test_list_jsonFlag_ambiguousConfigFallsBack(t *testing.T) {
 	if got != 0 {
 		t.Fatalf("list --json should succeed despite ambiguous config, got %d", got)
 	}
+	foundPosixer := false
 	for _, r := range recs {
-		if r.ImportPath == testImportPathPosixer && r.Channel != string(goutil.UpdateChannelMain) {
-			t.Errorf("posixer channel = %q, want main (from canonical config fallback)", r.Channel)
+		if r.ImportPath == testImportPathPosixer {
+			foundPosixer = true
+			if r.Channel != string(goutil.UpdateChannelMain) {
+				t.Errorf("posixer channel = %q, want main (from canonical config fallback)", r.Channel)
+			}
 		}
+	}
+	if !foundPosixer {
+		t.Fatal("expected posixer record in list --json output")
 	}
 }
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/fatih/color"
+	"github.com/nao1215/gup/internal/config"
 	"github.com/nao1215/gup/internal/goutil"
 	"github.com/nao1215/gup/internal/print"
 	"github.com/spf13/cobra"
@@ -51,8 +52,15 @@ func list(cmd *cobra.Command, _ []string) int {
 	}
 
 	if jsonOut {
-		pkgs = applyCheckChannels(pkgs)
-		if err := encodeJSONPackages(listJSONRecords(pkgs)); err != nil {
+		annotated, cerr := applyCheckChannels(pkgs, "")
+		if cerr != nil {
+			// list is read-only and is not the command targeted by the
+			// ambiguity check (#342); fall back to the user-level config for
+			// channel hints instead of failing.
+			confPkgs, _ := readConfFileIfExists(config.FilePath())
+			annotated = applySavedChannels(pkgs, confPkgs)
+		}
+		if err := encodeJSONPackages(listJSONRecords(annotated)); err != nil {
 			print.Err(err)
 			return 1
 		}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -72,6 +72,10 @@ using the current installed Go toolchain.`,
 	cmd.Flags().Bool("ignore-go-update", false, "ignore updates to the Go toolchain")
 	cmd.Flags().Bool("json", false, "output result as machine-readable JSON")
 	cmd.Flags().BoolP("quiet", "q", false, "suppress up-to-date lines; show only updated/failed binaries plus a summary")
+	cmd.Flags().StringP("file", "f", "", "specify gup.json file path to read/write saved update channels")
+	if err := cmd.MarkFlagFilename("file", "json"); err != nil {
+		panic(err)
+	}
 	addTimeoutFlag(cmd)
 
 	return cmd
@@ -168,12 +172,18 @@ func gup(cmd *cobra.Command, args []string) int {
 		return 1
 	}
 
-	confReadPath, resolveErr := config.ResolveImportFilePath("")
-	if resolveErr != nil {
-		// update only reads the config for channel hints and is not the
-		// command targeted by the ambiguity check, so fall back to the
-		// user-level config instead of failing.
-		confReadPath = config.FilePath()
+	confFile, err := getFlagString(cmd, "file")
+	if err != nil {
+		print.Err(err)
+		return 1
+	}
+	// When both the user-level config and ./gup.json exist and no --file is
+	// given, fail fast instead of silently choosing one (#342), consistent with
+	// import and check.
+	confReadPath, err := config.ResolveImportFilePath(confFile)
+	if err != nil {
+		print.Err(err)
+		return 1
 	}
 	confWritePath := config.FilePath()
 	if fileutil.IsFile(confReadPath) {

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -1938,3 +1938,54 @@ func Test_updateWithChannels_mainChannel(t *testing.T) {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
 }
+
+// Test_update_ambiguousConfigFailsFast verifies the #342 contract for update:
+// when both the user-level config and ./gup.json exist and no --file is given,
+// update fails fast with the ambiguity error instead of silently choosing one
+// config (mirroring import). It must not reach the install path.
+func Test_update_ambiguousConfigFailsFast(t *testing.T) {
+	gobin, err := filepath.Abs(filepath.Join("testdata", "check_success"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	setupXDGBase(t)
+	chdirToTemp(t)
+	t.Setenv("GOBIN", gobin)
+
+	if err := os.MkdirAll(config.DirPath(), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(config.FilePath(), []byte(validImportConf), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(config.LocalFilePath(), []byte(validImportConf), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	orgStdout := print.Stdout
+	orgStderr := print.Stderr
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	print.Stdout = pw
+	print.Stderr = pw
+
+	got := gup(newUpdateCmd(), []string{})
+
+	pw.Close()
+	print.Stdout = orgStdout
+	print.Stderr = orgStderr
+
+	buf := bytes.Buffer{}
+	io.Copy(&buf, pr)
+	pr.Close()
+
+	if got != 1 {
+		t.Errorf("update() = %d, want 1", got)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "multiple gup.json") || !strings.Contains(out, "--file") {
+		t.Errorf("expected ambiguity error mentioning --file, got: %s", out)
+	}
+}

--- a/cmd/version_cache.go
+++ b/cmd/version_cache.go
@@ -110,7 +110,7 @@ func fetchVerForChannel(ctx context.Context, modulePath string, channel goutil.U
 		if err == nil {
 			return ver, nil
 		}
-		// Do not fall back when the failure is a cancelled/expired context;
+		// Do not fall back when the failure is a canceled/expired context;
 		// the same cancellation would just hit @master too.
 		if ctx != nil && ctx.Err() != nil {
 			return "", err

--- a/cmd/version_cache.go
+++ b/cmd/version_cache.go
@@ -115,6 +115,12 @@ func fetchVerForChannel(ctx context.Context, modulePath string, channel goutil.U
 		if ctx != nil && ctx.Err() != nil {
 			return "", err
 		}
+		// Fall back to @master only when @main fails because the main branch is
+		// absent. Build/network/auth/other failures surface as-is so a
+		// wrong-branch version is never silently resolved (#340).
+		if !goutil.IsBranchNotFound(err, string(goutil.UpdateChannelMain)) {
+			return "", err
+		}
 		return getVerByRefCtx(ctx, modulePath, string(goutil.UpdateChannelMaster))
 	case goutil.UpdateChannelMaster:
 		return getVerByRefCtx(ctx, modulePath, string(goutil.UpdateChannelMaster))

--- a/internal/goutil/goutil.go
+++ b/internal/goutil/goutil.go
@@ -382,11 +382,39 @@ func InstallMainOrMaster(importPath string) error {
 // branch as "unknown revision <branch>". This is the only condition under which
 // gup is allowed to fall back from @main to @master (#340); any other failure
 // must surface as-is so a wrong-branch version is never silently installed.
+//
+// The branch is matched as a whole token, so branch "main" does not match
+// "unknown revision mainline".
 func IsBranchNotFound(err error, branch string) bool {
 	if err == nil {
 		return false
 	}
-	return strings.Contains(err.Error(), "unknown revision "+branch)
+	msg := err.Error()
+	marker := "unknown revision " + branch
+	for start := 0; ; {
+		i := strings.Index(msg[start:], marker)
+		if i < 0 {
+			return false
+		}
+		after := start + i + len(marker)
+		// The branch token must be followed by the end of the message or a
+		// non-word byte (e.g. newline), so a prefix like "main" in "mainline"
+		// is not treated as a match.
+		if after == len(msg) || !isBranchWordByte(msg[after]) {
+			return true
+		}
+		start = after
+	}
+}
+
+// isBranchWordByte reports whether b is part of a branch-name token (letters,
+// digits, or underscore), matching the \b word-boundary semantics used to
+// delimit the branch name in IsBranchNotFound.
+func isBranchWordByte(b byte) bool {
+	return b == '_' ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9')
 }
 
 // InstallMainOrMasterWithContext executes "$ go install <importPath>@main"

--- a/internal/goutil/goutil.go
+++ b/internal/goutil/goutil.go
@@ -376,25 +376,47 @@ func InstallMainOrMaster(importPath string) error {
 	return InstallMainOrMasterWithContext(context.Background(), importPath)
 }
 
+// IsBranchNotFound reports whether err indicates that the given branch (e.g.
+// "main") does not exist in the module's repository, as opposed to a build,
+// network, authentication, or other failure. The go toolchain reports a missing
+// branch as "unknown revision <branch>". This is the only condition under which
+// gup is allowed to fall back from @main to @master (#340); any other failure
+// must surface as-is so a wrong-branch version is never silently installed.
+func IsBranchNotFound(err error, branch string) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "unknown revision "+branch)
+}
+
 // InstallMainOrMasterWithContext executes "$ go install <importPath>@main"
 // or "$ go install <importPath>@master" with context cancellation support.
+//
+// The @master fallback is taken only when @main fails because the main branch
+// does not exist. Build failures, network/proxy/auth errors, timeouts, and
+// cancellations on @main are returned as-is and never trigger a @master install
+// (#340).
 func InstallMainOrMasterWithContext(ctx context.Context, importPath string) error {
 	mainErr := InstallWithContext(ctx, importPath, "main")
-	if mainErr != nil {
-		// Previous error is "invalid version: unknown revision main". Not return this error.
-		masterErr := InstallWithContext(ctx, importPath, "master")
-		if masterErr == nil {
-			return nil
-		}
-		const errMsg = "cannot update with @master or @main using the 'gup'. please update manually."
-		if strings.Contains(mainErr.Error(), "unknown revision main") {
-			return fmt.Errorf("%s\n%w", errMsg, masterErr)
-		} else if strings.Contains(masterErr.Error(), "unknown revision master") {
-			return fmt.Errorf("%s\n%w", errMsg, mainErr)
-		}
-		return fmt.Errorf("%s\n%s\n%w", errMsg, mainErr.Error(), masterErr)
+	if mainErr == nil {
+		return nil
 	}
-	return nil
+	// A cancelled/expired context would just hit @master too; surface the @main
+	// error instead of retrying.
+	if ctx != nil && ctx.Err() != nil {
+		return mainErr
+	}
+	// Only a missing main branch justifies trying @master.
+	if !IsBranchNotFound(mainErr, "main") {
+		return mainErr
+	}
+
+	masterErr := InstallWithContext(ctx, importPath, "master")
+	if masterErr == nil {
+		return nil
+	}
+	const errMsg = "cannot update with @master or @main using the 'gup'. please update manually."
+	return fmt.Errorf("%s\n%w", errMsg, masterErr)
 }
 
 // Install executes "$ go install <importPath>@<version>".

--- a/internal/goutil/goutil.go
+++ b/internal/goutil/goutil.go
@@ -401,7 +401,7 @@ func InstallMainOrMasterWithContext(ctx context.Context, importPath string) erro
 	if mainErr == nil {
 		return nil
 	}
-	// A cancelled/expired context would just hit @master too; surface the @main
+	// A canceled/expired context would just hit @master too; surface the @main
 	// error instead of retrying.
 	if ctx != nil && ctx.Err() != nil {
 		return mainErr

--- a/internal/goutil/goutil_test.go
+++ b/internal/goutil/goutil_test.go
@@ -1364,19 +1364,24 @@ func TestPackage_IsGoUpToDate_customBuildTag(t *testing.T) {
 	}
 }
 
-func TestInstallMainOrMaster_mainFails_masterFails(t *testing.T) {
+func TestInstallMainOrMaster_mainFailsGenericError_noMasterFallback(t *testing.T) {
 	oldGoExe := goExe
 	defer func() { goExe = oldGoExe }()
 
-	// Use a command that will fail for both main and master
+	// "false" exits non-zero with no "unknown revision main" on stderr, i.e. a
+	// generic (non-branch-not-found) failure. Per #340 gup must surface the
+	// @main error and must NOT fall back to @master.
 	goExe = "false"
 
 	err := InstallMainOrMaster("github.com/example/tool")
 	if err == nil {
-		t.Fatal("expected error when both main and master fail")
+		t.Fatal("expected error when @main fails")
 	}
-	if !strings.Contains(err.Error(), "cannot update with @master or @main") {
-		t.Errorf("unexpected error message: %v", err)
+	if !strings.Contains(err.Error(), "can't install github.com/example/tool") {
+		t.Errorf("error should surface the @main install failure, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "cannot update with @master or @main") {
+		t.Errorf("a generic @main failure must not trigger the @master fallback, got: %v", err)
 	}
 }
 

--- a/internal/goutil/goutil_test.go
+++ b/internal/goutil/goutil_test.go
@@ -1368,10 +1368,11 @@ func TestInstallMainOrMaster_mainFailsGenericError_noMasterFallback(t *testing.T
 	oldGoExe := goExe
 	defer func() { goExe = oldGoExe }()
 
-	// "false" exits non-zero with no "unknown revision main" on stderr, i.e. a
-	// generic (non-branch-not-found) failure. Per #340 gup must surface the
-	// @main error and must NOT fall back to @master.
-	goExe = "false"
+	// Point goExe at a path that does not exist so the @main install fails on
+	// every OS (no "unknown revision main" on stderr), i.e. a generic
+	// (non-branch-not-found) failure. Per #340 gup must surface the @main error
+	// and must NOT fall back to @master.
+	goExe = filepath.Join(t.TempDir(), "no-such-go-binary")
 
 	err := InstallMainOrMaster("github.com/example/tool")
 	if err == nil {

--- a/internal/goutil/helperprocess_test.go
+++ b/internal/goutil/helperprocess_test.go
@@ -245,10 +245,11 @@ func TestInstallMainOrMasterWithContext_helperProcess_masterFallbackSucceeds(t *
 }
 
 func TestInstallMainOrMasterWithContext_helperProcess_bothFail(t *testing.T) {
-	// Both @main and @master fail (exit 1) with distinct stderr. The combined
-	// error must mention the manual-update guidance.
+	// @main is missing (branch-not-found), so @master is tried and also fails
+	// (exit 1). The combined error must mention the manual-update guidance and
+	// surface the @master failure.
 	withHelperProcess(t, helperProcessConfig{
-		stderr: "go: some unrelated failure\n",
+		stderr: "go: unknown revision main\n",
 		exit:   1,
 	})
 
@@ -259,8 +260,51 @@ func TestInstallMainOrMasterWithContext_helperProcess_bothFail(t *testing.T) {
 	if !strings.Contains(err.Error(), "cannot update with @master or @main") {
 		t.Errorf("error should include manual-update guidance. got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "some unrelated failure") {
+	if !strings.Contains(err.Error(), "unknown revision main") {
 		t.Errorf("error should surface the underlying stderr. got: %v", err)
+	}
+}
+
+// TestInstallMainOrMasterWithContext_noFallbackOnGenericMainError verifies the
+// #340 contract: when @main fails for a reason other than a missing branch
+// (e.g. a build failure), gup must NOT silently install from @master. Here the
+// fallback helper would let @master succeed, so a successful return would prove
+// a wrong-branch install slipped through.
+func TestInstallMainOrMasterWithContext_noFallbackOnGenericMainError(t *testing.T) {
+	withHelperProcessMainMasterFallback(t, "go: build failed: some compile error\n")
+
+	err := InstallMainOrMasterWithContext(context.Background(), "github.com/example/tool")
+	if err == nil {
+		t.Fatal("InstallMainOrMasterWithContext() must not fall back to @master when @main fails for non-branch reasons")
+	}
+	if !strings.Contains(err.Error(), "build failed: some compile error") {
+		t.Errorf("error should surface the @main failure. got: %v", err)
+	}
+	if strings.Contains(err.Error(), "cannot update with @master or @main") {
+		t.Errorf("error must not include the @master fallback guidance for a non-branch @main failure. got: %v", err)
+	}
+}
+
+func TestIsBranchNotFound(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		branch string
+		want   bool
+	}{
+		{"nil error", nil, string(UpdateChannelMain), false},
+		{"main missing", fmt.Errorf("can't install x:\ngo: unknown revision main"), string(UpdateChannelMain), true},
+		{"master missing", fmt.Errorf("go: unknown revision master"), string(UpdateChannelMaster), true},
+		{"build failure is not branch-not-found", fmt.Errorf("build failed: compile error"), string(UpdateChannelMain), false},
+		{"network failure is not branch-not-found", fmt.Errorf("dial tcp: i/o timeout"), string(UpdateChannelMain), false},
+		{"wrong branch name does not match", fmt.Errorf("go: unknown revision master"), string(UpdateChannelMain), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsBranchNotFound(tt.err, tt.branch); got != tt.want {
+				t.Errorf("IsBranchNotFound(%v, %q) = %v, want %v", tt.err, tt.branch, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/goutil/helperprocess_test.go
+++ b/internal/goutil/helperprocess_test.go
@@ -298,6 +298,8 @@ func TestIsBranchNotFound(t *testing.T) {
 		{"build failure is not branch-not-found", fmt.Errorf("build failed: compile error"), string(UpdateChannelMain), false},
 		{"network failure is not branch-not-found", fmt.Errorf("dial tcp: i/o timeout"), string(UpdateChannelMain), false},
 		{"wrong branch name does not match", fmt.Errorf("go: unknown revision master"), string(UpdateChannelMain), false},
+		{"longer branch name is not a partial match", fmt.Errorf("go: unknown revision mainline"), string(UpdateChannelMain), false},
+		{"branch token followed by newline matches", fmt.Errorf("go: unknown revision main\n"), string(UpdateChannelMain), true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR groups three closely-related `gup.json` config / update-channel issues into a single change, since they all touch the same config-resolution and channel-handling subsystem. Implemented in TDD style (failing test → implementation → green).

Closes #340, #341, #342.

### #340 — Restrict `@main` → `@master` fallback to branch-not-found cases only
`gup update --main` and `gup check` previously fell back to `@master` on *any* `@main` failure. Now the fallback fires **only** when the `main` branch does not exist (`unknown revision main`). Build, network/proxy, authentication, timeout, and cancellation failures are surfaced as-is, so a wrong-branch version is never silently installed.

- New shared helper `goutil.IsBranchNotFound(err, branch)` gates both the install path (`InstallMainOrMasterWithContext`) and the version-resolution path (`fetchVerForChannel`).

### #341 — Preserve saved update channels during `gup export`
`gup export` now always resolves saved channels from the **canonical user-level config** (`$XDG_CONFIG_HOME/gup/gup.json`); `--file`/`--output` only change the export destination. Channel matching prefers `import_path` and falls back to the binary name with the Windows `.exe` suffix normalized, so exporting to a fresh file no longer resets channels to `latest`.

### #342 — Fail fast on multiple `gup.json` candidates for `check` and `update`
`check` and `update` gained a `--file`/`-f` flag and now hard-error (like `import`) when both the user-level config and `./gup.json` exist and `--file` is omitted, telling the user to disambiguate. `list --json` keeps its prior read-only soft-fallback (it is not the targeted command).

## Tests
- `IsBranchNotFound` table test; `@main` no-fallback-on-generic-error tests for both install and version-resolution paths; rewrote the two tests that encoded the old broad-fallback behavior.
- Export: `import_path`-preferred and `.exe`-normalized matching unit tests, plus an integration test proving `--file` does not reset channels read from the canonical config.
- Ambiguity: unit + full-command tests for `check`/`update` (exit 1, never reach the network).

## Verification
`gofmt`, `go vet`, `go test ./...`, and `golangci-lint run ./...` all pass.

## Docs
README (`@main`/`@master` fallback rule, config-resolution ambiguity, export channel source) and CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--file/-f` to `gup check` and `gup update` to explicitly select which `gup.json` controls saved update channels.
* **Bug Fixes**
  * Improved `@main` → `@master` fallback so it only happens when `@main` is actually missing; no fallback on other failures or canceled runs.
  * `gup check`, `gup update`, `gup export`, and `list --json` now handle ambiguous `gup.json` locations more predictably: fail fast unless `--file` is provided, with `list --json` falling back to the canonical config.
  * `gup export` preserves saved channels from the canonical user config and applies them using stronger matching (including Windows `.exe` normalization).
* **Documentation**
  * Updated CHANGELOG and README with the new flag behavior and fail-fast/auto-detection rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->