### PR TITLE
feat(cli): treat an empty environment as a friendly first-run (#350)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Add a `--file`/`-f` flag to `check` and `update` to select which `gup.json` to read saved update channels from (and write back to, for `update`), consistent with `import`/`export`. (#342)
 
+### Changes
+
+* Treat an empty global environment (no binaries installed by `go install` yet) as a normal first-run condition rather than an error: `list`, `check`, `export`, and `update` now exit 0. `list`/`check`/`update` print an informational note (or emit a valid empty `[]` in `--json` mode), and `export` writes an empty `gup.json`. Naming a non-existent binary or excluding everything is still treated as a usage error (exit 1). (#350)
+
 ### Bug Fixes
 
 * `gup update --main` and `check` now fall back from `@main` to `@master` only when the `main` branch does not exist. Build, network, proxy, authentication, timeout, and cancellation failures on `@main` are surfaced as-is instead of silently installing `@master`. (#340)

--- a/README.md
+++ b/README.md
@@ -213,6 +213,14 @@ Each element has these fields: `name`, `import_path`, `module_path`, `channel` (
 
 The array is always valid JSON, including partial failures (those packages get `"status": "error"`; error detail also goes to STDERR so STDOUT stays pure JSON). Exit codes are unchanged—`check` reporting `update-available` still exits `0`.
 
+### Behavior on an empty environment
+An empty global environment (no binaries installed by `go install` yet) is treated as a normal first-run condition, not an error:
+
+- `list`, `check`, and `update` exit `0`, printing a short informational note (or a valid empty `[]` with `--json`).
+- `export` exits `0` and writes an empty `gup.json`.
+
+Naming a binary that is not installed, or excluding every binary, is still a usage error and exits `1`.
+
 ### Export／Import subcommand
 Use export/import when you want to install the same Go binaries across multiple systems.
 `gup.json` stores import path, binary version, and update channel (`latest` / `main` / `master`).

--- a/cmd/args.go
+++ b/cmd/args.go
@@ -7,6 +7,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// emptyEnvMessage is the informational note shown when no Go binaries are
+// installed yet. An empty global environment is treated as a normal first-run
+// condition rather than an error (#350).
+const emptyEnvMessage = "no binaries are installed under $GOPATH/bin or $GOBIN"
+
 // argsGuidance builds a concise, actionable error for a missing-argument
 // situation: a one-line summary followed by one or two example invocations
 // (issue #324). It deliberately stays short and never dumps full help.

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -102,8 +102,24 @@ func check(cmd *cobra.Command, args []string) int {
 	pkgs = extractUserSpecifyPkg(pkgs, args)
 
 	if len(pkgs) == 0 {
-		print.Err("unable to check package: no package information")
-		return 1
+		// With explicit targets, an empty result means the user named binaries
+		// that are not installed: that is a usage error.
+		if len(args) != 0 {
+			print.Err("unable to check package: no package information")
+			return 1
+		}
+		// Otherwise the environment simply has no manageable binaries yet, which
+		// is a normal first-run condition, not an error (#350): emit an empty
+		// JSON array or an informational note and exit 0.
+		if jsonOut {
+			if err := encodeJSONPackages(nil); err != nil {
+				print.Err(err)
+				return 1
+			}
+			return 0
+		}
+		print.Info(emptyEnvMessage)
+		return 0
 	}
 
 	pkgs, err = applyCheckChannels(pkgs, confFile)

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -26,9 +26,13 @@ func Test_check(t *testing.T) {
 		want  int
 	}{
 		{
+			// testdata/check_fail holds a binary not installed by 'go install',
+			// so gup finds zero manageable binaries. Per #350 this empty-but-valid
+			// state is treated as a friendly first-run success (the unmanageable
+			// binary is still surfaced via a warning).
 			name:  "not go install command in $GOBIN",
 			gobin: filepath.Join("testdata", "check_fail"),
-			want:  1,
+			want:  0,
 		},
 	}
 	for _, tt := range tests {
@@ -51,25 +55,38 @@ func Test_check(t *testing.T) {
 			print.Stdout = orgStdout
 			print.Stderr = orgStderr
 
-			if tt.want == 1 {
-				return
-			}
-
 			buf := bytes.Buffer{}
 			_, err = io.Copy(&buf, pr)
 			if err != nil {
 				t.Error(err)
 			}
 			defer pr.Close()
-			got := strings.Split(buf.String(), "\n")
 
-			if !strings.Contains(got[len(got)-2], "posixer") {
-				t.Errorf("posixer package is not included in the update target: %s", got[len(got)-2])
-			}
-			if !strings.Contains(got[len(got)-2], "gal") {
-				t.Errorf("gal package is not included in the update target: %s", got[len(got)-2])
+			// An environment with no manageable binaries reports the friendly
+			// first-run note and exits 0 (#350).
+			if !strings.Contains(buf.String(), "no binaries are installed") {
+				t.Errorf("expected empty-environment note, got: %s", buf.String())
 			}
 		})
+	}
+}
+
+// Test_check_namedTargetNotInstalled verifies the #350 boundary: an empty
+// result caused by the user naming a binary that is not installed is a usage
+// error (exit 1), distinct from a genuinely empty environment (exit 0).
+func Test_check_namedTargetNotInstalled(t *testing.T) {
+	t.Setenv("GOBIN", filepath.Join("testdata", "check_success"))
+
+	var got int
+	out := captureCheckOutput(t, func() int {
+		got = check(newCheckCmd(), []string{"doesnotexist"})
+		return got
+	})
+	if got != 1 {
+		t.Fatalf("check(non-existent target) = %d, want 1", got)
+	}
+	if !strings.Contains(out, "no package information") {
+		t.Errorf("expected a no-package-information error, got: %s", out)
 	}
 }
 
@@ -189,12 +206,14 @@ func Test_check_gobin_is_empty(t *testing.T) {
 		stderr []string
 	}{
 		{
+			// An empty-but-valid environment is a normal first-run condition,
+			// not an error (#350): check succeeds with an informational note.
 			name:  "gobin is empty",
 			gobin: filepath.Join("testdata", "empty_dir"),
 			args:  args{},
-			want:  1,
+			want:  0,
 			stderr: []string{
-				"gup:ERROR: unable to check package: no package information",
+				"no binaries are installed under $GOPATH/bin or $GOBIN",
 				"",
 			},
 		},

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -71,9 +71,10 @@ func export(cmd *cobra.Command, _ []string) int {
 	}
 	pkgs = applySavedChannels(pkgs, confPkgs)
 
+	// An empty-but-valid environment is a normal first-run condition, not an
+	// error (#350): export still succeeds and writes an empty configuration.
 	if len(pkgs) == 0 {
-		print.Err("no package information")
-		return 1
+		print.Warn(emptyEnvMessage + "; exporting an empty configuration")
 	}
 
 	if output {

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -117,16 +117,6 @@ func Test_export(t *testing.T) {
 			want:   1,
 			stderr: []string{},
 		},
-		{
-			name:  "no package information",
-			gobin: filepath.Join("testdata", "text"),
-			want:  1,
-			stderr: []string{
-				"gup:WARN : could not read Go build info from " + filepath.Join("testdata", "text", "dummy.txt") + ": unrecognized file format",
-				"gup:ERROR: no package information",
-				"",
-			},
-		},
 	}
 
 	if runtime.GOOS == goosWindows {
@@ -303,6 +293,33 @@ func Test_export_preservesChannelsFromCanonicalConfig(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("posixer not found in exported config: %+v", exported)
+	}
+}
+
+// Test_export_emptyEnv_writesEmptyConfig verifies the #350 contract: exporting
+// an empty environment succeeds (exit 0) and writes an empty gup.json instead of
+// failing.
+func Test_export_emptyEnv_writesEmptyConfig(t *testing.T) {
+	if err := goutil.CanUseGoCmd(); err != nil {
+		t.Skip("go command is not available")
+	}
+
+	origConfigHome := xdg.ConfigHome
+	t.Cleanup(func() { xdg.ConfigHome = origConfigHome })
+	xdg.ConfigHome = t.TempDir()
+
+	t.Setenv("GOBIN", t.TempDir()) // existing but empty directory
+
+	if got := export(newExportCmd(), []string{}); got != 0 {
+		t.Fatalf("export() on empty env = %d, want 0", got)
+	}
+
+	pkgs, err := config.ReadConfFile(config.FilePath())
+	if err != nil {
+		t.Fatalf("exported config should be readable: %v", err)
+	}
+	if len(pkgs) != 0 {
+		t.Fatalf("exported config should have no packages, got %d", len(pkgs))
 	}
 }
 

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -157,6 +157,14 @@ func Test_export(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.name == testNoConfigDir && runtime.GOOS == goosWindows {
+				// This is a Unix permission test: it relies on "/root" being
+				// unwritable. On Windows that path is writable, so the export
+				// (which now writes an empty config on an empty env, #350) would
+				// succeed. Permission tests are skipped on Windows in this repo.
+				t.Skip("config-dir permission test is not portable on Windows")
+			}
+
 			t.Setenv("GOBIN", tt.gobin)
 
 			if tt.name == testNoConfigDir {

--- a/cmd/jsonout_test.go
+++ b/cmd/jsonout_test.go
@@ -405,6 +405,61 @@ func Test_list_jsonFlag_ambiguousConfigFallsBack(t *testing.T) {
 	}
 }
 
+// Test_emptyEnv_jsonEmitsEmptyArray verifies the #350 contract: in an empty
+// environment, list/check/update --json emit a valid empty JSON array and exit 0
+// instead of printing an error.
+func Test_emptyEnv_jsonEmitsEmptyArray(t *testing.T) {
+	emptyGobin := t.TempDir()
+
+	t.Run("list --json", func(t *testing.T) {
+		t.Setenv("GOBIN", emptyGobin)
+		cmd := newListCmd()
+		if err := cmd.Flags().Set("json", "true"); err != nil {
+			t.Fatal(err)
+		}
+		var got int
+		recs := readJSON(t, func() int { got = list(cmd, nil); return got })
+		if got != 0 {
+			t.Fatalf("list --json on empty env = %d, want 0", got)
+		}
+		if len(recs) != 0 {
+			t.Fatalf("list --json on empty env should be [], got %d records", len(recs))
+		}
+	})
+
+	t.Run("check --json", func(t *testing.T) {
+		t.Setenv("GOBIN", emptyGobin)
+		cmd := newCheckCmd()
+		if err := cmd.Flags().Set("json", "true"); err != nil {
+			t.Fatal(err)
+		}
+		var got int
+		recs := readJSON(t, func() int { got = check(cmd, nil); return got })
+		if got != 0 {
+			t.Fatalf("check --json on empty env = %d, want 0", got)
+		}
+		if len(recs) != 0 {
+			t.Fatalf("check --json on empty env should be [], got %d records", len(recs))
+		}
+	})
+
+	t.Run("update --json", func(t *testing.T) {
+		t.Setenv("GOBIN", emptyGobin)
+		cmd := newUpdateCmd()
+		if err := cmd.Flags().Set("json", "true"); err != nil {
+			t.Fatal(err)
+		}
+		var got int
+		recs := readJSON(t, func() int { got = gup(cmd, nil); return got })
+		if got != 0 {
+			t.Fatalf("update --json on empty env = %d, want 0", got)
+		}
+		if len(recs) != 0 {
+			t.Fatalf("update --json on empty env should be [], got %d records", len(recs))
+		}
+	})
+}
+
 // Test_gup_jsonFlag exercises gup() with --json (and --dry-run) so the
 // flag-parsing and JSON-dispatch branches in gup()/updateWithChannels are
 // covered without performing real installs.

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -40,11 +40,6 @@ func list(cmd *cobra.Command, _ []string) int {
 		return 1
 	}
 
-	if len(pkgs) == 0 {
-		print.Err("unable to list up package: no package information")
-		return 1
-	}
-
 	jsonOut, err := getFlagBool(cmd, "json")
 	if err != nil {
 		print.Err(err)
@@ -60,10 +55,18 @@ func list(cmd *cobra.Command, _ []string) int {
 			confPkgs, _ := readConfFileIfExists(config.FilePath())
 			annotated = applySavedChannels(pkgs, confPkgs)
 		}
+		// An empty environment yields a valid empty JSON array and exit 0 (#350).
 		if err := encodeJSONPackages(listJSONRecords(annotated)); err != nil {
 			print.Err(err)
 			return 1
 		}
+		return 0
+	}
+
+	// An empty-but-valid environment is a normal first-run condition, not an
+	// error (#350).
+	if len(pkgs) == 0 {
+		print.Info(emptyEnvMessage)
 		return 0
 	}
 

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -62,7 +62,6 @@ func Test_list_not_found_go_command(t *testing.T) {
 
 func Test_list_gobin_is_empty(t *testing.T) {
 	type args struct {
-		cmd  *cobra.Command
 		args []string
 	}
 	tests := []struct {
@@ -73,12 +72,14 @@ func Test_list_gobin_is_empty(t *testing.T) {
 		stderr []string
 	}{
 		{
+			// An empty-but-valid environment is a normal first-run condition,
+			// not an error (#350): list succeeds with an informational note.
 			name:  "gobin is empty",
 			gobin: filepath.Join("testdata", "empty_dir"),
 			args:  args{},
-			want:  1,
+			want:  0,
 			stderr: []string{
-				"gup:ERROR: unable to list up package: no package information",
+				"no binaries are installed under $GOPATH/bin or $GOBIN",
 				"",
 			},
 		},
@@ -136,7 +137,7 @@ func Test_list_gobin_is_empty(t *testing.T) {
 			print.Stdout = pw
 			print.Stderr = pw
 
-			if got := list(tt.args.cmd, tt.args.args); got != tt.want {
+			if got := list(newListCmd(), tt.args.args); got != tt.want {
 				t.Errorf("list() = %v, want %v", got, tt.want)
 			}
 			if err := pw.Close(); err != nil {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -168,8 +168,24 @@ func gup(cmd *cobra.Command, args []string) int {
 	pkgs = excludePkgs(excludePkgList, pkgs, jsonOut)
 
 	if len(pkgs) == 0 {
-		print.Err("unable to update package: no package information or no package under $GOBIN")
-		return 1
+		// With explicit targets or --exclude, an empty result means the user
+		// narrowed everything out: that is a usage error.
+		if len(args) != 0 || len(excludePkgList) != 0 {
+			print.Err("unable to update package: no package information or no package under $GOBIN")
+			return 1
+		}
+		// Otherwise the environment simply has no manageable binaries yet, which
+		// is a normal first-run condition, not an error (#350): emit an empty
+		// JSON array or an informational note and exit 0.
+		if jsonOut {
+			if err := encodeJSONPackages(nil); err != nil {
+				print.Err(err)
+				return 1
+			}
+			return 0
+		}
+		print.Info(emptyEnvMessage)
+		return 0
 	}
 
 	confFile, err := getFlagString(cmd, "file")


### PR DESCRIPTION
## Summary

Implements #350: define and harden gup behavior for an empty global environment. An empty environment (no binaries installed by `go install` yet) is now treated as a normal first-run condition rather than an error.

Closes #350.

### New contract
| Command | Empty environment | `--json` (empty) |
|---------|-------------------|------------------|
| `list`  | exit 0 + note | `[]`, exit 0 |
| `check` | exit 0 + note | `[]`, exit 0 |
| `update`| exit 0 + note | `[]`, exit 0 |
| `export`| exit 0, writes an empty `gup.json` (warning to STDERR) | n/a |

The empty-state note is centralized as `emptyEnvMessage` in `cmd/args.go`.

### Preserved as errors (exit 1)
- Naming a binary that is not installed (`gup check sometypo`, `gup update sometypo`).
- Excluding every binary (`gup update --exclude=...` that removes all).
- A missing/unreadable `$GOBIN` directory (distinct from an existing-but-empty one).

The empty-vs-usage-error distinction is gated on whether the user passed targets/`--exclude`, since `getPackageInfoByTargets` filters by targets at fetch time.

## Tests
- Updated `Test_list_gobin_is_empty`, `Test_check_gobin_is_empty`, `Test_check` (the `check_fail` empty-dummy case now exits 0).
- Added `Test_emptyEnv_jsonEmitsEmptyArray` (list/check/update `--json` → `[]`, exit 0), `Test_export_emptyEnv_writesEmptyConfig`, and `Test_check_namedTargetNotInstalled` (bad target still exits 1).

## Coverage
`cmd` ≈ 86%, overall ≈ 88% — both well above the 80% threshold.

## Verification
`gofmt`, `go vet`, `go test ./...`, `golangci-lint run ./...` all pass.

## Docs
README gains a "Behavior on an empty environment" section; CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes / Improvements**
  * `list`, `check`, `export`, and `update` now exit successfully on first run when no Go binaries are installed, showing an informational message instead of failing.
  * In `--json` mode, `list`, `check`, and `update` emit `[]`; `export` writes an empty `gup.json`.
  * If you explicitly name a missing binary (or exclude everything), the command still fails with exit code `1`.

* **Documentation**
  * Updated “How to use” with the empty-environment behavior.

* **Tests**
  * Expanded coverage for empty environments and first-run output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->