### PR TITLE
test(e2e): offline ShellSpec end-to-end suite for the real CLI (#346, #347)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     name: Offline E2E (ShellSpec)
@@ -14,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@v6
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,28 @@
+name: E2E
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  e2e:
+    name: Offline E2E (ShellSpec)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+
+      - name: Install ShellSpec
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/shellspec/shellspec/master/install.sh | sh -s -- --yes
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Run offline end-to-end tests
+        run: make e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,8 +25,9 @@ jobs:
           go-version-file: "go.mod"
 
       - name: Install ShellSpec
+        # Pin to a released version so CI behavior does not drift with upstream master.
         run: |
-          curl -fsSL https://raw.githubusercontent.com/shellspec/shellspec/master/install.sh | sh -s -- --yes
+          curl -fsSL https://raw.githubusercontent.com/shellspec/shellspec/0.28.1/install.sh | sh -s 0.28.1 --yes
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Run offline end-to-end tests

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 gup
+/testproxy
 dist
 cover.*
 /completions

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,6 +47,7 @@ linters:
       - third_party$
       - builtin$
       - examples$
+      - e2e/
 formatters:
   enable:
     - goimports
@@ -56,3 +57,4 @@ formatters:
       - third_party$
       - builtin$
       - examples$
+      - e2e/

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -8,6 +8,7 @@ coverage:
     - "github.com/nao1215/gup/cmd/root.go"
     - "github.com/nao1215/gup/cmd/man.go"
     - "github.com/nao1215/gup/cmd/bug_report.go"
+    - "github.com/nao1215/gup/e2e/testproxy/main.go"
   badge:
     path: doc/coverage.svg
 diff:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@
 * Fix the Homebrew install command in the README to the correct tap form `brew install nao1215/tap/gup`, and rewrite the feature-comparison table so the force-reinstall row is command-scoped (`update` never reinstalls up-to-date binaries; `migrate --force` reinstalls when the target already exists), removing the previously misleading row. (#349)
 * Sync the newer feature sections into all translated READMEs (`doc/{ja,ru,zh-cn,ko,es,fr}`): Quiet output (`--quiet`/`-q`), machine-readable JSON output (`--json`), disable-colorized output (`NO_COLOR`/`--no-color`), and the feature-comparison table; remove the stale `v1.0.0` breaking-change note. `doc_sync_test.go` now guards these sections so future drift fails CI. (#339)
 
+### Tests
+
+* Add an offline end-to-end test suite (ShellSpec) under `e2e/` that exercises the real `gup` binary in an isolated temp `HOME`/`XDG_CONFIG_HOME`/`GOBIN`, with no network access. It covers `list`, `export --output`, `import --file`, `migrate`, and non-TTY `remove`. Run it with `make e2e`; it also runs in CI (`.github/workflows/e2e.yml`). (#346)
+* Extend the offline E2E suite to cover real `check` and `update` flows through the actual `go` toolchain against a self-contained local module proxy (`e2e/testproxy`): up-to-date vs. update-available, installing a newer version, `--main` success, `@main`→`@master` fallback only on branch-not-found, and no fallback when `@main` exists but fails to build. (#347)
+
 ## [v1.4.0](https://github.com/nao1215/gup/compare/v1.3.1...v1.4.0) (2026-06-22)
 
 ### Features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ needs no network access. The suite uses [ShellSpec](https://github.com/shellspec
 
 ```shell
 # Install ShellSpec once (see https://github.com/shellspec/shellspec#installation)
-curl -fsSL https://raw.githubusercontent.com/shellspec/shellspec/master/install.sh | sh -s -- --yes
+curl -fsSL https://raw.githubusercontent.com/shellspec/shellspec/0.28.1/install.sh | sh -s 0.28.1 --yes
 
 # Run the whole offline suite
 make e2e

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,25 @@ make coverage-tree
 
 ![treemap](./doc/img/cover-tree.svg)
 
-### 4. Manage developer tools with Go tool declarations
+### 4. Run the end-to-end tests (optional but recommended for CLI changes)
+gup has an offline end-to-end suite that exercises the real `gup` binary and the
+real `go` toolchain against a self-contained module proxy, all inside a throwaway
+temp tree. It never touches your real `$HOME`, `~/.config/gup`, or `$GOBIN`, and
+needs no network access. The suite uses [ShellSpec](https://github.com/shellspec/shellspec).
+
+```shell
+# Install ShellSpec once (see https://github.com/shellspec/shellspec#installation)
+curl -fsSL https://raw.githubusercontent.com/shellspec/shellspec/master/install.sh | sh -s -- --yes
+
+# Run the whole offline suite
+make e2e
+```
+
+The harness lives under `e2e/`: `e2e/run.sh` builds gup, starts the offline
+module proxy (`e2e/testproxy`), and runs the ShellSpec specs in `e2e/spec/`. The
+same `make e2e` command runs in CI (`.github/workflows/e2e.yml`).
+
+### 5. Manage developer tools with Go tool declarations
 gup manages helper tools via `go.mod` `tool` entries.
 Use the command below to add or update tool dependencies:
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test clean vet fmt chkfmt changelog update-tools help coverage-tree
+.PHONY: build test e2e clean vet fmt chkfmt changelog update-tools help coverage-tree
 
 APP         = gup
 VERSION     = $(shell git describe --tags --abbrev=0)
@@ -28,6 +28,9 @@ clean: ## Clean project
 test: ## Start test
 	env GOOS=$(GOOS) $(GO_TEST) -cover $(GO_PKGROOT) -coverprofile=cover.out
 	$(GO_TOOL) cover -html=cover.out -o cover.html
+
+e2e: ## Run offline end-to-end tests against the real CLI (requires shellspec)
+	./e2e/run.sh
 
 vet: ## Start go vet
 	$(GO_VET) $(GO_PACKAGES)

--- a/e2e/.shellspec
+++ b/e2e/.shellspec
@@ -1,0 +1,3 @@
+--require spec_helper
+--shell bash
+--default-path spec

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# run.sh builds gup, starts a self-contained offline Go module proxy, and runs
+# the ShellSpec end-to-end suite against the real CLI. Everything happens in a
+# throwaway temp tree, so the developer's real $HOME, ~/.config/gup, and $GOBIN
+# are never touched, and no network access is required.
+#
+# Usage: e2e/run.sh [shellspec args...]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
+if ! command -v shellspec >/dev/null 2>&1; then
+	echo "e2e: shellspec is not installed. Install it from https://github.com/shellspec/shellspec" >&2
+	echo "e2e: e.g. 'curl -fsSL https://git.io/shellspec | sh' or 'brew install shellspec'" >&2
+	exit 127
+fi
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/gup-e2e.XXXXXX")"
+cleanup() {
+	if [ -n "${PROXY_PID:-}" ]; then
+		kill "$PROXY_PID" >/dev/null 2>&1 || true
+		wait "$PROXY_PID" 2>/dev/null || true
+	fi
+	# The Go module cache is written read-only; make it removable.
+	chmod -R u+w "$TMP" >/dev/null 2>&1 || true
+	rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP/bin"
+
+echo "e2e: building gup and the test proxy..."
+( cd "$REPO_ROOT" && go build -ldflags '-X github.com/nao1215/gup/internal/cmdinfo.Version=v0.0.0-e2e' -o "$TMP/bin/gup" . )
+( cd "$REPO_ROOT" && go build -o "$TMP/bin/testproxy" ./e2e/testproxy )
+
+echo "e2e: starting offline module proxy..."
+"$TMP/bin/testproxy" -dir "$TMP/proxy" -url-file "$TMP/proxy.url" -addr 127.0.0.1:0 &
+PROXY_PID=$!
+
+# Wait for the proxy to report its URL.
+for _ in $(seq 1 50); do
+	[ -s "$TMP/proxy.url" ] && break
+	sleep 0.1
+done
+if [ ! -s "$TMP/proxy.url" ]; then
+	echo "e2e: test proxy did not start" >&2
+	exit 1
+fi
+
+# Shared, read-only-ish caches across specs (downloads are deduplicated); each
+# spec still gets its own HOME/GOBIN/working dir (see spec_helper.sh).
+export GUP_E2E_BIN="$TMP/bin/gup"
+export GUP_E2E_PROXY="$(cat "$TMP/proxy.url")"
+export GUP_E2E_GOMODCACHE="$TMP/gomodcache"
+export GUP_E2E_GOCACHE="$TMP/gocache"
+export GUP_E2E_TMP="$TMP"
+
+# Pre-warm the shared module cache so gup's child "go" calls during the measured
+# examples never emit "downloading ..." progress to stderr. Branch/build-failure
+# fixtures are warmed too (failures ignored) so only their zips are cached.
+echo "e2e: warming module cache..."
+(
+	export HOME="$TMP/warm/home" GOBIN="$TMP/warm/gobin" GOPATH="$TMP/warm/gopath"
+	export GOMODCACHE="$GUP_E2E_GOMODCACHE" GOCACHE="$GUP_E2E_GOCACHE"
+	export GOPROXY="$GUP_E2E_PROXY" GOSUMDB=off GOFLAGS=-mod=mod GOTOOLCHAIN=local
+	mkdir -p "$GOBIN"
+	for m in \
+		gup.test/uptodate@v1.0.0 \
+		gup.test/outdated@v1.0.0 \
+		gup.test/outdated@v1.1.0 \
+		gup.test/maintool@main \
+		gup.test/mastertool@master \
+		gup.test/badmaintool@v1.0.0 \
+		gup.test/badmaintool@main \
+		gup.test/badmaintool@master; do
+		go install "$m" >/dev/null 2>&1 || true
+	done
+)
+
+echo "e2e: GOPROXY=$GUP_E2E_PROXY"
+cd "$SCRIPT_DIR"
+shellspec "$@"

--- a/e2e/spec/check_spec.sh
+++ b/e2e/spec/check_spec.sh
@@ -1,0 +1,25 @@
+#shellcheck shell=bash
+# End-to-end coverage for `gup check` against the real `go` toolchain and a local
+# offline module proxy (#347).
+
+Describe 'gup check'
+  BeforeEach 'e2e_setup'
+  AfterEach 'e2e_teardown'
+
+  It 'reports up-to-date for a binary already at the latest version'
+    install_fixture gup.test/uptodate@v1.0.0
+    When call gup check --json
+    The status should be success
+    The output should include '"name": "uptodate"'
+    The output should include '"status": "up-to-date"'
+  End
+
+  It 'reports update-available for an outdated binary'
+    install_fixture gup.test/outdated@v1.0.0
+    When call gup check --json
+    The status should be success
+    The output should include '"name": "outdated"'
+    The output should include '"status": "update-available"'
+    The output should include '"latest_version": "v1.1.0"'
+  End
+End

--- a/e2e/spec/export_import_spec.sh
+++ b/e2e/spec/export_import_spec.sh
@@ -1,0 +1,25 @@
+#shellcheck shell=bash
+# End-to-end coverage for `gup export` and `gup import` round-tripping through a
+# gup.json in an isolated, offline environment.
+
+Describe 'gup export / import'
+  BeforeEach 'e2e_setup'
+  AfterEach 'e2e_teardown'
+
+  It 'export --output prints the installed tool as JSON on STDOUT'
+    install_fixture gup.test/outdated@v1.0.0
+    When call gup export --output
+    The status should be success
+    The output should include 'gup.test/outdated'
+    The output should include '"schema_version"'
+  End
+
+  It 'import --file installs the tools listed in a gup.json'
+    config_file="$E2E_WORK/work/gup.json"
+    printf '%s\n' '{"schema_version":1,"packages":[{"name":"uptodate","import_path":"gup.test/uptodate","version":"v1.0.0","channel":"latest"}]}' > "$config_file"
+    When call gup import --file "$config_file"
+    The status should be success
+    The path "$GOBIN/uptodate" should be exist
+    The output should include 'gup.test/uptodate'
+  End
+End

--- a/e2e/spec/list_spec.sh
+++ b/e2e/spec/list_spec.sh
@@ -1,0 +1,28 @@
+#shellcheck shell=bash
+# End-to-end coverage for `gup list` against the real CLI in an isolated,
+# offline environment.
+
+Describe 'gup list'
+  BeforeEach 'e2e_setup'
+  AfterEach 'e2e_teardown'
+
+  It 'lists an installed binary with its import path'
+    install_fixture gup.test/outdated@v1.0.0
+    When call gup list
+    The status should be success
+    The output should include 'outdated'
+    The output should include 'gup.test/outdated'
+  End
+
+  It 'reports a friendly note on an empty environment (#350)'
+    When call gup list
+    The status should be success
+    The output should include 'no binaries are installed'
+  End
+
+  It 'emits a valid empty JSON array on an empty environment with --json'
+    When call gup list --json
+    The status should be success
+    The output should equal '[]'
+  End
+End

--- a/e2e/spec/migrate_spec.sh
+++ b/e2e/spec/migrate_spec.sh
@@ -1,0 +1,19 @@
+#shellcheck shell=bash
+# End-to-end coverage for `gup migrate`, reinstalling binaries from one GOBIN
+# directory into another in an isolated, offline environment.
+
+Describe 'gup migrate'
+  BeforeEach 'e2e_setup'
+  AfterEach 'e2e_teardown'
+
+  It 'reinstalls binaries from BEFORE_PATH into AFTER_PATH'
+    before="$E2E_WORK/work/before"
+    after="$E2E_WORK/work/after"
+    mkdir -p "$before"
+    install_fixture_into "$before" gup.test/outdated@v1.0.0
+    When call gup migrate "$before" "$after"
+    The status should be success
+    The path "$after/outdated" should be exist
+    The output should include 'migration'
+  End
+End

--- a/e2e/spec/remove_spec.sh
+++ b/e2e/spec/remove_spec.sh
@@ -1,0 +1,24 @@
+#shellcheck shell=bash
+# End-to-end coverage for `gup remove`, including the non-TTY safety behavior, in
+# an isolated, offline environment.
+
+Describe 'gup remove'
+  BeforeEach 'e2e_setup'
+  AfterEach 'e2e_teardown'
+
+  It 'removes an installed binary with --force'
+    install_fixture gup.test/outdated@v1.0.0
+    When call gup_no_tty remove --force outdated
+    The status should be success
+    The output should include 'removed'
+    The path "$GOBIN/outdated" should not be exist
+  End
+
+  It 'refuses to remove without --force when stdin is not a TTY (#323)'
+    install_fixture gup.test/outdated@v1.0.0
+    When call gup_no_tty remove outdated
+    The status should be failure
+    The stderr should include 'not a TTY'
+    The path "$GOBIN/outdated" should be exist
+  End
+End

--- a/e2e/spec/spec_helper.sh
+++ b/e2e/spec/spec_helper.sh
@@ -1,0 +1,78 @@
+#shellcheck shell=bash
+# spec_helper.sh sets up the isolated, offline environment every e2e spec runs
+# in. run.sh exports GUP_E2E_BIN (the built gup binary), GUP_E2E_PROXY (the local
+# module proxy URL), and the shared Go caches before invoking shellspec.
+
+# shellcheck disable=SC2034  # used by shellspec
+spec_helper_precheck() {
+  if [ -z "${GUP_E2E_BIN:-}" ] || [ -z "${GUP_E2E_PROXY:-}" ]; then
+    abort "e2e specs must be run via 'make e2e' (or e2e/run.sh), not 'shellspec' directly."
+  fi
+}
+
+spec_helper_loaded() { :; }
+spec_helper_configure() { :; }
+
+# e2e_setup creates a fresh isolated environment for a single example: a private
+# HOME, XDG_CONFIG_HOME, GOBIN, GOPATH and working directory, plus the offline
+# go toolchain settings. It guarantees the test never touches the developer's
+# real ~/.config/gup or real $GOBIN, and never reaches the network.
+e2e_setup() {
+  E2E_WORK="$(mktemp -d "${GUP_E2E_TMP:-${TMPDIR:-/tmp}}/case.XXXXXX")"
+  export HOME="$E2E_WORK/home"
+  export XDG_CONFIG_HOME="$E2E_WORK/home/.config"
+  export GOBIN="$E2E_WORK/gobin"
+  export GOPATH="$E2E_WORK/gopath"
+  export GOMODCACHE="${GUP_E2E_GOMODCACHE}"
+  export GOCACHE="${GUP_E2E_GOCACHE}"
+
+  # Fully offline go toolchain: only our local proxy, no checksum DB, no
+  # automatic toolchain download.
+  export GOPROXY="$GUP_E2E_PROXY"
+  export GOSUMDB="off"
+  export GOFLAGS="-mod=mod"
+  export GOTOOLCHAIN="local"
+  unset GOPRIVATE GONOSUMDB GONOPROXY GONOSUMCHECK 2>/dev/null || true
+
+  mkdir -p "$HOME" "$XDG_CONFIG_HOME" "$GOBIN" "$E2E_WORK/work"
+  cd "$E2E_WORK/work" || return 1
+}
+
+# e2e_teardown removes the per-example working tree.
+e2e_teardown() {
+  if [ -n "${E2E_WORK:-}" ]; then
+    chmod -R u+w "$E2E_WORK" >/dev/null 2>&1 || true
+    rm -rf "$E2E_WORK"
+  fi
+}
+
+# gup runs the built binary under test.
+gup() { "$GUP_E2E_BIN" "$@"; }
+
+# gup_no_tty runs gup with stdin connected to a pipe (not a character device),
+# so gup's "stdin is not a TTY" detection fires deterministically regardless of
+# how the suite is launched. (/dev/null is itself a character device, so it would
+# read as a TTY; a pipe does not.)
+gup_no_tty() { printf '' | "$GUP_E2E_BIN" "$@"; }
+
+# install_fixture installs a module from the offline proxy into the isolated
+# GOBIN using the real go toolchain (e.g. install_fixture gup.test/outdated@v1.0.0).
+# Output is swallowed on success (the module cache is pre-warmed by run.sh, so no
+# download progress is expected) and surfaced only on failure.
+install_fixture() {
+  local out
+  if ! out="$(go install "$1" 2>&1)"; then
+    echo "install_fixture failed for $1: $out" >&2
+    return 1
+  fi
+}
+
+# install_fixture_into installs a module into a specific directory (used to seed
+# a source GOBIN for migrate). Usage: install_fixture_into <dir> <module@version>.
+install_fixture_into() {
+  local out
+  if ! out="$(GOBIN="$1" go install "$2" 2>&1)"; then
+    echo "install_fixture_into failed for $2 -> $1: $out" >&2
+    return 1
+  fi
+}

--- a/e2e/spec/update_spec.sh
+++ b/e2e/spec/update_spec.sh
@@ -1,0 +1,59 @@
+#shellcheck shell=bash
+# End-to-end coverage for `gup update` against the real `go` toolchain and a local
+# offline module proxy (#347), including the @main -> @master fallback rules.
+
+Describe 'gup update'
+  BeforeEach 'e2e_setup'
+  AfterEach 'e2e_teardown'
+
+  It 'updates an outdated binary'
+    install_fixture gup.test/outdated@v1.0.0
+    When call gup update outdated
+    The status should be success
+    The output should include 'outdated'
+    The path "$GOBIN/outdated" should be exist
+  End
+
+  It 'installs the newer version (binary build info reflects v1.1.0)'
+    install_fixture gup.test/outdated@v1.0.0
+    gup update outdated >/dev/null 2>&1
+    When call go version -m "$GOBIN/outdated"
+    The output should include 'gup.test/outdated'
+    The output should include 'v1.1.0'
+  End
+
+  Describe '--main / @master fallback'
+    It 'installs from @main when the main branch exists'
+      install_fixture gup.test/maintool@main
+      When call gup update --main maintool
+      The status should be success
+      The output should include 'maintool'
+      The path "$GOBIN/maintool" should be exist
+    End
+
+    It 'falls back to @master only when the repo has no main branch'
+      install_fixture gup.test/mastertool@master
+      When call gup update --main mastertool
+      The status should be success
+      The output should include 'mastertool'
+      The path "$GOBIN/mastertool" should be exist
+    End
+
+    It 'does NOT fall back to @master when @main exists but fails to build'
+      install_fixture gup.test/badmaintool@v1.0.0
+      When call gup update --main badmaintool
+      The status should be failure
+      The output should include 'update binary under'
+      # The build failure is reported; @master is never tried as a fallback (the
+      # "leaves the binary unchanged" example below proves @master was not used).
+      The stderr should not include 'badmaintool master'
+    End
+
+    It 'leaves the binary unchanged when @main fails to build (no @master fallback)'
+      install_fixture gup.test/badmaintool@v1.0.0
+      gup update --main badmaintool >/dev/null 2>&1 || true
+      When call go version -m "$GOBIN/badmaintool"
+      The output should include 'v1.0.0'
+    End
+  End
+End

--- a/e2e/testproxy/main.go
+++ b/e2e/testproxy/main.go
@@ -1,0 +1,241 @@
+// Command testproxy generates a self-contained Go module proxy tree from
+// in-repo fixtures and serves it over 127.0.0.1, so the end-to-end tests can
+// run real "go install" commands fully offline.
+//
+// It emulates a real GOPROXY closely enough for gup's behavior under test:
+//   - version downloads (.info/.mod/.zip and @v/list, @latest),
+//   - branch resolution via @v/<branch>.info (e.g. @main, @master),
+//   - a missing branch returns HTTP 404 with an "unknown revision <ref>" body,
+//     matching what proxy.golang.org reports, so gup's @main -> @master
+//     fallback (which only triggers on branch-not-found) can be exercised.
+//
+// Usage:
+//
+//	testproxy -dir <proxyDir> -url-file <path> [-addr 127.0.0.1:0]
+//
+// It writes the chosen base URL (e.g. http://127.0.0.1:54321) to -url-file and
+// then serves until the process is killed.
+package main
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// modVersion describes one module version served by the proxy.
+type modVersion struct {
+	module  string // module path, e.g. "gup.test/outdated"
+	version string // semantic or pseudo version
+	mainGo  string // contents of main.go for this version
+}
+
+// branchRef maps a VCS ref (branch name) to a concrete version the proxy
+// resolves it to. A module with a ref absent from this list reports
+// "unknown revision <ref>" for that ref.
+type branchRef struct {
+	module  string
+	ref     string
+	version string
+}
+
+// fixtureTime is a fixed timestamp; tests must be deterministic and the runtime
+// forbids reading the wall clock here anyway.
+const fixtureTime = "2024-01-01T00:00:00Z"
+
+func goMod(module string) string {
+	return "module " + module + "\n\ngo 1.21\n"
+}
+
+func okMain(msg string) string {
+	return "package main\n\nimport \"fmt\"\n\nfunc main() { fmt.Println(\"" + msg + "\") }\n"
+}
+
+// badMain does not compile, so "go install" fails with a build error rather than
+// a branch-not-found error.
+const badMain = "package main\n\nfunc main() { thisSymbolDoesNotExist() }\n"
+
+// fixtures returns the module versions and branch refs the proxy serves.
+//
+// Pseudo-versions use the standard v0.0.0-<utc>-<12 hex> form. Real semantic
+// versions stay within v0/v1 because a v2+ module path would need a /v2 suffix.
+func fixtures() ([]modVersion, []branchRef, map[string][]string, map[string]string) {
+	versions := []modVersion{
+		// uptodate: a single version that is also @latest.
+		{"gup.test/uptodate", "v1.0.0", okMain("uptodate v1.0.0")},
+		// outdated: installed at v1.0.0, newer v1.1.0 available as @latest.
+		{"gup.test/outdated", "v1.0.0", okMain("outdated v1.0.0")},
+		{"gup.test/outdated", "v1.1.0", okMain("outdated v1.1.0")},
+		// maintool: tracked on @main (resolves to a pseudo-version).
+		{"gup.test/maintool", "v0.0.0-20240101000000-00000000000a", okMain("maintool main")},
+		// mastertool: has only a master branch (no main).
+		{"gup.test/mastertool", "v0.0.0-20240101000000-00000000000b", okMain("mastertool master")},
+		// badmaintool: installable at v1.0.0; @main resolves but does NOT compile;
+		// @master resolves and DOES compile. This proves gup must not fall back to
+		// the working @master when @main fails for a non-branch reason.
+		// The @main and @master pseudo-versions sort NEWER than v1.0.0 (they are
+		// "+1 commit after v1.0.0"), so gup actually attempts the install instead
+		// of treating the installed v1.0.0 as up-to-date.
+		{"gup.test/badmaintool", "v1.0.0", okMain("badmaintool v1.0.0")},
+		{"gup.test/badmaintool", "v1.0.1-0.20240102000000-00000000000c", badMain},
+		{"gup.test/badmaintool", "v1.0.1-0.20240102000000-00000000000d", okMain("badmaintool master")},
+	}
+	branches := []branchRef{
+		{"gup.test/maintool", "main", "v0.0.0-20240101000000-00000000000a"},
+		{"gup.test/mastertool", "master", "v0.0.0-20240101000000-00000000000b"},
+		{"gup.test/badmaintool", "main", "v1.0.1-0.20240102000000-00000000000c"},
+		{"gup.test/badmaintool", "master", "v1.0.1-0.20240102000000-00000000000d"},
+	}
+	// @v/list contents per module. Modules tracked only via a branch still need a
+	// (possibly empty) list so the go client's deprecation lookup does not 404.
+	lists := map[string][]string{
+		"gup.test/uptodate":    {"v1.0.0"},
+		"gup.test/outdated":    {"v1.0.0", "v1.1.0"},
+		"gup.test/maintool":    {},
+		"gup.test/mastertool":  {},
+		"gup.test/badmaintool": {"v1.0.0"},
+	}
+	// @latest version per module. The go client resolves @latest even for a
+	// branch install (deprecation lookup), so branch-only modules point @latest
+	// at their branch pseudo-version.
+	latest := map[string]string{
+		"gup.test/uptodate":    "v1.0.0",
+		"gup.test/outdated":    "v1.1.0",
+		"gup.test/maintool":    "v0.0.0-20240101000000-00000000000a",
+		"gup.test/mastertool":  "v0.0.0-20240101000000-00000000000b",
+		"gup.test/badmaintool": "v1.0.0",
+	}
+	return versions, branches, lists, latest
+}
+
+func writeFile(path, content string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil { //nolint:gosec // test fixture dir
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0o644) //nolint:gosec // test fixture file
+}
+
+func infoJSON(version string) string {
+	b, _ := json.Marshal(map[string]string{"Version": version, "Time": fixtureTime})
+	return string(b)
+}
+
+// writeVersion writes the .info/.mod/.zip for one module version.
+func writeVersion(dir string, v modVersion) error {
+	vdir := filepath.Join(dir, v.module, "@v")
+	if err := writeFile(filepath.Join(vdir, v.version+".info"), infoJSON(v.version)); err != nil {
+		return err
+	}
+	if err := writeFile(filepath.Join(vdir, v.version+".mod"), goMod(v.module)); err != nil {
+		return err
+	}
+	zipPath := filepath.Join(vdir, v.version+".zip")
+	if err := os.MkdirAll(filepath.Dir(zipPath), 0o755); err != nil { //nolint:gosec // test fixture dir
+		return err
+	}
+	zf, err := os.Create(zipPath) //nolint:gosec // test fixture path
+	if err != nil {
+		return err
+	}
+	defer func() { _ = zf.Close() }()
+	zw := zip.NewWriter(zf)
+	prefix := v.module + "@" + v.version + "/"
+	for name, content := range map[string]string{"go.mod": goMod(v.module), "main.go": v.mainGo} {
+		w, werr := zw.Create(prefix + name)
+		if werr != nil {
+			return werr
+		}
+		if _, werr := w.Write([]byte(content)); werr != nil {
+			return werr
+		}
+	}
+	return zw.Close()
+}
+
+// generate writes the whole proxy tree under dir.
+func generate(dir string) error {
+	versions, branches, lists, latest := fixtures()
+	for _, v := range versions {
+		if err := writeVersion(dir, v); err != nil {
+			return err
+		}
+	}
+	for _, b := range branches {
+		if err := writeFile(filepath.Join(dir, b.module, "@v", b.ref+".info"), infoJSON(b.version)); err != nil {
+			return err
+		}
+	}
+	for module, vs := range lists {
+		content := ""
+		if len(vs) > 0 {
+			content = strings.Join(vs, "\n") + "\n"
+		}
+		if err := writeFile(filepath.Join(dir, module, "@v", "list"), content); err != nil {
+			return err
+		}
+	}
+	for module, v := range latest {
+		if err := writeFile(filepath.Join(dir, module, "@latest"), infoJSON(v)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// proxyHandler serves the static tree, emulating a real proxy's branch-not-found
+// error for a missing @v/<ref>.info so the go client reports "unknown revision".
+func proxyHandler(root string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		clean := filepath.Clean(r.URL.Path)
+		path := filepath.Join(root, clean)
+		// Keep the resolved path within root (defense in depth for a test server).
+		if !strings.HasPrefix(path, filepath.Clean(root)) {
+			http.NotFound(w, r)
+			return
+		}
+		if data, err := os.ReadFile(path); err == nil { //nolint:gosec // path constrained to root
+			_, _ = w.Write(data)
+			return
+		}
+		if strings.HasSuffix(clean, ".info") {
+			ref := strings.TrimSuffix(filepath.Base(clean), ".info")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = fmt.Fprintf(w, "unknown revision %s", ref)
+			return
+		}
+		http.NotFound(w, r)
+	}
+}
+
+func main() {
+	dir := flag.String("dir", "", "directory to generate the proxy tree into (required)")
+	urlFile := flag.String("url-file", "", "file to write the served base URL into (required)")
+	addr := flag.String("addr", "127.0.0.1:0", "listen address")
+	flag.Parse()
+
+	if *dir == "" || *urlFile == "" {
+		log.Fatal("testproxy: -dir and -url-file are required")
+	}
+	if err := generate(*dir); err != nil {
+		log.Fatalf("testproxy: generate: %v", err)
+	}
+	ln, err := net.Listen("tcp", *addr)
+	if err != nil {
+		log.Fatalf("testproxy: listen: %v", err)
+	}
+	baseURL := "http://" + ln.Addr().String()
+	if err := os.WriteFile(*urlFile, []byte(baseURL), 0o644); err != nil { //nolint:gosec // test url file
+		log.Fatalf("testproxy: write url file: %v", err)
+	}
+	log.Printf("testproxy serving %s from %s", baseURL, *dir)
+	if err := http.Serve(ln, proxyHandler(*dir)); err != nil { //nolint:gosec // long-lived test server
+		log.Fatalf("testproxy: serve: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds an offline end-to-end test suite that exercises the **real** `gup` binary and the **real** `go` toolchain, with no network access and without ever touching the developer's real `$HOME`, `~/.config/gup`, or `$GOBIN`.

Closes #346, #347.

### Framework & design
- **ShellSpec** (the issue's preferred framework). Specs live in `e2e/spec/`.
- `e2e/run.sh` is the single entry point (`make e2e`): it builds `gup`, starts a self-contained offline module proxy, pre-warms a shared module cache, and runs ShellSpec.
- `e2e/testproxy` is a tiny stdlib-only Go program that **generates and serves a local Go module proxy** on `127.0.0.1`. It implements enough of the proxy protocol for real `go install`:
  - version downloads (`.info`/`.mod`/`.zip`, `@v/list`, `@latest`),
  - branch resolution via `@v/<branch>.info` (e.g. `@main`, `@master`),
  - a missing branch returns 404 with an `unknown revision <ref>` body, matching `proxy.golang.org`, so gup's `@main`→`@master` fallback (which only fires on branch-not-found) can be exercised offline.
- Each example runs in a fresh isolated `HOME`/`XDG_CONFIG_HOME`/`GOBIN`/working dir; the go toolchain is locked offline (`GOPROXY=<local>`, `GOSUMDB=off`, `GOTOOLCHAIN=local`).

### Coverage (#346)
`list`, `export --output`, `import --file`, `migrate`, and non-TTY `remove` — plus the empty-environment behavior and the non-TTY safety guard.

### Coverage (#347) — real `check`/`update` through actual `go`
- `check` reports `up-to-date` and `update-available` correctly,
- `update` installs the newer version from local fixtures (verified via the binary's build info),
- `--main` installs from `@main` when it exists,
- `@main`→`@master` fallback happens **only** when the repo has no `main` branch,
- **no** fallback when `@main` exists but fails to build (the working `@master` is deliberately present and must not be used).

## CI / docs
- `make e2e` runs the suite; `.github/workflows/e2e.yml` runs it on Ubuntu for every PR.
- CONTRIBUTING documents the framework and command.
- `e2e/testproxy/main.go` is excluded from coverage (`.octocov.yml`) and from lint (`.golangci.yml`), consistent with existing test-support exclusions.

## Verification
`make e2e` → 16 examples, 0 failures, fully offline. `go test ./...`, `go vet`, `gofmt`, `golangci-lint run ./...` all pass.

Note: #348 (GoReleaser artifact smoke tests) is a separate, release-pipeline-focused PR to keep this one reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an offline ShellSpec end-to-end suite for core CLI commands: list, export/import, remove, migrate, check, and update (including `@main` → `@master` fallback rules).
  * Introduced a throwaway offline test runner and local module proxy support, plus an `e2e` make target.
* **New Features**
  * Added a CI workflow to automatically run the offline end-to-end suite.
* **Documentation**
  * Updated contribution guidance with instructions for running the end-to-end tests.
* **Chores**
  * Updated linting/coverage and ignore rules to exclude end-to-end test artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->