### PR TITLE
fix(config): fail fast on invalid/ambiguous gup.json and reject directory destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,9 @@ By default:
   1) `$XDG_CONFIG_HOME/gup/gup.json` (if exists)
   2) `./gup.json` (if exists)
 
-If **both** the user-level `gup.json` and `./gup.json` exist, `import`, `check`, and `update` fail fast and ask you to disambiguate with `--file`, instead of silently picking one. You can always override the path with `--file` (`-f`).
+If **both** the user-level `gup.json` and `./gup.json` exist, `import`, `check`, `update`, and `list --json` fail fast and ask you to disambiguate with `--file`, instead of silently picking one. You can always override the path with `--file` (`-f`); `list` accepts `--file` together with `--json` to choose the config that supplies the reported `channel`.
+
+A malformed `gup.json` (invalid JSON or an unsupported `schema_version`) is also treated as an error rather than silently ignored: `check`, `update`, and `export` fail fast and name the offending file, so saved per-package channels are never quietly downgraded to `latest` because the config could not be parsed.
 
 `gup export` always resolves saved update channels from the canonical user-level `gup.json`; `--file`/`--output` only change the export destination, so exporting to a new file never resets a package's channel back to `latest`.
 

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -108,6 +108,13 @@ func check(cmd *cobra.Command, args []string) int {
 			print.Err("unable to check package: no package information")
 			return 1
 		}
+		// An explicitly named --file must be validated even when no binaries are
+		// installed: honoring explicit user input must not depend on unrelated
+		// environment state (#368).
+		if err := validateExplicitConfFile(confFile); err != nil {
+			print.Err(err)
+			return 1
+		}
 		// Otherwise the environment simply has no manageable binaries yet, which
 		// is a normal first-run condition, not an error (#350): emit an empty
 		// JSON array or an informational note and exit 0.
@@ -146,10 +153,12 @@ func applyCheckChannels(pkgs []goutil.Package, confFile string) ([]goutil.Packag
 		return nil, err
 	}
 
+	// A malformed or unreadable config must fail fast instead of silently
+	// falling back to @latest, which would make check compare against the wrong
+	// channel (#369).
 	confPkgs, err := readConfFileIfExists(confReadPath)
 	if err != nil {
-		print.Warn(fmt.Sprintf("failed to read %s: %s (continuing without config)", confReadPath, err))
-		confPkgs = []goutil.Package{}
+		return nil, err
 	}
 
 	return applySavedChannels(pkgs, confPkgs), nil

--- a/cmd/check_channel_test.go
+++ b/cmd/check_channel_test.go
@@ -288,6 +288,112 @@ func Test_check_ambiguousConfigFailsFast(t *testing.T) {
 	}
 }
 
