### PR TITLE
ci(release): smoke-test GoReleaser artifacts before publishing (#348)

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -1,0 +1,39 @@
+name: Release Smoke
+
+# Build the GoReleaser artifacts in snapshot mode (no publishing) and smoke-test
+# them on every PR and push to main, so packaging/archive regressions are caught
+# before a release is ever tagged.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: GoReleaser artifact smoke test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+
+      - name: Build release artifacts (snapshot, no publish)
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          version: latest
+          args: release --snapshot --clean --skip=publish,sign,sbom
+
+      - name: Smoke-test artifacts
+        run: ./scripts/smoke_artifacts.sh dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,13 @@ jobs:
         uses: sigstore/cosign-installer@v3
       - name: Install Syft (SBOM generator)
         uses: anchore/sbom-action/download-syft@v0
+      - name: Build artifacts for smoke test (snapshot, no publish)
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          version: latest
+          args: release --snapshot --clean --skip=publish,sign,sbom
+      - name: Smoke-test artifacts before publishing
+        run: ./scripts/smoke_artifacts.sh dist
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
 * Add an offline end-to-end test suite (ShellSpec) under `e2e/` that exercises the real `gup` binary in an isolated temp `HOME`/`XDG_CONFIG_HOME`/`GOBIN`, with no network access. It covers `list`, `export --output`, `import --file`, `migrate`, and non-TTY `remove`. Run it with `make e2e`; it also runs in CI (`.github/workflows/e2e.yml`). (#346)
 * Extend the offline E2E suite to cover real `check` and `update` flows through the actual `go` toolchain against a self-contained local module proxy (`e2e/testproxy`): up-to-date vs. update-available, installing a newer version, `--main` success, `@main`→`@master` fallback only on branch-not-found, and no fallback when `@main` exists but fails to build. (#347)
 
+### CI
+
+* Smoke-test the GoReleaser artifacts before publishing a release: the release workflow now builds a snapshot and runs `scripts/smoke_artifacts.sh` (extracted archive runs `gup --version`, every archive ships the completion files, and the Linux `.deb` installs and runs) before the real `goreleaser release`, so a packaging regression blocks publication. A `Release Smoke` workflow runs the same check on every PR. (#348)
+
 ## [v1.4.0](https://github.com/nao1215/gup/compare/v1.3.1...v1.4.0) (2026-06-22)
 
 ### Features

--- a/scripts/smoke_artifacts.sh
+++ b/scripts/smoke_artifacts.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# smoke_artifacts.sh validates GoReleaser output before it is published.
+#
+# It checks that:
+#   - the host (linux/amd64) archive extracts and `gup --version` runs,
+#   - every archive contains the gup binary and the shell completion files,
+#   - the Linux .deb installs and the installed gup runs, with its bash
+#     completion present.
+#
+# Usage: scripts/smoke_artifacts.sh [dist-dir]   (default: dist)
+set -euo pipefail
+
+DIST="${1:-dist}"
+
+if [ ! -d "$DIST" ]; then
+	echo "smoke: dist directory '$DIST' does not exist (run goreleaser first)" >&2
+	exit 1
+fi
+
+fail() {
+	echo "smoke: FAIL: $*" >&2
+	exit 1
+}
+
+note() { echo "smoke: $*"; }
+
+# Collect archives.
+shopt -s nullglob
+tarballs=("$DIST"/*.tar.gz)
+zips=("$DIST"/*.zip)
+shopt -u nullglob
+
+if [ ${#tarballs[@]} -eq 0 ] && [ ${#zips[@]} -eq 0 ]; then
+	fail "no archives (*.tar.gz / *.zip) found in $DIST"
+fi
+
+# 1) Every archive must contain the gup binary and the completion files.
+check_archive_contents() {
+	local archive="$1" listing
+	case "$archive" in
+	*.zip) listing="$(unzip -Z1 "$archive")" ;;
+	*) listing="$(tar -tzf "$archive")" ;;
+	esac
+	echo "$listing" | grep -Eq '(^|/)gup(\.exe)?$' || fail "$archive is missing the gup binary"
+	echo "$listing" | grep -q 'completions/gup\.bash' || fail "$archive is missing completions/gup.bash"
+	echo "$listing" | grep -q 'completions/gup\.zsh' || fail "$archive is missing completions/gup.zsh"
+	echo "$listing" | grep -q 'completions/gup\.fish' || fail "$archive is missing completions/gup.fish"
+	note "archive contents OK: $(basename "$archive")"
+}
+
+for a in "${tarballs[@]}" "${zips[@]}"; do
+	check_archive_contents "$a"
+done
+
+# 2) The host (linux/amd64) archive must extract and run.
+host_archive=""
+for a in "${tarballs[@]}"; do
+	case "$a" in
+	*_linux_amd64.tar.gz) host_archive="$a" ;;
+	esac
+done
+if [ -z "$host_archive" ]; then
+	fail "no linux/amd64 archive found to execute"
+fi
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+tar -xzf "$host_archive" -C "$workdir"
+[ -x "$workdir/gup" ] || fail "extracted gup binary is not executable"
+version_out="$("$workdir/gup" --version)"
+echo "$version_out" | grep -q 'gup version' || fail "gup --version output unexpected: $version_out"
+note "extracted binary runs: $version_out"
+
+# 3) The Linux .deb (amd64) must install and run, with bash completion present.
+shopt -s nullglob
+debs=("$DIST"/*_linux_amd64.deb)
+shopt -u nullglob
+if [ ${#debs[@]} -gt 0 ] && command -v dpkg >/dev/null 2>&1; then
+	deb="${debs[0]}"
+	note "installing $(basename "$deb")"
+	sudo dpkg -i "$deb"
+	pkg_version="$(gup --version)"
+	echo "$pkg_version" | grep -q 'gup version' || fail "installed gup --version unexpected: $pkg_version"
+	[ -f /usr/share/bash-completion/completions/gup ] || fail ".deb did not install the bash completion"
+	note "deb install OK: $pkg_version"
+else
+	note "skipping .deb install check (no amd64 .deb or dpkg unavailable)"
+fi
+
+note "all artifact smoke checks passed"


### PR DESCRIPTION
## Summary

Adds smoke tests for the GoReleaser artifacts so a packaging/archive regression is caught **before** a release is published.

Closes #348.

## What it checks (`scripts/smoke_artifacts.sh`)
- Every archive (`*.tar.gz`/`*.zip`) ships the `gup` binary and all shell completion files (`completions/gup.bash`/`.zsh`/`.fish`).
- The host (linux/amd64) archive extracts and its binary runs `gup --version`.
- The Linux `.deb` installs (`dpkg -i`) and the installed `gup` runs, with its bash completion present at `/usr/share/bash-completion/completions/gup`.

## Where it runs
- **`release.yml`**: builds a snapshot (`goreleaser release --snapshot --clean --skip=publish,sign,sbom`) and runs the smoke script **before** the real `goreleaser release --clean`. If smoke fails, the job stops and nothing is published.
- **`release-smoke.yml`** (new): runs the same snapshot build + smoke on every PR and push to `main`, so regressions surface early (least-privilege `contents: read`, `persist-credentials: false`).

## Verification
- `scripts/smoke_artifacts.sh` validated locally against a goreleaser-style layout (archive content checks, extract-and-run, deb step skipped when unavailable).
- `bash -n` clean; both workflow files parse as valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added pre-release validation to test artifacts before publication
  * Implemented automated artifact verification workflow on pull requests targeting the main branch
  * Enhanced release quality assurance pipeline to confirm binary functionality and package integrity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->