### PR TITLE
fix(bug-report): improve title guidance and align with issue template (#345)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,14 +1,19 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: "[BUG Report] "
+title: ""
 labels: bug
 assignees: ''
 
 ---
 
-## gup version**
-v0.y.z
+<!-- Please write a short, descriptive title summarizing the bug. -->
+
+## gup version
+<!-- Output of `gup version`, e.g. v1.4.0 -->
+
+## OS
+<!-- Operating system and architecture, e.g. linux/amd64 -->
 
 ## Description (About the problem)
 A clear description of the bug encountered.
@@ -19,5 +24,5 @@ Steps to reproduce the bug.
 ## Expected behavior
 Expected behavior.
 
-## Additional details**
+## Additional details
 Any other useful data to share.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * `gup check` and `gup update` now fail fast when both the user-level `gup.json` and `./gup.json` exist and `--file` is omitted, instead of silently picking one — matching the existing `gup import` behavior. (#342)
 * `gup completion --install` now exits non-zero when a completion file cannot be written (previously it could print an error but still exit 0), and fails fast with a clear message when `HOME` is unset instead of writing completion files into relative paths under the current directory. (#343)
 * `gup man` now creates the target `man1` directory when it does not exist (e.g. for a valid custom `MANPATH`) instead of failing, and reports a clear error for unwritable targets. (#344)
+* `gup bug-report` no longer pre-fills a generic placeholder issue title (so reports are less likely to be filed with an empty/placeholder title), now includes the OS alongside the gup version in the generated body, and its help text no longer claims to include broader system information than is actually present. The bug-report issue template is aligned with the command. (#345)
 
 ## [v1.4.0](https://github.com/nao1215/gup/compare/v1.3.1...v1.4.0) (2026-06-22)
 

--- a/cmd/bug_report.go
+++ b/cmd/bug_report.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/url"
+	"runtime"
 	"strings"
 
 	"github.com/nao1215/gup/internal/cmdinfo"
@@ -14,7 +15,7 @@ func newBugReportCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:               "bug-report",
 		Short:             "Submit a bug report at GitHub",
-		Long:              "bug-report opens the default browser to start a bug report which will include useful system information.",
+		Long:              "bug-report opens the default browser to start a bug report pre-filled with your gup version and OS.",
 		Example:           "  gup bug-report",
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
@@ -27,7 +28,9 @@ func newBugReportCmd() *cobra.Command {
 // openBrowserFunc is a function that opens a browser to the specified URL.
 type openBrowserFunc func(string) bool
 
-// bugReport opens the default browser to start a bug report which will include useful system information.
+// bugReport opens the default browser to start a bug report pre-filled with the
+// gup version and OS. The issue title is intentionally left empty so the user is
+// prompted to write a descriptive one instead of submitting a placeholder.
 func bugReport(cmd *cobra.Command, _ []string, openBrowser openBrowserFunc) int {
 	var buf bytes.Buffer
 	version := strings.TrimSpace(cmd.Version)
@@ -53,15 +56,17 @@ Any other useful data to share.
 `
 	)
 	_, _ = fmt.Fprintf(&buf, "## gup version\n%s\n\n", version)
+	_, _ = fmt.Fprintf(&buf, "## OS\n%s/%s\n\n", runtime.GOOS, runtime.GOARCH)
 	buf.WriteString(description)
 	buf.WriteString(toReproduce)
 	buf.WriteString(expectedBehavior)
 	buf.WriteString(additionalDetails)
 
 	body := buf.String()
+	// Leave the title empty so GitHub prompts the user for a descriptive title
+	// rather than offering a placeholder that often gets submitted unchanged.
 	q := url.Values{
-		"title": {"[Bug Report] Title"},
-		"body":  {body},
+		"body": {body},
 	}
 	url := "https://github.com/nao1215/gup/issues/new?" + q.Encode()
 

--- a/cmd/bug_report_test.go
+++ b/cmd/bug_report_test.go
@@ -5,8 +5,10 @@ package cmd
 import (
 	"bytes"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -61,6 +63,39 @@ func Test_bugReport(t *testing.T) {
 	if gotReturnVal != wantReturnVal {
 		t.Errorf("bugReport() = %d; want %d", gotReturnVal, wantReturnVal)
 	}
+}
+
+// Test_bugReport_noPlaceholderTitle verifies the #345 contract: the generated
+// issue URL no longer pre-fills a generic placeholder title that users tend to
+// submit as-is.
+func Test_bugReport_noPlaceholderTitle(t *testing.T) {
+	t.Parallel()
+
+	cmd := newBugReportCmd()
+	cmd.Version = testVersionZero
+
+	bugReport(cmd, nil, func(s string) bool {
+		if strings.Contains(s, url.QueryEscape("[Bug Report] Title")) {
+			t.Errorf("URL should not pre-fill a placeholder title, got: %s", s)
+		}
+		return true
+	})
+}
+
+// Test_bugReport_includesOS verifies the #345 contract: the generated body
+// includes the OS so reports carry the minimum useful diagnostics.
+func Test_bugReport_includesOS(t *testing.T) {
+	t.Parallel()
+
+	cmd := newBugReportCmd()
+	cmd.Version = testVersionZero
+
+	bugReport(cmd, nil, func(s string) bool {
+		if !strings.Contains(s, runtime.GOOS) {
+			t.Errorf("body should include OS %q, got: %s", runtime.GOOS, s)
+		}
+		return true
+	})
 }
 
 func Test_bugReport_fallbackVersion(t *testing.T) {

--- a/cmd/testdata/bug_report/bug_report.txt
+++ b/cmd/testdata/bug_report/bug_report.txt
@@ -1,4 +1,4 @@
-bug-report opens the default browser to start a bug report which will include useful system information.
+bug-report opens the default browser to start a bug report pre-filled with your gup version and OS.
 
 Usage:
   gup bug-report [flags]


### PR DESCRIPTION
## Summary

Improves the bug-report flow so users are guided toward meaningful issue titles, and aligns the command with the issue template. TDD-style.

Closes #345.

### Command (`gup bug-report`)
- **No placeholder title**: the generated GitHub issue URL no longer pre-fills `[Bug Report] Title` (the `title` param is omitted), so GitHub prompts the user for a descriptive title instead of one that often gets submitted unchanged.
- **Include OS**: the generated body now contains an `## OS` section (`GOOS/GOARCH`) in addition to the gup version — the minimum useful diagnostics.
- **Accurate help text**: the `Long` description no longer claims to include broader "system information" than is actually present; it now states it pre-fills the gup version and OS.

### Issue template (`.github/ISSUE_TEMPLATE/bug_report.md`)
- Removed the `[BUG Report] ` placeholder title (`title: ""`) and added a comment asking for a descriptive title.
- Added an `## OS` section and fixed stray `**` typos, so the template asks for the same essential info as the command.

## Tests
- `Test_bugReport_noPlaceholderTitle` — asserts the URL contains no placeholder title.
- `Test_bugReport_includesOS` — asserts the body includes the OS.
- Updated the `--help` golden file for the new description.

## Verification
`gofmt`, `go vet`, `go test ./...`, `golangci-lint run ./...` all pass. (`cmd/bug_report.go` is coverage-excluded per `.octocov.yml`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `gup bug-report` command no longer pre-fills a generic title—users must provide a descriptive one
  * Generated issue bodies now include OS and architecture details alongside the gup version
  * Help text updated to accurately describe what system information is included

<!-- end of auto-generated comment: release notes by coderabbit.ai -->