### PR TITLE
fix(json): stabilize --json output ordering for parallel commands

### DIFF
--- a/cmd/jsonout.go
+++ b/cmd/jsonout.go
@@ -70,7 +70,9 @@ func resultToJSONPackage(v updateResult) jsonPackage {
 }
 
 // resultsToJSONPackages converts execution results into JSON records, preserving
-// completion order.
+// the order of the given results. executePackages returns results in input
+// order, so --json output stays deterministic across runs regardless of worker
+// completion order (#365).
 func resultsToJSONPackages(results []updateResult) []jsonPackage {
 	recs := make([]jsonPackage, 0, len(results))
 	for _, v := range results {

--- a/cmd/jsonout_test.go
+++ b/cmd/jsonout_test.go
@@ -6,11 +6,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nao1215/gup/internal/config"
 	"github.com/nao1215/gup/internal/goutil"
@@ -185,6 +187,43 @@ func Test_doCheck_jsonOutput(t *testing.T) {
 	}
 	if got["outdated"] != statusUpdateAvailable {
 		t.Errorf("outdated status = %q, want %q", got["outdated"], statusUpdateAvailable)
+	}
+}
+
+// Test_doCheckJSON_stableInputOrder verifies the #365 contract end-to-end for
+// check --json: even when the latest-version lookup resolves earlier packages
+// last (inverting completion order), the emitted JSON array stays in input
+// order.
+func Test_doCheckJSON_stableInputOrder(t *testing.T) {
+	origLatest := getLatestVerCtx
+	t.Cleanup(func() { getLatestVerCtx = origLatest })
+
+	const total = 6
+	pkgs := make([]goutil.Package, total)
+	sleepByModule := make(map[string]time.Duration, total)
+	for i := 0; i < total; i++ {
+		p := newCheckPkg(fmt.Sprintf("tool-%d", i), testVersionTwo, goutil.UpdateChannelLatest)
+		pkgs[i] = p
+		// Earlier packages resolve slower so they complete last.
+		sleepByModule[p.ModulePath] = time.Duration(total-i) * 3 * time.Millisecond
+	}
+
+	getLatestVerCtx = func(_ context.Context, modulePath string) (string, error) {
+		time.Sleep(sleepByModule[modulePath])
+		return testVersionTwo, nil
+	}
+
+	recs := readJSON(t, func() int {
+		return doCheckJSON(pkgs, total, 0, true)
+	})
+
+	if len(recs) != total {
+		t.Fatalf("got %d records, want %d", len(recs), total)
+	}
+	for i, r := range recs {
+		if want := fmt.Sprintf("tool-%d", i); r.Name != want {
+			t.Errorf("records[%d].Name = %q, want %q (stable input order)", i, r.Name, want)
+		}
 	}
 }
 

--- a/cmd/parallel.go
+++ b/cmd/parallel.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -77,8 +78,13 @@ func summarizeResults(results []updateResult, isCheck bool) string {
 // executePackages runs worker over each package with signal-based cancellation
 // and a per-package timeout, then reports results via collectResults. It is the
 // shared operation engine used by update, check, import, and migrate. It returns
-// the exit code (1 if any package failed) and the per-package results in
-// completion order.
+// the exit code (1 if any package failed) and the per-package results in the
+// original input order.
+//
+// Human-readable progress is still streamed in completion order inside
+// collectResults; only the returned slice is reordered, so machine-readable
+// (--json) output is deterministic across runs regardless of worker scheduling
+// (#365).
 func executePackages(pkgs []goutil.Package, cpus int, timeout time.Duration,
 	worker func(context.Context, goutil.Package) updateResult,
 	onResult func(prefix string, v updateResult)) (int, []updateResult) {
@@ -86,7 +92,11 @@ func executePackages(pkgs []goutil.Package, cpus int, timeout time.Duration,
 	defer stopSignalCancelContext(cancel, signals)
 
 	ch := forEachPackage(ctx, pkgs, cpus, timeout, worker)
-	return collectResults(ch, len(pkgs), onResult)
+	code, results := collectResults(ch, len(pkgs), onResult)
+	sort.SliceStable(results, func(i, j int) bool {
+		return results[i].inputIndex < results[j].inputIndex
+	})
+	return code, results
 }
 
 // forEachPackage runs fn for each package with a fixed-size worker pool.
@@ -108,18 +118,27 @@ func forEachPackage(ctx context.Context, pkgs []goutil.Package, cpus int, timeou
 		cpus = len(pkgs)
 	}
 
-	jobs := make(chan goutil.Package)
+	// Each job carries the package's position in the input slice so the result
+	// can be reordered back to input order for deterministic --json output,
+	// independent of which worker finishes first (#365).
+	type indexedPackage struct {
+		index int
+		pkg   goutil.Package
+	}
+	jobs := make(chan indexedPackage)
 	var wg sync.WaitGroup
 
 	worker := func() {
 		defer wg.Done()
 
-		for p := range jobs {
+		for job := range jobs {
 			select {
 			case <-ctx.Done():
-				ch <- updateResult{pkg: p, err: ctx.Err()}
+				ch <- updateResult{pkg: job.pkg, err: ctx.Err(), inputIndex: job.index}
 			default:
-				ch <- runWithTimeout(ctx, timeout, p, fn)
+				res := runWithTimeout(ctx, timeout, job.pkg, fn)
+				res.inputIndex = job.index
+				ch <- res
 			}
 		}
 	}
@@ -132,11 +151,11 @@ func forEachPackage(ctx context.Context, pkgs []goutil.Package, cpus int, timeou
 	go func() {
 		defer close(jobs)
 
-		for _, p := range pkgs {
+		for i, p := range pkgs {
 			select {
 			case <-ctx.Done():
-				ch <- updateResult{pkg: p, err: ctx.Err()}
-			case jobs <- p:
+				ch <- updateResult{pkg: p, err: ctx.Err(), inputIndex: i}
+			case jobs <- indexedPackage{index: i, pkg: p}:
 			}
 		}
 	}()

--- a/cmd/parallel_test.go
+++ b/cmd/parallel_test.go
@@ -573,6 +573,9 @@ func TestExecutePackages_StableInputOrderWithFailures(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("executePackages exit code = %d, want 1 (some failed)", code)
 	}
+	if len(results) != total {
+		t.Fatalf("received %d results, want %d", len(results), total)
+	}
 	for i, r := range results {
 		if want := pkgs[i].Name; r.pkg.Name != want {
 			t.Fatalf("results[%d].pkg.Name = %q, want %q (input order preserved across mixed outcomes)", i, r.pkg.Name, want)

--- a/cmd/parallel_test.go
+++ b/cmd/parallel_test.go
@@ -493,6 +493,97 @@ func TestExecutePackages_TimeoutIsolation(t *testing.T) {
 	}
 }
 
+// TestExecutePackages_StableInputOrder verifies the #365 contract: even when
+// workers finish in the reverse of input order, executePackages returns results
+// in the original input order, so the JSON records derived from them are
+// deterministic across runs. The worker sleeps longer for earlier packages so
+// completion order is inverted relative to input order.
+func TestExecutePackages_StableInputOrder(t *testing.T) {
+	t.Parallel()
+
+	const total = 8
+	pkgs := makePkgs(total)
+
+	// Earlier input index -> longer sleep -> finishes later. Workers only read
+	// this map (built before the run), so concurrent access is safe.
+	sleepByName := make(map[string]time.Duration, total)
+	for i, p := range pkgs {
+		sleepByName[p.Name] = time.Duration(total-i) * 3 * time.Millisecond
+	}
+
+	code, results := executePackages(pkgs, total, 0,
+		func(_ context.Context, p goutil.Package) updateResult {
+			time.Sleep(sleepByName[p.Name])
+			return updateResult{pkg: p, status: statusUpdated}
+		},
+		nil)
+
+	if code != 0 {
+		t.Fatalf("executePackages exit code = %d, want 0", code)
+	}
+	if len(results) != total {
+		t.Fatalf("received %d results, want %d", len(results), total)
+	}
+	for i, r := range results {
+		if want := pkgs[i].Name; r.pkg.Name != want {
+			t.Errorf("results[%d].pkg.Name = %q, want %q (input order)", i, r.pkg.Name, want)
+		}
+	}
+
+	// The JSON records must follow the same input order.
+	recs := resultsToJSONPackages(results)
+	for i, rec := range recs {
+		if want := pkgs[i].Name; rec.Name != want {
+			t.Errorf("json record[%d].Name = %q, want %q (input order)", i, rec.Name, want)
+		}
+	}
+}
+
+// TestExecutePackages_StableInputOrderWithFailures verifies #365 holds when the
+// results are a mix of successes and failures (the update/check --json case):
+// failed and succeeded records stay interleaved in input order, not grouped by
+// outcome or completion time.
+func TestExecutePackages_StableInputOrderWithFailures(t *testing.T) {
+	t.Parallel()
+
+	const total = 10
+	pkgs := makePkgs(total)
+
+	sleepByName := make(map[string]time.Duration, total)
+	for i, p := range pkgs {
+		sleepByName[p.Name] = time.Duration(total-i) * 2 * time.Millisecond
+	}
+
+	// Even-indexed packages fail; odd-indexed succeed.
+	failByName := make(map[string]bool, total)
+	for i, p := range pkgs {
+		failByName[p.Name] = i%2 == 0
+	}
+
+	code, results := executePackages(pkgs, total, 0,
+		func(_ context.Context, p goutil.Package) updateResult {
+			time.Sleep(sleepByName[p.Name])
+			if failByName[p.Name] {
+				return updateResult{pkg: p, err: errors.New("boom"), status: statusError}
+			}
+			return updateResult{pkg: p, status: statusUpdated}
+		},
+		nil)
+
+	if code != 1 {
+		t.Fatalf("executePackages exit code = %d, want 1 (some failed)", code)
+	}
+	for i, r := range results {
+		if want := pkgs[i].Name; r.pkg.Name != want {
+			t.Fatalf("results[%d].pkg.Name = %q, want %q (input order preserved across mixed outcomes)", i, r.pkg.Name, want)
+		}
+		wantErr := i%2 == 0
+		if (r.err != nil) != wantErr {
+			t.Errorf("results[%d] err presence = %v, want %v", i, r.err != nil, wantErr)
+		}
+	}
+}
+
 // TestForEachPackage_ProducerCancellation exercises the producer's ctx.Done
 // branch while it is dispatching jobs. With a single worker and a context that
 // is canceled before draining, the producer must emit ctx.Err() results for the

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -291,6 +291,7 @@ type updateResult struct {
 	skipped     bool   // true when the package was intentionally skipped (no error)
 	skipReason  string // human-readable reason when skipped is true
 	status      string // machine-readable status for --json output (see jsonout.go)
+	inputIndex  int    // position of this package in the original input slice (#365)
 }
 
 func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus int, ignoreGoUpdate bool, channelMap map[string]goutil.UpdateChannel, timeout time.Duration, jsonOut, quiet bool) (exitCode int, succeeded []goutil.Package, renamed map[string]string) {


### PR DESCRIPTION
## Overview

`check`, `update`, `import`, and `migrate` run package work in parallel and collected results in **completion order**. The human-readable streaming output is naturally completion-ordered, but the `--json` output reused that same path, so the order of elements in the JSON array varied between runs depending on goroutine scheduling and timing.

This is fine for interactive progress but creates needless noise for snapshot tests, scripted diffs, repeated CI comparisons, and anyone diffing output across runs.

## Change

The shared operation engine `executePackages` (used by all four commands) now threads each package's **input index** through the worker pool and returns results sorted back into the original input order. Human-readable progress is still streamed in completion order inside `collectResults` — only the returned slice (and therefore `--json` output) is reordered.

- `updateResult` gains an `inputIndex` field.
- `forEachPackage` dispatches `{index, pkg}` jobs and stamps the index on each result (including the cancellation path), preserving the exactly-one-result-per-package invariant.
- `executePackages` does a `sort.SliceStable` by `inputIndex` before returning.

Exit codes, `status` values, and `error` semantics are unchanged.

## Tests
- `TestExecutePackages_StableInputOrder` — workers complete in reverse order, results (and derived JSON records) stay in input order.
- `TestExecutePackages_StableInputOrderWithFailures` — input order preserved across a mix of success/failure records.
- `Test_doCheckJSON_stableInputOrder` — end-to-end `check --json` with an inverted version-lookup completion order.

All unit tests (incl. `-race`), `golangci-lint`, and the existing parallel-engine invariants pass.

Closes #365


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deterministic behavior for `--json` and package execution results by ensuring entries follow the original input package order, regardless of concurrent worker completion order.

* **Tests**
  * Added regression coverage that forces out-of-order completion (via delays) and verifies stable input ordering for both all-success and mixed success/failure runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->