+// Test_check_emptyEnv_validatesExplicitMalformedFile verifies the #368 contract:
+// an explicitly named --file is validated even when no binaries are installed, so
+// a malformed config makes check fail instead of silently succeeding.
+func Test_check_emptyEnv_validatesExplicitMalformedFile(t *testing.T) {
+	setupXDGBase(t)
+	t.Setenv("GOBIN", t.TempDir()) // empty environment
+
+	badJSON := filepath.Join(t.TempDir(), "bad.json")
+	if err := os.WriteFile(badJSON, []byte("{invalid"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newCheckCmd()
+	if err := cmd.Flags().Set("file", badJSON); err != nil {
+		t.Fatalf("failed to set --file: %v", err)
+	}
+
+	var got int
+	out := captureCheckOutput(t, func() int {
+		got = check(cmd, []string{})
+		return got
+	})
+	if got != 1 {
+		t.Fatalf("check() = %d, want 1 for a malformed --file on an empty environment", got)
+	}
+	if !strings.Contains(out, badJSON) {
+		t.Errorf("error should name the failing --file %q, got: %s", badJSON, out)
+	}
+}
+
+// Test_check_emptyEnv_validatesExplicitDirectoryFile verifies #368 for a --file
+// that points to a directory rather than a file.
+func Test_check_emptyEnv_validatesExplicitDirectoryFile(t *testing.T) {
+	setupXDGBase(t)
+	t.Setenv("GOBIN", t.TempDir()) // empty environment
+
+	dir := filepath.Join(t.TempDir(), "config-dir")
+	if err := os.Mkdir(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newCheckCmd()
+	if err := cmd.Flags().Set("file", dir); err != nil {
+		t.Fatalf("failed to set --file: %v", err)
+	}
+
+	got := 0
+	_ = captureCheckOutput(t, func() int {
+		got = check(cmd, []string{})
+		return got
+	})
+	if got != 1 {
+		t.Fatalf("check() = %d, want 1 for a directory --file on an empty environment", got)
+	}
+}
+
+// Test_check_emptyEnv_succeedsWithoutExplicitConfigProblem is the #368 regression
+// guard: an empty environment with no explicit config problem still exits 0.
+func Test_check_emptyEnv_succeedsWithoutExplicitConfigProblem(t *testing.T) {
+	setupXDGBase(t)
+	chdirToTemp(t)
+	t.Setenv("GOBIN", t.TempDir()) // empty environment
+
+	got := 0
+	_ = captureCheckOutput(t, func() int {
+		got = check(newCheckCmd(), []string{})
+		return got
+	})
+	if got != 0 {
+		t.Fatalf("check() = %d, want 0 on an empty environment with no config problem", got)
+	}
+}
+
+// Test_check_failsFastOnMalformedConfig verifies the #369 contract for check:
+// when the resolved config is malformed, check fails fast (naming the path)
+// instead of continuing without config.
+func Test_check_failsFastOnMalformedConfig(t *testing.T) {
+	gobin, err := filepath.Abs(filepath.Join("testdata", "check_success"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	setupXDGBase(t)
+	chdirToTemp(t)
+	t.Setenv("GOBIN", gobin)
+
+	if err := os.MkdirAll(config.DirPath(), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	confPath := config.FilePath()
+	if err := os.WriteFile(confPath, []byte("{invalid"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var got int
+	out := captureCheckOutput(t, func() int {
+		got = check(newCheckCmd(), []string{})
+		return got
+	})
+	if got != 1 {
+		t.Fatalf("check() = %d, want 1 on a malformed config", got)
+	}
+	if !strings.Contains(out, confPath) {
+		t.Errorf("error should name the failing config path %q, got: %s", confPath, out)
+	}
+}
+
 func Test_applySavedChannels(t *testing.T) {
 	confPkgs := []goutil.Package{
 		{Name: testBinMainTool, UpdateChannel: goutil.UpdateChannelMain},

--- a/cmd/config_file.go
+++ b/cmd/config_file.go
@@ -18,6 +18,12 @@ var renameFunc = os.Rename //nolint:gochecknoglobals // swapped in tests to simu
 
 func writeConfigFile(path string, pkgs []goutil.Package) (err error) {
 	path = filepath.Clean(path)
+	// Reject an existing directory before any temp/backup files are created, so
+	// a mistaken path (e.g. 'export --file <dir>') cannot replace a directory
+	// tree with a regular file (#367).
+	if fileutil.IsDir(path) {
+		return fmt.Errorf("%s is a directory, not a file", path)
+	}
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, fileutil.FileModeCreatingDir); err != nil {
 		return fmt.Errorf("%s: %w", "can not make config directory", err)

--- a/cmd/config_file_test.go
+++ b/cmd/config_file_test.go
@@ -245,6 +245,89 @@ func Test_writeConfigFile_noStrayFilesOnRenameFailure(t *testing.T) {
 	assertNoTempFiles(t, dir, filepath.Base(path))
 }
 
+// Test_writeConfigFile_rejectsEmptyDirectory verifies the #367 contract: an
+// existing empty directory passed as the destination is rejected, the directory
+// survives, and no temp/backup artifacts are left behind.
+func Test_writeConfigFile_rejectsEmptyDirectory(t *testing.T) {
+	t.Parallel()
+
+	parent := t.TempDir()
+	target := filepath.Join(parent, "gup.json")
+	if err := os.Mkdir(target, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	err := writeConfigFile(target, []goutil.Package{{Name: testBinPosixer}})
+	if err == nil {
+		t.Fatal("writeConfigFile() should reject an existing directory path")
+	}
+
+	info, statErr := os.Stat(target)
+	if statErr != nil {
+		t.Fatalf("directory should still exist after failed write: %v", statErr)
+	}
+	if !info.IsDir() {
+		t.Fatal("target should still be a directory, not replaced by a file")
+	}
+	assertNoTempFiles(t, parent, filepath.Base(target))
+}
+
+// Test_writeConfigFile_rejectsNonEmptyDirectory verifies #367 for a directory
+// that has contents: the directory and its child are untouched and no *.bak-* is
+// created next to it.
+func Test_writeConfigFile_rejectsNonEmptyDirectory(t *testing.T) {
+	t.Parallel()
+
+	parent := t.TempDir()
+	target := filepath.Join(parent, "gup.json")
+	if err := os.Mkdir(target, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	child := filepath.Join(target, "keep.txt")
+	if err := os.WriteFile(child, []byte("precious"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writeConfigFile(target, []goutil.Package{{Name: testBinPosixer}}); err == nil {
+		t.Fatal("writeConfigFile() should reject a non-empty directory path")
+	}
+
+	if info, statErr := os.Stat(target); statErr != nil || !info.IsDir() {
+		t.Fatalf("directory should survive failed write, stat err = %v", statErr)
+	}
+	if data, readErr := os.ReadFile(filepath.Clean(child)); readErr != nil || string(data) != "precious" {
+		t.Fatalf("directory contents must be unchanged, read err = %v, data = %q", readErr, data)
+	}
+	assertNoTempFiles(t, parent, filepath.Base(target))
+}
+
+// Test_writeConfigFile_regularFileStillWorks is a regression guard ensuring the
+// #367 directory check does not break the normal file-target path.
+func Test_writeConfigFile_regularFileStillWorks(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gup.json")
+
+	pkg := goutil.Package{Name: testBinPosixer, ImportPath: testImportPathPosixer, Version: &goutil.Version{Current: "v0.1.0"}}
+	if err := writeConfigFile(path, []goutil.Package{pkg}); err != nil {
+		t.Fatalf("writeConfigFile() on a regular file path should succeed, got: %v", err)
+	}
+	if !fileExists(t, path) {
+		t.Fatal("expected the config file to be written")
+	}
+	assertNoTempFiles(t, dir, filepath.Base(path))
+}
+
+func fileExists(t *testing.T, path string) bool {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
+}
+
 // assertNoTempFiles fails if any leftover temporary or backup files matching the
 // config file's temp/backup naming pattern remain in dir.
 func assertNoTempFiles(t *testing.T, dir, base string) {

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -64,10 +64,13 @@ func export(cmd *cobra.Command, _ []string) int {
 	// config; --file/--output only change the export destination, not where
 	// channels are read from (#341).
 	channelSource := config.FilePath()
+	// A malformed channel-source config must fail fast instead of silently
+	// exporting every package as @latest, which would drop intentionally pinned
+	// channels such as @main from the written gup.json (#369).
 	confPkgs, err := readConfFileIfExists(channelSource)
 	if err != nil {
-		print.Warn("failed to read " + channelSource + ": " + err.Error())
-		confPkgs = []goutil.Package{}
+		print.Err(err)
+		return 1
 	}
 	pkgs = applySavedChannels(pkgs, confPkgs)
 

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -324,6 +324,103 @@ func Test_export_preservesChannelsFromCanonicalConfig(t *testing.T) {
 	}
 }
 
+// Test_export_rejectsDirectoryDestination verifies the #367 contract through the
+// export command entry point: `export --file <dir>` fails, the directory and its
+// contents survive, and no temp/backup artifacts are left next to it.
+func Test_export_rejectsDirectoryDestination(t *testing.T) {
+	if err := goutil.CanUseGoCmd(); err != nil {
+		t.Skip("go command is not available")
+	}
+
+	origConfigHome := xdg.ConfigHome
+	t.Cleanup(func() { xdg.ConfigHome = origConfigHome })
+	xdg.ConfigHome = t.TempDir()
+	t.Setenv("GOBIN", filepath.Join("testdata", "check_success"))
+
+	parent := t.TempDir()
+	dest := filepath.Join(parent, "gup.json")
+	if err := os.Mkdir(dest, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	child := filepath.Join(dest, "keep.txt")
+	if err := os.WriteFile(child, []byte("precious"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newExportCmd()
+	if err := cmd.Flags().Set("file", dest); err != nil {
+		t.Fatalf("failed to set --file: %v", err)
+	}
+	if got := export(cmd, []string{}); got != 1 {
+		t.Fatalf("export() = %d, want 1 when --file points to a directory", got)
+	}
+
+	if info, statErr := os.Stat(dest); statErr != nil || !info.IsDir() {
+		t.Fatalf("destination directory should survive, stat err = %v", statErr)
+	}
+	if data, readErr := os.ReadFile(filepath.Clean(child)); readErr != nil || string(data) != "precious" {
+		t.Fatalf("directory contents must be unchanged, read err = %v, data = %q", readErr, data)
+	}
+	assertNoTempFiles(t, parent, filepath.Base(dest))
+}
+
+// Test_export_failsFastOnMalformedChannelSource verifies the #369 contract: a
+// malformed channel-source config makes export fail fast instead of silently
+// exporting every package as @latest.
+func Test_export_failsFastOnMalformedChannelSource(t *testing.T) {
+	if err := goutil.CanUseGoCmd(); err != nil {
+		t.Skip("go command is not available")
+	}
+
+	origConfigHome := xdg.ConfigHome
+	t.Cleanup(func() { xdg.ConfigHome = origConfigHome })
+	xdg.ConfigHome = t.TempDir()
+	if err := os.MkdirAll(config.DirPath(), 0o750); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+	if err := os.WriteFile(config.FilePath(), []byte("{invalid"), 0o600); err != nil {
+		t.Fatalf("failed to seed malformed config: %v", err)
+	}
+	t.Setenv("GOBIN", filepath.Join("testdata", "check_success"))
+
+	dest := filepath.Join(t.TempDir(), "exported.json")
+	cmd := newExportCmd()
+	if err := cmd.Flags().Set("file", dest); err != nil {
+		t.Fatalf("failed to set --file: %v", err)
+	}
+	if got := export(cmd, []string{}); got != 1 {
+		t.Fatalf("export() = %d, want 1 on malformed channel source", got)
+	}
+	if fileutil.IsFile(dest) {
+		t.Fatal("export must not write a destination file when the channel source is malformed")
+	}
+}
+
+// Test_export_failsFastOnUnsupportedSchema verifies #369 for a config whose
+// schema_version is not supported: export fails fast rather than dropping
+// channels.
+func Test_export_failsFastOnUnsupportedSchema(t *testing.T) {
+	if err := goutil.CanUseGoCmd(); err != nil {
+		t.Skip("go command is not available")
+	}
+
+	origConfigHome := xdg.ConfigHome
+	t.Cleanup(func() { xdg.ConfigHome = origConfigHome })
+	xdg.ConfigHome = t.TempDir()
+	if err := os.MkdirAll(config.DirPath(), 0o750); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+	unsupported := `{"schema_version":999,"packages":[]}` + "\n"
+	if err := os.WriteFile(config.FilePath(), []byte(unsupported), 0o600); err != nil {
+		t.Fatalf("failed to seed unsupported-schema config: %v", err)
+	}
+	t.Setenv("GOBIN", filepath.Join("testdata", "check_success"))
+
+	if got := export(newExportCmd(), []string{}); got != 1 {
+		t.Fatalf("export() = %d, want 1 on unsupported schema_version", got)
+	}
+}
+
 // Test_export_emptyEnv_writesEmptyConfig verifies the #350 contract: exporting
 // an empty environment succeeds (exit 0) and writes an empty gup.json instead of
 // failing.

--- a/cmd/jsonout_test.go
+++ b/cmd/jsonout_test.go
@@ -350,11 +350,12 @@ func Test_list_jsonFlag(t *testing.T) {
 	}
 }
 
-// Test_list_jsonFlag_ambiguousConfigFallsBack verifies that list --json is
-// read-only and is NOT subject to the #342 ambiguity hard-error: when both the
-// user-level config and ./gup.json exist, list still succeeds and resolves
-// channel hints from the canonical user-level config.
-func Test_list_jsonFlag_ambiguousConfigFallsBack(t *testing.T) {
+// Test_list_jsonFlag_ambiguousConfigFailsFast verifies the #364 contract: list
+// --json uses the same config-resolution rules as check/update/import, so when
+// both the user-level config and ./gup.json exist and no --file is given, it
+// fails fast with the ambiguity error instead of silently picking one. An
+// explicit --file resolves the ambiguity and annotates the saved channel.
+func Test_list_jsonFlag_ambiguousConfigFailsFast(t *testing.T) {
 	gobin, err := filepath.Abs(filepath.Join("testdata", "check_success"))
 	if err != nil {
 		t.Fatal(err)
@@ -366,9 +367,6 @@ func Test_list_jsonFlag_ambiguousConfigFallsBack(t *testing.T) {
 	if err := os.MkdirAll(config.DirPath(), 0o750); err != nil {
 		t.Fatal(err)
 	}
-	// Canonical config records posixer on @main; ./gup.json makes the auto
-	// detection ambiguous and records a DIFFERENT channel (@master), so the test
-	// fails if list reads the local file instead of the canonical config.
 	canonical := `{"schema_version":1,"packages":[{"name":"posixer","import_path":"` + testImportPathPosixer + `","version":"v0.1.0","channel":"main"}]}` + "\n"
 	local := `{"schema_version":1,"packages":[{"name":"posixer","import_path":"` + testImportPathPosixer + `","version":"v0.1.0","channel":"master"}]}` + "\n"
 	if err := os.WriteFile(config.FilePath(), []byte(canonical), 0o600); err != nil {
@@ -378,9 +376,30 @@ func Test_list_jsonFlag_ambiguousConfigFallsBack(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// No --file: the ambiguous config must make list --json fail fast.
+	ambiguousCmd := newListCmd()
+	if err := ambiguousCmd.Flags().Set("json", "true"); err != nil {
+		t.Fatalf("failed to set json flag: %v", err)
+	}
+	var ambiguousGot int
+	out := captureCheckOutput(t, func() int {
+		ambiguousGot = list(ambiguousCmd, []string{})
+		return ambiguousGot
+	})
+	if ambiguousGot != 1 {
+		t.Errorf("list --json = %d, want 1 on ambiguous config", ambiguousGot)
+	}
+	if !strings.Contains(out, "multiple gup.json") || !strings.Contains(out, "--file") {
+		t.Errorf("expected ambiguity error mentioning --file, got: %s", out)
+	}
+
+	// Explicit --file resolves the ambiguity and annotates the saved channel.
 	cmd := newListCmd()
 	if err := cmd.Flags().Set("json", "true"); err != nil {
 		t.Fatalf("failed to set json flag: %v", err)
+	}
+	if err := cmd.Flags().Set("file", config.LocalFilePath()); err != nil {
+		t.Fatalf("failed to set file flag: %v", err)
 	}
 
 	var got int
@@ -389,14 +408,14 @@ func Test_list_jsonFlag_ambiguousConfigFallsBack(t *testing.T) {
 		return got
 	})
 	if got != 0 {
-		t.Fatalf("list --json should succeed despite ambiguous config, got %d", got)
+		t.Fatalf("list --json --file should succeed in ambiguous repo state, got %d", got)
 	}
 	foundPosixer := false
 	for _, r := range recs {
 		if r.ImportPath == testImportPathPosixer {
 			foundPosixer = true
-			if r.Channel != string(goutil.UpdateChannelMain) {
-				t.Errorf("posixer channel = %q, want main (from canonical config fallback)", r.Channel)
+			if r.Channel != string(goutil.UpdateChannelMaster) {
+				t.Errorf("posixer channel = %q, want master (from explicit --file ./gup.json)", r.Channel)
 			}
 		}
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/fatih/color"
-	"github.com/nao1215/gup/internal/config"
 	"github.com/nao1215/gup/internal/goutil"
 	"github.com/nao1215/gup/internal/print"
 	"github.com/spf13/cobra"
@@ -25,6 +24,10 @@ func newListCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().Bool("json", false, "output result as machine-readable JSON")
+	cmd.Flags().StringP("file", "f", "", "specify gup.json file path to read saved update channels from (with --json)")
+	if err := cmd.MarkFlagFilename("file", "json"); err != nil {
+		panic(err)
+	}
 	return cmd
 }
 
@@ -46,16 +49,37 @@ func list(cmd *cobra.Command, _ []string) int {
 		return 1
 	}
 
+	confFile, err := getFlagString(cmd, "file")
+	if err != nil {
+		print.Err(err)
+		return 1
+	}
+
 	if jsonOut {
-		annotated, cerr := applyCheckChannels(pkgs, "")
-		if cerr != nil {
-			// list is read-only and is not the command targeted by the
-			// ambiguity check (#342); fall back to the user-level config for
-			// channel hints instead of failing.
-			confPkgs, _ := readConfFileIfExists(config.FilePath())
-			annotated = applySavedChannels(pkgs, confPkgs)
+		// An empty environment has no packages to annotate, so emit a valid
+		// empty JSON array and exit 0 without resolving config (#350). An
+		// explicitly named --file is still validated for consistency with
+		// check/update (#368).
+		if len(pkgs) == 0 {
+			if err := validateExplicitConfFile(confFile); err != nil {
+				print.Err(err)
+				return 1
+			}
+			if err := encodeJSONPackages(listJSONRecords(nil)); err != nil {
+				print.Err(err)
+				return 1
+			}
+			return 0
 		}
-		// An empty environment yields a valid empty JSON array and exit 0 (#350).
+		// Use the same config-resolution rules as check/update/import so the
+		// reported channel matches what those commands would actually use, and
+		// fail fast on an ambiguous or malformed config instead of silently
+		// picking the user-level one (#364).
+		annotated, cerr := applyCheckChannels(pkgs, confFile)
+		if cerr != nil {
+			print.Err(cerr)
+			return 1
+		}
 		if err := encodeJSONPackages(listJSONRecords(annotated)); err != nil {
 			print.Err(err)
 			return 1

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -164,6 +164,12 @@ func gup(cmd *cobra.Command, args []string) int {
 		return 1
 	}
 
+	confFile, err := getFlagString(cmd, "file")
+	if err != nil {
+		print.Err(err)
+		return 1
+	}
+
 	pkgs = extractUserSpecifyPkg(pkgs, args)
 	pkgs = excludePkgs(excludePkgList, pkgs, jsonOut)
 
@@ -172,6 +178,13 @@ func gup(cmd *cobra.Command, args []string) int {
 		// narrowed everything out: that is a usage error.
 		if len(args) != 0 || len(excludePkgList) != 0 {
 			print.Err("unable to update package: no package information or no package under $GOBIN")
+			return 1
+		}
+		// An explicitly named --file must be validated even when no binaries are
+		// installed: honoring explicit user input must not depend on unrelated
+		// environment state (#368).
+		if err := validateExplicitConfFile(confFile); err != nil {
+			print.Err(err)
 			return 1
 		}
 		// Otherwise the environment simply has no manageable binaries yet, which
@@ -188,11 +201,6 @@ func gup(cmd *cobra.Command, args []string) int {
 		return 0
 	}
 
-	confFile, err := getFlagString(cmd, "file")
-	if err != nil {
-		print.Err(err)
-		return 1
-	}
 	// When both the user-level config and ./gup.json exist and no --file is
 	// given, fail fast instead of silently choosing one (#342), consistent with
 	// import and check.
@@ -203,10 +211,13 @@ func gup(cmd *cobra.Command, args []string) int {
 	}
 	confWritePath := resolveConfWritePath(confFile, confReadPath)
 
+	// A malformed or unreadable config must fail fast instead of silently
+	// falling back to @latest, which would update from the wrong channel and
+	// then persist that downgrade back to gup.json (#369).
 	confPkgs, err := readConfFileIfExists(confReadPath)
 	if err != nil {
-		print.Warn(fmt.Sprintf("failed to read %s: %s (continuing without config)", confReadPath, err))
-		confPkgs = []goutil.Package{}
+		print.Err(err)
+		return 1
 	}
 
 	channelMap, err := resolveUpdateChannels(pkgs, confPkgs, mainPkgNames, masterPkgNames, latestPkgNames)
@@ -570,6 +581,12 @@ func packageUpdateChannel(name string, fallback goutil.UpdateChannel, channelMap
 }
 
 func readConfFileIfExists(path string) ([]goutil.Package, error) {
+	// A directory passed where a gup.json file is expected is a user mistake,
+	// not "no config": reject it so check/update/export fail fast instead of
+	// silently ignoring the path (#367, #368).
+	if fileutil.IsDir(path) {
+		return nil, fmt.Errorf("%s is a directory, not a gup.json file", path)
+	}
 	if !fileutil.IsFile(path) {
 		return []goutil.Package{}, nil
 	}
@@ -578,6 +595,24 @@ func readConfFileIfExists(path string) ([]goutil.Package, error) {
 		return nil, err
 	}
 	return pkgs, nil
+}
+
+// validateExplicitConfFile validates an explicitly provided --file path so that
+// 'check' and 'update' honor it even on an empty environment, where the normal
+// config read is otherwise skipped (#368). An empty confFile means no --file was
+// given, so there is nothing to validate. A malformed file, an unsupported
+// schema version, or a directory path is reported as an error; a non-existent
+// path is left as "no config", matching the non-empty-environment behavior.
+func validateExplicitConfFile(confFile string) error {
+	if strings.TrimSpace(confFile) == "" {
+		return nil
+	}
+	path, err := config.ResolveImportFilePath(confFile)
+	if err != nil {
+		return err
+	}
+	_, err = readConfFileIfExists(path)
+	return err
 }
 
 func shouldPersistChannels(mainPkgNames, masterPkgNames, latestPkgNames []string) bool {

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -403,6 +403,82 @@ func Test_gup_ignoreGoUpdateFlag(t *testing.T) {
 	}
 }
 
+// Test_gup_emptyEnv_validatesExplicitMalformedFile verifies the #368 contract
+// for update: an explicit --file is validated even when no binaries are
+// installed, so a malformed config fails instead of being silently ignored.
+func Test_gup_emptyEnv_validatesExplicitMalformedFile(t *testing.T) {
+	setupXDGBase(t)
+	t.Setenv("GOBIN", t.TempDir()) // empty environment
+
+	badJSON := filepath.Join(t.TempDir(), "bad.json")
+	if err := os.WriteFile(badJSON, []byte("{invalid"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newUpdateCmd()
+	if err := cmd.Flags().Set("file", badJSON); err != nil {
+		t.Fatalf("failed to set --file: %v", err)
+	}
+
+	var got int
+	out := captureCheckOutput(t, func() int {
+		got = gup(cmd, []string{})
+		return got
+	})
+	if got != 1 {
+		t.Fatalf("gup() = %d, want 1 for a malformed --file on an empty environment", got)
+	}
+	if !strings.Contains(out, badJSON) {
+		t.Errorf("error should name the failing --file %q, got: %s", badJSON, out)
+	}
+}
+
+// Test_gup_emptyEnv_validatesExplicitDirectoryFile verifies #368 for update when
+// --file points to a directory.
+func Test_gup_emptyEnv_validatesExplicitDirectoryFile(t *testing.T) {
+	setupXDGBase(t)
+	t.Setenv("GOBIN", t.TempDir()) // empty environment
+
+	dir := filepath.Join(t.TempDir(), "config-dir")
+	if err := os.Mkdir(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newUpdateCmd()
+	if err := cmd.Flags().Set("file", dir); err != nil {
+		t.Fatalf("failed to set --file: %v", err)
+	}
+
+	got := 0
+	_ = captureCheckOutput(t, func() int {
+		got = gup(cmd, []string{})
+		return got
+	})
+	if got != 1 {
+		t.Fatalf("gup() = %d, want 1 for a directory --file on an empty environment", got)
+	}
+}
+
+// Test_gup_emptyEnv_succeedsWithoutExplicitConfigProblem is the #368 regression
+// guard: an empty environment with no explicit config problem still exits 0.
+func Test_gup_emptyEnv_succeedsWithoutExplicitConfigProblem(t *testing.T) {
+	setupXDGBase(t)
+	chdirToTemp(t)
+	t.Setenv("GOBIN", t.TempDir()) // empty environment
+
+	got := 0
+	_ = captureCheckOutput(t, func() int {
+		got = gup(newUpdateCmd(), []string{})
+		return got
+	})
+	if got != 0 {
+		t.Fatalf("gup() = %d, want 0 on an empty environment with no config problem", got)
+	}
+}
+
+// Test_gup_invalidConfigFile verifies the #369 contract: a malformed gup.json is
+// not silently treated as "no config" (which would downgrade saved channels to
+// @latest); update fails fast and names the failing path instead.
 func Test_gup_invalidConfigFile(t *testing.T) {
 	setupXDGBase(t)
 	t.Setenv("GOBIN", filepath.Join("testdata", "check_success"))
@@ -416,8 +492,16 @@ func Test_gup_invalidConfigFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got := gup(newUpdateCmd(), []string{}); got != 0 {
-		t.Fatalf("gup() = %v, want %v (invalid config should be warned, not fatal)", got, 0)
+	var got int
+	out := captureCheckOutput(t, func() int {
+		got = gup(newUpdateCmd(), []string{})
+		return got
+	})
+	if got != 1 {
+		t.Fatalf("gup() = %v, want %v (malformed config must fail fast)", got, 1)
+	}
+	if !strings.Contains(out, confPath) {
+		t.Errorf("error should name the failing config path %q, got: %s", confPath, out)
 	}
 }
 


### PR DESCRIPTION
## Overview

Makes `gup`'s config-file (`gup.json`) handling consistent and safe across `check`, `update`, `export`, and `list --json`, fixing four related issues in one change.

## Changes

### Fail fast on invalid `gup.json` (#369)
`check`, `update`, and `export` previously **warned and continued** when the selected `gup.json` could not be read or parsed, silently discarding saved per-package channels and falling back to `@latest`. This could make `check` compare against the wrong channel, `update` install from the wrong channel, and `export` emit `latest` for a package intentionally pinned to `main`. They now fail fast and name the offending file.

### Validate explicit `--file` on an empty environment (#368)
`check --file <path>` and `update --file <path>` returned success on an empty environment (no installed binaries) **before** validating the explicit config path. Now an explicitly named `--file` is validated regardless of environment state: malformed JSON or a directory path is reported as an error, while a non-existent path stays "no config" (matching the non-empty path). Empty-environment success with no explicit config problem is preserved.

### Reject directory destinations for `export --file` (#367)
`export --file <dir>` could replace an existing directory with a regular file (exit 0), and for a non-empty directory move it aside as a `*.bak-*` path. `writeConfigFile` now rejects an existing directory **before** any temp/backup files are created; the directory and its contents remain untouched and no `*.tmp-*`/`*.bak-*` artifacts are left behind.

### Consistent config resolution for `list --json` (#364)
`gup list --json` silently fell back to the user-level config on an ambiguous state. It now uses the same resolution rules as `check`/`update`/`import` (fails fast when both the user-level `gup.json` and `./gup.json` exist with no `--file`), and gains a `--file` flag to disambiguate. An empty environment still emits a valid empty JSON array and exits 0.

## Tests
- Directory-rejection (empty/non-empty dir, no stray temp/backup, regular-file regression) at both `writeConfigFile` and `export` command level.
- Empty-environment `--file` validation (malformed / directory / regression) for `check` and `update`.
- Fail-fast on malformed / unsupported-schema config for `check`, `update`, `export`.
- `list --json` ambiguity fail-fast and `--file` resolution.
- Updated the two existing tests that pinned the old warn-and-continue / silent-fallback behavior.

All unit tests, `golangci-lint`, and the offline ShellSpec e2e suite (18/18) pass.

## Docs
README config section updated to document the malformed/unsupported-schema fail-fast and `list --json --file`.

Closes #364
Closes #367
Closes #368
Closes #369


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--file`/`-f` flag to `gup list` for explicit config selection.

* **Bug Fixes**
  * Commands now fail fast on ambiguous configuration when both user and local `gup.json` exist, requiring `--file`.
  * Malformed or unsupported `gup.json` no longer gets ignored; commands now error out and report the offending path.
  * Directory destinations/inputs are rejected instead of proceeding.
  * `check`, `update`, `export`, and `list --json` now validate explicitly provided configs even in empty environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->