### PR TITLE
chore(gosign): generate sigstore bundles

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -78,11 +78,10 @@ sboms:
 # covers every published artifact (issue #285).
 signs:
   - cmd: cosign
-    certificate: "${artifact}.pem"
+    signature: "${artifact}.sigstore.json"
     args:
       - sign-blob
-      - "--output-certificate=${certificate}"
-      - "--output-signature=${signature}"
+      - "--bundle=${signature}"
       - "${artifact}"
       - "--yes"
     artifacts: checksum

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ nix profile install nixpkgs#gogup
 ## Verifying release integrity
 Every release ships supply-chain metadata so you can verify what you download:
 
-- **Signed checksums** — `checksums.txt` is signed with [cosign](https://github.com/sigstore/cosign) (keyless), producing `checksums.txt.sig` and `checksums.txt.pem`.
+- **Signed checksums** — `checksums.txt` is signed with [cosign](https://github.com/sigstore/cosign) (keyless), producing `checksums.txt.sigstore.json`.
 - **SBOM** — an SPDX Software Bill of Materials is attached to each release archive.
 - **Build provenance** — SLSA build provenance is attested via GitHub OIDC.
 
@@ -68,8 +68,7 @@ Verify the signed checksums (then check your archive against `checksums.txt`):
 
 ```shell
 cosign verify-blob \
-  --certificate checksums.txt.pem \
-  --signature checksums.txt.sig \
+  --bundle checksums.txt.sigstore.json \
   --certificate-identity-regexp 'https://github.com/nao1215/gup/\.github/workflows/release\.yml@refs/tags/.*' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
   checksums.txt

--- a/doc/es/README.md
+++ b/doc/es/README.md
@@ -61,7 +61,7 @@ nix profile install nixpkgs#gogup
 ## Verificar la integridad del release
 Cada release incluye metadatos de cadena de suministro para que puedas verificar lo que descargas:
 
-- **Checksums firmados** — `checksums.txt` se firma con [cosign](https://github.com/sigstore/cosign) (sin clave), produciendo `checksums.txt.sig` y `checksums.txt.pem`.
+- **Checksums firmados** — `checksums.txt` se firma con [cosign](https://github.com/sigstore/cosign) (sin clave), produciendo `checksums.txt.sigstore.json`.
 - **SBOM** — se adjunta un SPDX Software Bill of Materials a cada archivo del release.
 - **Procedencia de la compilación** — la procedencia de compilación SLSA se atestigua mediante GitHub OIDC.
 
@@ -69,8 +69,7 @@ Verifica los checksums firmados (luego comprueba tu archivo contra `checksums.tx
 
 ```shell
 cosign verify-blob \
-  --certificate checksums.txt.pem \
-  --signature checksums.txt.sig \
+  --bundle checksums.txt.sigstore.json \
   --certificate-identity-regexp 'https://github.com/nao1215/gup/\.github/workflows/release\.yml@refs/tags/.*' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
   checksums.txt

--- a/doc/fr/README.md
+++ b/doc/fr/README.md
@@ -61,7 +61,7 @@ nix profile install nixpkgs#gogup
 ## Vérifier l'intégrité de la release
 Chaque release est accompagnée de métadonnées de chaîne d'approvisionnement afin que vous puissiez vérifier ce que vous téléchargez :
 
-- **Sommes de contrôle signées** — `checksums.txt` est signé avec [cosign](https://github.com/sigstore/cosign) (sans clé), produisant `checksums.txt.sig` et `checksums.txt.pem`.
+- **Sommes de contrôle signées** — `checksums.txt` est signé avec [cosign](https://github.com/sigstore/cosign) (sans clé), produisant `checksums.txt.sigstore.json`.
 - **SBOM** — un SPDX Software Bill of Materials est joint à chaque archive de release.
 - **Provenance de build** — la provenance de build SLSA est attestée via GitHub OIDC.
 
@@ -69,8 +69,7 @@ Vérifiez les sommes de contrôle signées (puis comparez votre archive à `chec
 
 ```shell
 cosign verify-blob \
-  --certificate checksums.txt.pem \
-  --signature checksums.txt.sig \
+  --bundle checksums.txt.sigstore.json \
   --certificate-identity-regexp 'https://github.com/nao1215/gup/\.github/workflows/release\.yml@refs/tags/.*' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
   checksums.txt

--- a/doc/ja/README.md
+++ b/doc/ja/README.md
@@ -90,7 +90,7 @@ nix profile install nixpkgs#gogup
 ## リリースの完全性を検証する
 各リリースには、ダウンロードしたものを検証できるようにサプライチェーンのメタデータが添付されています:
 
-- **署名付きチェックサム** — `checksums.txt` は [cosign](https://github.com/sigstore/cosign)（keyless）で署名され、`checksums.txt.sig` と `checksums.txt.pem` が生成されます。
+- **署名付きチェックサム** — `checksums.txt` は [cosign](https://github.com/sigstore/cosign)（keyless）で署名され、`checksums.txt.sigstore.json` が生成されます。
 - **SBOM** — 各リリースアーカイブに SPDX 形式のソフトウェア部品表（SBOM）が添付されます。
 - **ビルドプロベナンス** — GitHub OIDC を用いて SLSA ビルドプロベナンスが付与されます。
 
@@ -98,8 +98,7 @@ nix profile install nixpkgs#gogup
 
 ```shell
 cosign verify-blob \
-  --certificate checksums.txt.pem \
-  --signature checksums.txt.sig \
+  --bundle checksums.txt.sigstore.json \
   --certificate-identity-regexp 'https://github.com/nao1215/gup/\.github/workflows/release\.yml@refs/tags/.*' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
   checksums.txt

--- a/doc/ko/README.md
+++ b/doc/ko/README.md
@@ -61,7 +61,7 @@ nix profile install nixpkgs#gogup
 ## 릴리스 무결성 검증
 모든 릴리스에는 다운로드한 항목을 검증할 수 있도록 공급망 메타데이터가 함께 제공됩니다.
 
-- **서명된 체크섬** — `checksums.txt`는 [cosign](https://github.com/sigstore/cosign)(키리스)으로 서명되어 `checksums.txt.sig`와 `checksums.txt.pem`을 생성합니다.
+- **서명된 체크섬** — `checksums.txt`는 [cosign](https://github.com/sigstore/cosign)(키리스)으로 서명되어 `checksums.txt.sigstore.json`을 생성합니다.
 - **SBOM** — 각 릴리스 아카이브에 SPDX 소프트웨어 자재 명세서(Software Bill of Materials)가 첨부됩니다.
 - **빌드 출처** — SLSA 빌드 출처(provenance)는 GitHub OIDC를 통해 증명됩니다.
 
@@ -69,8 +69,7 @@ nix profile install nixpkgs#gogup
 
 ```shell
 cosign verify-blob \
-  --certificate checksums.txt.pem \
-  --signature checksums.txt.sig \
+  --bundle checksums.txt.sigstore.json \
   --certificate-identity-regexp 'https://github.com/nao1215/gup/\.github/workflows/release\.yml@refs/tags/.*' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
   checksums.txt

--- a/doc/ru/README.md
+++ b/doc/ru/README.md
@@ -61,7 +61,7 @@ nix profile install nixpkgs#gogup
 ## Проверка целостности релиза
 Каждый релиз поставляется с метаданными цепочки поставок, чтобы вы могли проверить то, что скачиваете:
 
-- **Подписанные контрольные суммы** — `checksums.txt` подписан с помощью [cosign](https://github.com/sigstore/cosign) (без ключей), создавая `checksums.txt.sig` и `checksums.txt.pem`.
+- **Подписанные контрольные суммы** — `checksums.txt` подписан с помощью [cosign](https://github.com/sigstore/cosign) (без ключей), создавая `checksums.txt.sigstore.json`.
 - **SBOM** — к каждому архиву релиза прикреплена SPDX Software Bill of Materials.
 - **Происхождение сборки** — происхождение сборки SLSA удостоверяется через GitHub OIDC.
 
@@ -69,8 +69,7 @@ nix profile install nixpkgs#gogup
 
 ```shell
 cosign verify-blob \
-  --certificate checksums.txt.pem \
-  --signature checksums.txt.sig \
+  --bundle checksums.txt.sigstore.json \
   --certificate-identity-regexp 'https://github.com/nao1215/gup/\.github/workflows/release\.yml@refs/tags/.*' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
   checksums.txt

--- a/doc/zh-cn/README.md
+++ b/doc/zh-cn/README.md
@@ -61,7 +61,7 @@ nix profile install nixpkgs#gogup
 ## 验证发布完整性
 每个发布版本都附带供应链元数据，以便您验证所下载的内容：
 
-- **已签名的校验和** — `checksums.txt` 使用 [cosign](https://github.com/sigstore/cosign)（无密钥）签名，生成 `checksums.txt.sig` 和 `checksums.txt.pem`。
+- **已签名的校验和** — `checksums.txt` 使用 [cosign](https://github.com/sigstore/cosign)（无密钥）签名，生成 `checksums.txt.sigstore.json`。
 - **SBOM** — 每个发布归档都附有 SPDX 软件物料清单（Software Bill of Materials）。
 - **构建溯源** — 通过 GitHub OIDC 对 SLSA 构建溯源进行证明。
 
@@ -69,8 +69,7 @@ nix profile install nixpkgs#gogup
 
 ```shell
 cosign verify-blob \
-  --certificate checksums.txt.pem \
-  --signature checksums.txt.sig \
+  --bundle checksums.txt.sigstore.json \
   --certificate-identity-regexp 'https://github.com/nao1215/gup/\.github/workflows/release\.yml@refs/tags/.*' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
   checksums.txt


### PR DESCRIPTION

<!-- Thanks for contributing to gup! Please fill in the sections below. -->

## Summary

<!-- What does this PR change and why? -->

SSIA, Separate certificate and signature inputs are deprecated as of cosign 3.1.1, https://github.com/sigstore/cosign/releases/tag/v3.1.1

## Related issue

<!-- e.g. Closes #123 -->

## Checklist

- [ ] Added or updated unit tests for the change
- [ ] `make test` / `make vet` / `make fmt` pass locally
- [x] If I changed `README.md`, I updated the translated READMEs under
      `doc/<lang>/README.md` for the affected sections, or confirmed the
      "translation may lag behind English" banner is present
      (see [CONTRIBUTING.md](../CONTRIBUTING.md#documentation-and-translations))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated release integrity verification instructions across all language variants to use Sigstore bundle signing output (`checksums.txt.sigstore.json`) and the `cosign verify-blob --bundle checksums.txt.sigstore.json` verification flow (instead of separate certificate/signature references).

* **Chores**
  * Updated the release signing configuration for keyless cosign signing to produce and bundle signature artifacts in the new `*.sigstore.json` format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->