### PR TITLE
fix(cli): harden completion --install and man for environment edge cases (#343, #344)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * `gup update --main` and `check` now fall back from `@main` to `@master` only when the `main` branch does not exist. Build, network, proxy, authentication, timeout, and cancellation failures on `@main` are surfaced as-is instead of silently installing `@master`. (#340)
 * `gup export` now preserves each package's saved update channel (`latest`/`main`/`master`) regardless of `--file`/`--output`. Channels are always resolved from the canonical user-level `gup.json`, matched by `import_path` first (with Windows `.exe` name differences normalized), so exporting to a new destination no longer resets channels to `latest`. (#341)
 * `gup check` and `gup update` now fail fast when both the user-level `gup.json` and `./gup.json` exist and `--file` is omitted, instead of silently picking one — matching the existing `gup import` behavior. (#342)
+* `gup completion --install` now exits non-zero when a completion file cannot be written (previously it could print an error but still exit 0), and fails fast with a clear message when `HOME` is unset instead of writing completion files into relative paths under the current directory. (#343)
+* `gup man` now creates the target `man1` directory when it does not exist (e.g. for a valid custom `MANPATH`) instead of failing, and reports a clear error for unwritable targets. (#344)
 
 ## [v1.4.0](https://github.com/nao1215/gup/compare/v1.3.1...v1.4.0) (2026-06-22)
 

--- a/README.md
+++ b/README.md
@@ -309,7 +309,10 @@ Supported flags: `--dry-run` (`-n`), `--notify` (`-N`), `--jobs` (`-j`),
 `--force`.
 
 ### Generate man-pages (for linux, mac)
-man subcommand generates man-pages under /usr/share/man/man1.
+man subcommand generates man-pages under /usr/share/man/man1 by default. If
+`MANPATH` is set, gup writes to the `man1` directory under each entry instead,
+creating it when it does not exist yet. An unwritable target exits with a clear
+error.
 ```shell
 $ sudo gup man
 Generate /usr/share/man/man1/gup-bug-report.1.gz
@@ -340,6 +343,10 @@ $ gup completion powershell > gup.ps1
 # Install files automatically to default user paths
 $ gup completion --install
 ```
+
+`--install` requires `HOME` to be set; it fails fast (without writing files into
+the current directory) when `HOME` is empty, and exits non-zero if any
+completion file cannot be written.
 
 ### Desktop notification
 If you use gup with --notify option, gup command notify you on your desktop whether the update was successful or unsuccessful after the update was finished.

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -39,8 +39,7 @@ Use --install to write bash/fish/zsh completion files to the user shell config p
 				if isWindows() {
 					return fmt.Errorf("--install is not supported on Windows; run 'gup completion powershell' to output PowerShell completion to stdout")
 				}
-				completion.DeployShellCompletionFileIfNeeded(rootCmd)
-				return nil
+				return completion.DeployShellCompletionFileIfNeeded(rootCmd)
 			}
 			if len(args) == 0 {
 				return argsGuidance(

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -67,6 +68,9 @@ func TestCompletion_Install(t *testing.T) {
 // 'completion --install' fails fast with a clear message and writes nothing into
 // relative paths under the current working directory.
 func TestCompletion_InstallUnsetHOME(t *testing.T) {
+	if runtime.GOOS == goosWindows {
+		t.Skip("completion --install is a no-op on Windows (file install is unsupported)")
+	}
 	stubIsWindows(t, false)
 	t.Setenv("HOME", "")
 
@@ -93,6 +97,9 @@ func TestCompletion_InstallUnsetHOME(t *testing.T) {
 // completion file cannot be written, the command exits non-zero instead of
 // silently succeeding.
 func TestCompletion_InstallWriteErrorFails(t *testing.T) {
+	if runtime.GOOS == goosWindows {
+		t.Skip("completion --install is a no-op on Windows (file install is unsupported)")
+	}
 	stubIsWindows(t, false)
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -3,6 +3,8 @@ package cmd
 
 import (
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -58,6 +60,53 @@ func TestCompletion_Install(t *testing.T) {
 	cmd.SetArgs([]string{testFlagInstall})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("completion --install should succeed: %v", err)
+	}
+}
+
+// TestCompletion_InstallUnsetHOME verifies the #343 contract: with HOME unset,
+// 'completion --install' fails fast with a clear message and writes nothing into
+// relative paths under the current working directory.
+func TestCompletion_InstallUnsetHOME(t *testing.T) {
+	stubIsWindows(t, false)
+	t.Setenv("HOME", "")
+
+	// Run from an isolated temp working directory so we can detect stray writes.
+	t.Chdir(t.TempDir())
+
+	cmd := newCompletionCmd()
+	cmd.SetArgs([]string{testFlagInstall})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("completion --install should fail when HOME is unset")
+	}
+	if !strings.Contains(err.Error(), "HOME") {
+		t.Errorf("error should mention HOME, got: %v", err)
+	}
+	for _, stray := range []string{".local", ".config", ".zsh", ".zshrc"} {
+		if _, statErr := os.Stat(stray); statErr == nil {
+			t.Errorf("completion --install must not create %q under the working directory when HOME is unset", stray)
+		}
+	}
+}
+
+// TestCompletion_InstallWriteErrorFails verifies the #343 contract: when a
+// completion file cannot be written, the command exits non-zero instead of
+// silently succeeding.
+func TestCompletion_InstallWriteErrorFails(t *testing.T) {
+	stubIsWindows(t, false)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Place a regular file where the bash-completion parent directory must be
+	// created so MkdirAll fails.
+	if err := os.WriteFile(filepath.Join(home, ".local"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newCompletionCmd()
+	cmd.SetArgs([]string{testFlagInstall})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("completion --install should fail when a completion file cannot be written")
 	}
 }
 

--- a/cmd/man.go
+++ b/cmd/man.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nao1215/gup/internal/fileutil"
 	"github.com/nao1215/gup/internal/print"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
@@ -101,6 +102,13 @@ func generateManpages(dst string) error {
 
 func copyManpages(manFiles []string, dst string) error {
 	dst = filepath.Clean(dst)
+
+	// Ensure the target man1 directory exists before writing. A valid custom
+	// MANPATH whose man1 directory is absent should be created rather than
+	// causing a failure; an unwritable target surfaces as a clear error (#344).
+	if err := os.MkdirAll(dst, fileutil.FileModeCreatingDir); err != nil {
+		return fmt.Errorf("can not create man directory %s: %w", dst, err)
+	}
 
 	for _, file := range manFiles {
 		if err := copyOneManpage(filepath.Clean(file), dst); err != nil {

--- a/cmd/man_test.go
+++ b/cmd/man_test.go
@@ -104,10 +104,37 @@ func TestMan(t *testing.T) {
 		}
 	})
 
-	t.Run("failure when MANPATH target dir does not exist", func(t *testing.T) {
+	t.Run("success creates a missing MANPATH man1 dir", func(t *testing.T) {
+		// A valid custom MANPATH whose man1 directory does not exist yet must be
+		// created rather than causing a failure (#344).
 		base := t.TempDir()
-		dst := filepath.Join(base, "not-created", "man1")
-		t.Setenv("MANPATH", dst)
+		manpath := filepath.Join(base, "shareman")
+		t.Setenv("MANPATH", manpath)
+
+		if got := man(nil, nil); got != 0 {
+			t.Fatalf("man() = %d, want 0", got)
+		}
+
+		dst := filepath.Join(manpath, "man1")
+		manFiles, err := filepath.Glob(filepath.Join(dst, "*.1.gz"))
+		if err != nil {
+			t.Fatalf("glob failed: %v", err)
+		}
+		if len(manFiles) == 0 {
+			t.Fatalf("man pages were not written to the auto-created dir %s", dst)
+		}
+	})
+
+	t.Run("failure when MANPATH target is not writable", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("root bypasses directory permissions")
+		}
+		base := t.TempDir()
+		readonly := filepath.Join(base, "readonly")
+		if err := os.MkdirAll(readonly, 0o500); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("MANPATH", filepath.Join(readonly, "shareman"))
 
 		if got := man(nil, nil); got != 1 {
 			t.Fatalf("man() = %d, want 1", got)

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -2,6 +2,7 @@ package completion
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,18 +11,29 @@ import (
 
 	"github.com/nao1215/gup/internal/cmdinfo"
 	"github.com/nao1215/gup/internal/fileutil"
-	"github.com/nao1215/gup/internal/print"
 	"github.com/spf13/cobra"
 )
 
-// DeployShellCompletionFileIfNeeded creates the shell completion file.
-// If the file with the same contents already exists, it is not created.
-func DeployShellCompletionFileIfNeeded(cmd *cobra.Command) {
-	if !IsWindows() {
-		makeBashCompletionFileIfNeeded(cmd)
-		makeFishCompletionFileIfNeeded(cmd)
-		makeZshCompletionFileIfNeeded(cmd)
+// DeployShellCompletionFileIfNeeded creates the shell completion files.
+// If a file with the same contents already exists, it is not recreated.
+//
+// It returns a non-nil error when HOME is unset/empty (so completion files are
+// never written into relative paths under the current directory) or when any
+// required completion file cannot be written. Errors from individual shells are
+// aggregated so a single run reports every failure (#343).
+func DeployShellCompletionFileIfNeeded(cmd *cobra.Command) error {
+	if IsWindows() {
+		return nil
 	}
+	if strings.TrimSpace(os.Getenv("HOME")) == "" {
+		return fmt.Errorf("HOME environment variable is not set; cannot determine where to install shell completion files")
+	}
+
+	return errors.Join(
+		makeBashCompletionFileIfNeeded(cmd),
+		makeFishCompletionFileIfNeeded(cmd),
+		makeZshCompletionFileIfNeeded(cmd),
+	)
 }
 
 // IsWindows check whether runtime is windosw or not.
@@ -29,77 +41,71 @@ func IsWindows() bool {
 	return runtime.GOOS == "windows"
 }
 
-func makeBashCompletionFileIfNeeded(cmd *cobra.Command) {
+func makeBashCompletionFileIfNeeded(cmd *cobra.Command) error {
 	if existSameBashCompletionFile(cmd) {
-		return
+		return nil
 	}
 
 	path := bashCompletionFilePath()
 	bashCompletion := new(bytes.Buffer)
 	if err := cmd.GenBashCompletionV2(bashCompletion, false); err != nil {
-		print.Err(fmt.Errorf("can not generate bash completion content: %w", err))
-		return
+		return fmt.Errorf("can not generate bash completion content: %w", err)
 	}
 
 	if !fileutil.IsDir(filepath.Dir(path)) {
 		if err := os.MkdirAll(filepath.Dir(path), fileutil.FileModeCreatingDir); err != nil {
-			print.Err(fmt.Errorf("can not create bash-completion file: %w", err))
-			return
+			return fmt.Errorf("can not create bash-completion file: %w", err)
 		}
 	}
 	fp, err := os.OpenFile(filepath.Clean(path), os.O_RDWR|os.O_CREATE|os.O_TRUNC, fileutil.FileModeCreatingFile)
 	if err != nil {
-		print.Err(fmt.Errorf("can not open .bash_completion: %w", err))
-		return
+		return fmt.Errorf("can not open .bash_completion: %w", err)
 	}
 	defer func() {
 		if closeErr := fp.Close(); closeErr != nil {
-			print.Err(fmt.Errorf("can not close .bash_completion: %w", closeErr))
+			err = errors.Join(err, fmt.Errorf("can not close .bash_completion: %w", closeErr))
 		}
 	}()
 
 	if _, err := fp.WriteString(bashCompletion.String()); err != nil {
-		print.Err(fmt.Errorf("can not write .bash_completion: %w", err))
-		return
+		return fmt.Errorf("can not write .bash_completion: %w", err)
 	}
+	return err
 }
 
-func makeFishCompletionFileIfNeeded(cmd *cobra.Command) {
+func makeFishCompletionFileIfNeeded(cmd *cobra.Command) error {
 	if isSameFishCompletionFile(cmd) {
-		return
+		return nil
 	}
 
 	path := fishCompletionFilePath()
 	if err := os.MkdirAll(filepath.Dir(path), fileutil.FileModeCreatingDir); err != nil {
-		print.Err(fmt.Errorf("can not create fish-completion file: %w", err))
-		return
+		return fmt.Errorf("can not create fish-completion file: %w", err)
 	}
 
 	if err := cmd.GenFishCompletionFile(path, false); err != nil {
-		print.Err(fmt.Errorf("can not create fish-completion file: %w", err))
-		return
+		return fmt.Errorf("can not create fish-completion file: %w", err)
 	}
+	return nil
 }
 
-func makeZshCompletionFileIfNeeded(cmd *cobra.Command) {
+func makeZshCompletionFileIfNeeded(cmd *cobra.Command) error {
 	if isSameZshCompletionFile(cmd) {
-		return
+		return nil
 	}
 
 	path := zshCompletionFilePath()
 	if err := os.MkdirAll(filepath.Dir(path), fileutil.FileModeCreatingDir); err != nil {
-		print.Err(fmt.Errorf("can not create zsh-completion file: %w", err))
-		return
+		return fmt.Errorf("can not create zsh-completion file: %w", err)
 	}
 
 	if err := cmd.GenZshCompletionFile(path); err != nil {
-		print.Err(fmt.Errorf("can not create zsh-completion file: %w", err))
-		return
+		return fmt.Errorf("can not create zsh-completion file: %w", err)
 	}
-	appendFpathAtZshrcIfNeeded()
+	return appendFpathAtZshrcIfNeeded()
 }
 
-func appendFpathAtZshrcIfNeeded() {
+func appendFpathAtZshrcIfNeeded() (err error) {
 	const zshFpath = `
 # setting for gup command (auto generate)
 fpath=(~/.zsh/completion $fpath)
@@ -107,47 +113,45 @@ autoload -Uz compinit && compinit -i
 `
 	zshrcPath := zshrcPath()
 	if !fileutil.IsFile(zshrcPath) {
-		fp, err := os.OpenFile(filepath.Clean(zshrcPath), os.O_RDWR|os.O_CREATE, fileutil.FileModeCreatingFile)
-		if err != nil {
-			print.Err(fmt.Errorf("can not open .zshrc: %w", err).Error())
-			return
+		fp, openErr := os.OpenFile(filepath.Clean(zshrcPath), os.O_RDWR|os.O_CREATE, fileutil.FileModeCreatingFile)
+		if openErr != nil {
+			return fmt.Errorf("can not open .zshrc: %w", openErr)
 		}
 		defer func() {
 			if closeErr := fp.Close(); closeErr != nil {
-				print.Err(fmt.Errorf("can not close .zshrc: %w", closeErr).Error())
+				err = errors.Join(err, fmt.Errorf("can not close .zshrc: %w", closeErr))
 			}
 		}()
 
-		if _, err := fp.WriteString(zshFpath); err != nil {
-			print.Err(fmt.Errorf("can not write zsh $fpath in .zshrc: %w", err).Error())
+		if _, writeErr := fp.WriteString(zshFpath); writeErr != nil {
+			return fmt.Errorf("can not write zsh $fpath in .zshrc: %w", writeErr)
 		}
-		return
+		return err
 	}
 
-	zshrc, err := os.ReadFile(filepath.Clean(zshrcPath))
-	if err != nil {
-		print.Err(fmt.Errorf("can not read .zshrc: %w", err).Error())
-		return
+	zshrc, readErr := os.ReadFile(filepath.Clean(zshrcPath))
+	if readErr != nil {
+		return fmt.Errorf("can not read .zshrc: %w", readErr)
 	}
 
 	if strings.Contains(string(zshrc), zshFpath) {
-		return
+		return nil
 	}
 
-	fp, err := os.OpenFile(filepath.Clean(zshrcPath), os.O_RDWR|os.O_APPEND, fileutil.FileModeCreatingFile)
-	if err != nil {
-		print.Err(fmt.Errorf("can not open .zshrc: %w", err).Error())
-		return
+	fp, openErr := os.OpenFile(filepath.Clean(zshrcPath), os.O_RDWR|os.O_APPEND, fileutil.FileModeCreatingFile)
+	if openErr != nil {
+		return fmt.Errorf("can not open .zshrc: %w", openErr)
 	}
 	defer func() {
 		if closeErr := fp.Close(); closeErr != nil {
-			print.Err(fmt.Errorf("can not close .zshrc: %w", closeErr).Error())
+			err = errors.Join(err, fmt.Errorf("can not close .zshrc: %w", closeErr))
 		}
 	}()
 
-	if _, err := fp.WriteString(zshFpath); err != nil {
-		print.Err(fmt.Errorf("can not write zsh $fpath in .zshrc: %w", err).Error())
+	if _, writeErr := fp.WriteString(zshFpath); writeErr != nil {
+		return fmt.Errorf("can not write zsh $fpath in .zshrc: %w", writeErr)
 	}
+	return err
 }
 
 func existSameBashCompletionFile(cmd *cobra.Command) bool {
@@ -160,7 +164,8 @@ func existSameBashCompletionFile(cmd *cobra.Command) bool {
 func hasSameBashCompletionContent(cmd *cobra.Command) bool {
 	bashCompletionFileInLocal, err := os.ReadFile(bashCompletionFilePath())
 	if err != nil {
-		print.Err(fmt.Errorf("can not read .bash_completion: %w", err).Error())
+		// The caller only reaches here when the file exists; treat a read error
+		// as "not the same" so the completion file is regenerated.
 		return false
 	}
 

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -41,25 +41,25 @@ func IsWindows() bool {
 	return runtime.GOOS == "windows"
 }
 
-func makeBashCompletionFileIfNeeded(cmd *cobra.Command) error {
+func makeBashCompletionFileIfNeeded(cmd *cobra.Command) (err error) {
 	if existSameBashCompletionFile(cmd) {
 		return nil
 	}
 
 	path := bashCompletionFilePath()
 	bashCompletion := new(bytes.Buffer)
-	if err := cmd.GenBashCompletionV2(bashCompletion, false); err != nil {
-		return fmt.Errorf("can not generate bash completion content: %w", err)
+	if genErr := cmd.GenBashCompletionV2(bashCompletion, false); genErr != nil {
+		return fmt.Errorf("can not generate bash completion content: %w", genErr)
 	}
 
 	if !fileutil.IsDir(filepath.Dir(path)) {
-		if err := os.MkdirAll(filepath.Dir(path), fileutil.FileModeCreatingDir); err != nil {
-			return fmt.Errorf("can not create bash-completion file: %w", err)
+		if mkErr := os.MkdirAll(filepath.Dir(path), fileutil.FileModeCreatingDir); mkErr != nil {
+			return fmt.Errorf("can not create bash-completion file: %w", mkErr)
 		}
 	}
-	fp, err := os.OpenFile(filepath.Clean(path), os.O_RDWR|os.O_CREATE|os.O_TRUNC, fileutil.FileModeCreatingFile)
-	if err != nil {
-		return fmt.Errorf("can not open .bash_completion: %w", err)
+	fp, openErr := os.OpenFile(filepath.Clean(path), os.O_RDWR|os.O_CREATE|os.O_TRUNC, fileutil.FileModeCreatingFile)
+	if openErr != nil {
+		return fmt.Errorf("can not open .bash_completion: %w", openErr)
 	}
 	defer func() {
 		if closeErr := fp.Close(); closeErr != nil {
@@ -67,8 +67,8 @@ func makeBashCompletionFileIfNeeded(cmd *cobra.Command) error {
 		}
 	}()
 
-	if _, err := fp.WriteString(bashCompletion.String()); err != nil {
-		return fmt.Errorf("can not write .bash_completion: %w", err)
+	if _, writeErr := fp.WriteString(bashCompletion.String()); writeErr != nil {
+		return fmt.Errorf("can not write .bash_completion: %w", writeErr)
 	}
 	return err
 }

--- a/internal/completion/completion_more_test.go
+++ b/internal/completion/completion_more_test.go
@@ -1,7 +1,6 @@
 package completion
 
 import (
-	"bytes"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -9,18 +8,7 @@ import (
 	"testing"
 
 	"github.com/nao1215/gup/internal/fileutil"
-	"github.com/nao1215/gup/internal/print"
 )
-
-// capturePrintStderr redirects print.Stderr into a buffer for the test.
-func capturePrintStderr(t *testing.T) *bytes.Buffer {
-	t.Helper()
-	org := print.Stderr
-	buf := &bytes.Buffer{}
-	print.Stderr = buf
-	t.Cleanup(func() { print.Stderr = org })
-	return buf
-}
 
 func TestIsWindows(t *testing.T) {
 	t.Parallel()
@@ -34,14 +22,18 @@ func TestDeployShellCompletionFileIfNeeded(t *testing.T) {
 	cmd := testCompletionCmd()
 
 	if IsWindows() {
-		DeployShellCompletionFileIfNeeded(cmd)
+		if err := DeployShellCompletionFileIfNeeded(cmd); err != nil {
+			t.Errorf("DeployShellCompletionFileIfNeeded() on Windows should be a no-op, got: %v", err)
+		}
 		if fileutil.IsFile(bashCompletionFilePath()) {
 			t.Error("no completion files should be deployed on Windows")
 		}
 		return
 	}
 
-	DeployShellCompletionFileIfNeeded(cmd)
+	if err := DeployShellCompletionFileIfNeeded(cmd); err != nil {
+		t.Fatalf("DeployShellCompletionFileIfNeeded() error = %v", err)
+	}
 
 	for _, path := range []string{
 		bashCompletionFilePath(),
@@ -59,7 +51,30 @@ func TestDeployShellCompletionFileIfNeeded(t *testing.T) {
 
 	// A second run hits the "already up to date" branches and must not error
 	// or duplicate the zshrc fpath block.
-	DeployShellCompletionFileIfNeeded(cmd)
+	if err := DeployShellCompletionFileIfNeeded(cmd); err != nil {
+		t.Errorf("second DeployShellCompletionFileIfNeeded() error = %v", err)
+	}
+}
+
+// TestDeployShellCompletionFileIfNeeded_unsetHOME verifies the #343 contract:
+// with HOME unset, deployment fails fast and writes nothing.
+func TestDeployShellCompletionFileIfNeeded_unsetHOME(t *testing.T) {
+	if IsWindows() {
+		t.Skip("completion install is not supported on Windows")
+	}
+	t.Setenv("HOME", "")
+	t.Chdir(t.TempDir())
+
+	cmd := testCompletionCmd()
+	err := DeployShellCompletionFileIfNeeded(cmd)
+	if err == nil || !strings.Contains(err.Error(), "HOME") {
+		t.Fatalf("expected an error mentioning HOME, got: %v", err)
+	}
+	for _, stray := range []string{".local", ".config", ".zsh", ".zshrc"} {
+		if _, statErr := os.Stat(stray); statErr == nil {
+			t.Errorf("no %q should be created under the working directory when HOME is unset", stray)
+		}
+	}
 }
 
 func TestExistSameBashCompletionFile(t *testing.T) {
@@ -88,7 +103,9 @@ func TestIsSameFishCompletionFile(t *testing.T) {
 		t.Fatal("isSameFishCompletionFile() = true, want false when no file exists")
 	}
 
-	makeFishCompletionFileIfNeeded(cmd)
+	if err := makeFishCompletionFileIfNeeded(cmd); err != nil {
+		t.Fatalf("makeFishCompletionFileIfNeeded() error = %v", err)
+	}
 
 	if !isSameFishCompletionFile(cmd) {
 		t.Fatal("isSameFishCompletionFile() = false, want true after generation")
@@ -106,7 +123,9 @@ func TestIsSameZshCompletionFile(t *testing.T) {
 		t.Fatal("isSameZshCompletionFile() = true, want false when no file exists")
 	}
 
-	makeZshCompletionFileIfNeeded(cmd)
+	if err := makeZshCompletionFileIfNeeded(cmd); err != nil {
+		t.Fatalf("makeZshCompletionFileIfNeeded() error = %v", err)
+	}
 
 	if !isSameZshCompletionFile(cmd) {
 		t.Fatal("isSameZshCompletionFile() = false, want true after generation")
@@ -121,7 +140,9 @@ func TestAppendFpathAtZshrcIfNeeded(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	appendFpathAtZshrcIfNeeded()
+	if err := appendFpathAtZshrcIfNeeded(); err != nil {
+		t.Fatalf("appendFpathAtZshrcIfNeeded() error = %v", err)
+	}
 
 	data, err := os.ReadFile(zshrcPath())
 	if err != nil {
@@ -132,7 +153,9 @@ func TestAppendFpathAtZshrcIfNeeded(t *testing.T) {
 	}
 
 	// Calling again must not duplicate the block (contains-check branch).
-	appendFpathAtZshrcIfNeeded()
+	if err := appendFpathAtZshrcIfNeeded(); err != nil {
+		t.Fatalf("second appendFpathAtZshrcIfNeeded() error = %v", err)
+	}
 	data, err = os.ReadFile(zshrcPath())
 	if err != nil {
 		t.Fatal(err)
@@ -155,11 +178,9 @@ func TestMakeBashCompletionFileIfNeeded_MkdirError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	buf := capturePrintStderr(t)
-	makeBashCompletionFileIfNeeded(cmd)
-
-	if !strings.Contains(buf.String(), "can not create bash-completion file") {
-		t.Errorf("expected MkdirAll error, got: %s", buf.String())
+	err := makeBashCompletionFileIfNeeded(cmd)
+	if err == nil || !strings.Contains(err.Error(), "can not create bash-completion file") {
+		t.Errorf("expected MkdirAll error, got: %v", err)
 	}
 }
 
@@ -176,11 +197,9 @@ func TestMakeBashCompletionFileIfNeeded_OpenError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	buf := capturePrintStderr(t)
-	makeBashCompletionFileIfNeeded(cmd)
-
-	if !strings.Contains(buf.String(), "can not open .bash_completion") {
-		t.Errorf("expected OpenFile error, got: %s", buf.String())
+	err := makeBashCompletionFileIfNeeded(cmd)
+	if err == nil || !strings.Contains(err.Error(), "can not open .bash_completion") {
+		t.Errorf("expected OpenFile error, got: %v", err)
 	}
 }
 
@@ -197,11 +216,9 @@ func TestMakeFishCompletionFileIfNeeded_GenError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	buf := capturePrintStderr(t)
-	makeFishCompletionFileIfNeeded(cmd)
-
-	if !strings.Contains(buf.String(), "can not create fish-completion file") {
-		t.Errorf("expected fish generation error, got: %s", buf.String())
+	err := makeFishCompletionFileIfNeeded(cmd)
+	if err == nil || !strings.Contains(err.Error(), "can not create fish-completion file") {
+		t.Errorf("expected fish generation error, got: %v", err)
 	}
 }
 
@@ -218,11 +235,9 @@ func TestMakeZshCompletionFileIfNeeded_GenError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	buf := capturePrintStderr(t)
-	makeZshCompletionFileIfNeeded(cmd)
-
-	if !strings.Contains(buf.String(), "can not create zsh-completion file") {
-		t.Errorf("expected zsh generation error, got: %s", buf.String())
+	err := makeZshCompletionFileIfNeeded(cmd)
+	if err == nil || !strings.Contains(err.Error(), "can not create zsh-completion file") {
+		t.Errorf("expected zsh generation error, got: %v", err)
 	}
 }
 
@@ -235,11 +250,9 @@ func TestAppendFpathAtZshrcIfNeeded_OpenError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	buf := capturePrintStderr(t)
-	appendFpathAtZshrcIfNeeded()
-
-	if !strings.Contains(buf.String(), "can not open .zshrc") {
-		t.Errorf("expected .zshrc open error, got: %s", buf.String())
+	err := appendFpathAtZshrcIfNeeded()
+	if err == nil || !strings.Contains(err.Error(), "can not open .zshrc") {
+		t.Errorf("expected .zshrc open error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Groups two related CLI-robustness fixes (filesystem writes + environment validation) into one PR. TDD-style (failing test → implementation → green).

Closes #343, #344.

### #343 — `completion --install`: fail on write errors and reject unset HOME
- `internal/completion.DeployShellCompletionFileIfNeeded` now returns an error. The three `make*CompletionFileIfNeeded` helpers propagate their write/open errors instead of only printing them, and failures are aggregated with `errors.Join` so one run reports every shell that failed.
- HOME is validated up front: when `HOME` is empty/unset the command fails fast with a clear message **before** generating anything, so completion files are never written into relative paths (`.local`, `.config`, `.zsh`, `.zshrc`) under the current directory.
- `cmd/completion.go` returns the error from `RunE`; `main.go` already prints it and exits 1.

### #344 — `gup man`: robust for custom MANPATH
- `copyManpages` now creates the target `man1` directory (`os.MkdirAll`) before writing, so a valid custom `MANPATH` whose `man1` dir does not exist succeeds instead of failing. An unwritable target returns a clear error and exits non-zero. The default `/usr/share/man/man1` path behaves as before.

## Tests
- completion: unset-HOME (no stray files + clear error) and write-error exit-code tests at both the command and package level; existing error tests rewritten to assert the returned error rather than captured stderr.
- man: auto-create-missing-`man1` success test and an unwritable-target failure test (skipped under root).

## Coverage
`internal/completion` 77.2% → 81.1%; overall 88.4%. All ≥ 80% threshold.

## Verification
`gofmt`, `go vet`, `go test ./...`, `golangci-lint run ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * `gup completion --install` now reliably returns a non-zero exit when any completion file can’t be written, and fails fast with a clear message if `HOME` is unset (avoiding unintended writes in the current directory).
  * `gup man` now creates the `man1` directory as needed for custom `MANPATH` entries and reports clear errors for unwritable targets.

* **Documentation**
  * Updated README to clarify the `HOME` requirement and the failure/exit behaviors for `completion --install` and `man`.

* **Tests**
  * Added/updated tests covering unset `HOME`, write-error failures, and `MANPATH` directory creation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->