### PR TITLE
fix(completion): honor XDG paths and ZDOTDIR in completion --install

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,9 +353,14 @@ $ gup completion powershell > gup.ps1
 $ gup completion --install
 ```
 
-`--install` requires `HOME` to be set; it fails fast (without writing files into
-the current directory) when `HOME` is empty, and exits non-zero if any
-completion file cannot be written.
+`--install` writes to the paths that match your shell/config layout: bash honors
+`XDG_DATA_HOME` (falling back to `$HOME/.local/share`), fish honors
+`XDG_CONFIG_HOME` (falling back to `$HOME/.config`), and zsh resolves both the
+completion file and `.zshrc` via `ZDOTDIR` (falling back to `$HOME`). It still
+requires `HOME` to be set; it fails fast (without writing files into the current
+directory) when `HOME` is empty, and exits non-zero if any completion file
+cannot be written. Re-running `--install` is idempotent and does not duplicate
+the zsh init snippet in `.zshrc`.
 
 ### Desktop notification
 If you use gup with --notify option, gup command notify you on your desktop whether the update was successful or unsuccessful after the update was finished.

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain clears XDG_DATA_HOME, XDG_CONFIG_HOME, and ZDOTDIR for the whole
+// package so completion-install tests that assert HOME-rooted paths are
+// deterministic regardless of the ambient environment (CI runners may set these,
+// which 'gup completion --install' now honors). Tests that exercise those
+// variables set them explicitly via t.Setenv, which is restored after each test
+// (#366).
+func TestMain(m *testing.M) {
+	_ = os.Unsetenv("XDG_DATA_HOME")
+	_ = os.Unsetenv("XDG_CONFIG_HOME")
+	_ = os.Unsetenv("ZDOTDIR")
+	os.Exit(m.Run())
+}

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -105,12 +105,31 @@ func makeZshCompletionFileIfNeeded(cmd *cobra.Command) error {
 	return appendFpathAtZshrcIfNeeded()
 }
 
-func appendFpathAtZshrcIfNeeded() (err error) {
-	const zshFpath = `
-# setting for gup command (auto generate)
-fpath=(~/.zsh/completion $fpath)
+// zshFpathMarker is the comment line that uniquely identifies gup's fpath block
+// in .zshrc. Idempotency keys on this marker rather than the full snippet text so
+// a re-run never appends a second block even if the referenced completion
+// directory differs between runs (e.g. ZDOTDIR toggled while .zshrc resolves to
+// the same file).
+const zshFpathMarker = "# setting for gup command (auto generate)"
+
+// zshFpathSnippet returns the fpath block written to .zshrc. The completion
+// directory it references tracks zshCompletionFilePath: under ZDOTDIR it expands
+// via ${ZDOTDIR} (zsh expands ~ to $HOME, not $ZDOTDIR), otherwise it uses the
+// portable ~/.zsh/completion form (#366).
+func zshFpathSnippet() string {
+	completionDir := "~/.zsh/completion"
+	if strings.TrimSpace(os.Getenv("ZDOTDIR")) != "" {
+		completionDir = "${ZDOTDIR}/.zsh/completion"
+	}
+	return fmt.Sprintf(`
+%s
+fpath=(%s $fpath)
 autoload -Uz compinit && compinit -i
-`
+`, zshFpathMarker, completionDir)
+}
+
+func appendFpathAtZshrcIfNeeded() (err error) {
+	zshFpath := zshFpathSnippet()
 	zshrcPath := zshrcPath()
 	if !fileutil.IsFile(zshrcPath) {
 		fp, openErr := os.OpenFile(filepath.Clean(zshrcPath), os.O_RDWR|os.O_CREATE, fileutil.FileModeCreatingFile)
@@ -134,7 +153,7 @@ autoload -Uz compinit && compinit -i
 		return fmt.Errorf("can not read .zshrc: %w", readErr)
 	}
 
-	if strings.Contains(string(zshrc), zshFpath) {
+	if strings.Contains(string(zshrc), zshFpathMarker) {
 		return nil
 	}
 
@@ -223,22 +242,51 @@ func isSameZshCompletionFile(cmd *cobra.Command) bool {
 	return true
 }
 
+// xdgDataHome returns the base directory for user data files, honoring
+// XDG_DATA_HOME when set and falling back to $HOME/.local/share otherwise (#366).
+func xdgDataHome() string {
+	if dir := strings.TrimSpace(os.Getenv("XDG_DATA_HOME")); dir != "" {
+		return dir
+	}
+	return filepath.Join(os.Getenv("HOME"), ".local", "share")
+}
+
+// xdgConfigHome returns the base directory for user config files, honoring
+// XDG_CONFIG_HOME when set and falling back to $HOME/.config otherwise (#366).
+func xdgConfigHome() string {
+	if dir := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); dir != "" {
+		return dir
+	}
+	return filepath.Join(os.Getenv("HOME"), ".config")
+}
+
+// zshDotDir returns the directory zsh reads its startup files from, honoring
+// ZDOTDIR when set and falling back to $HOME otherwise (#366). Both the zsh
+// completion files and .zshrc are resolved relative to this directory so the
+// install matches the user's active zsh configuration layout.
+func zshDotDir() string {
+	if dir := strings.TrimSpace(os.Getenv("ZDOTDIR")); dir != "" {
+		return dir
+	}
+	return os.Getenv("HOME")
+}
+
 // bashCompletionFilePath return bash-completion file path.
 func bashCompletionFilePath() string {
-	return filepath.Join(os.Getenv("HOME"), ".local", "share", "bash-completion", "completions", cmdinfo.Name)
+	return filepath.Join(xdgDataHome(), "bash-completion", "completions", cmdinfo.Name)
 }
 
 // fishCompletionFilePath return fish-completion file path.
 func fishCompletionFilePath() string {
-	return filepath.Join(os.Getenv("HOME"), ".config", "fish", "completions", cmdinfo.Name+".fish")
+	return filepath.Join(xdgConfigHome(), "fish", "completions", cmdinfo.Name+".fish")
 }
 
 // zshCompletionFilePath return zsh-completion file path.
 func zshCompletionFilePath() string {
-	return filepath.Join(os.Getenv("HOME"), ".zsh", "completion", "_"+cmdinfo.Name)
+	return filepath.Join(zshDotDir(), ".zsh", "completion", "_"+cmdinfo.Name)
 }
 
 // zshrcPath return .zshrc path.
 func zshrcPath() string {
-	return filepath.Join(os.Getenv("HOME"), ".zshrc")
+	return filepath.Join(zshDotDir(), ".zshrc")
 }

--- a/internal/completion/completion_more_test.go
+++ b/internal/completion/completion_more_test.go
@@ -10,6 +10,17 @@ import (
 	"github.com/nao1215/gup/internal/fileutil"
 )
 
+// TestMain clears the XDG/ZDOTDIR variables for the whole package so the many
+// tests that assert HOME-rooted completion paths are deterministic regardless of
+// the ambient environment. Tests that exercise those variables set them
+// explicitly via t.Setenv, which is restored after each test (#366).
+func TestMain(m *testing.M) {
+	_ = os.Unsetenv("XDG_DATA_HOME")
+	_ = os.Unsetenv("XDG_CONFIG_HOME")
+	_ = os.Unsetenv("ZDOTDIR")
+	os.Exit(m.Run())
+}
+
 func TestIsWindows(t *testing.T) {
 	t.Parallel()
 	if got, want := IsWindows(), runtime.GOOS == "windows"; got != want {
@@ -56,6 +67,118 @@ func TestDeployShellCompletionFileIfNeeded(t *testing.T) {
 	}
 }
 
+// TestBashCompletionFilePath_HonorsXDGDataHome verifies the #366 contract: bash
+// completion installs under XDG_DATA_HOME when it is set, not under
+// $HOME/.local/share.
+func TestBashCompletionFilePath_HonorsXDGDataHome(t *testing.T) {
+	if IsWindows() {
+		t.Skip("completion install is not supported on Windows")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	xdgData := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdgData)
+	cmd := testCompletionCmd()
+
+	if err := makeBashCompletionFileIfNeeded(cmd); err != nil {
+		t.Fatalf("makeBashCompletionFileIfNeeded() error = %v", err)
+	}
+
+	got := bashCompletionFilePath()
+	if !strings.HasPrefix(got, xdgData) {
+		t.Errorf("bash completion path = %q, want it rooted at XDG_DATA_HOME %q", got, xdgData)
+	}
+	if strings.HasPrefix(got, filepath.Join(home, ".local")) {
+		t.Errorf("bash completion path = %q, must not fall back to $HOME/.local/share when XDG_DATA_HOME is set", got)
+	}
+	if !fileutil.IsFile(got) {
+		t.Errorf("bash completion file was not written at %q", got)
+	}
+}
+
+// TestFishCompletionFilePath_HonorsXDGConfigHome verifies the #366 contract: fish
+// completion installs under XDG_CONFIG_HOME when it is set, not under
+// $HOME/.config.
+func TestFishCompletionFilePath_HonorsXDGConfigHome(t *testing.T) {
+	if IsWindows() {
+		t.Skip("fish completion is not deployed on Windows")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	xdgConfig := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdgConfig)
+	cmd := testCompletionCmd()
+
+	if err := makeFishCompletionFileIfNeeded(cmd); err != nil {
+		t.Fatalf("makeFishCompletionFileIfNeeded() error = %v", err)
+	}
+
+	got := fishCompletionFilePath()
+	if !strings.HasPrefix(got, xdgConfig) {
+		t.Errorf("fish completion path = %q, want it rooted at XDG_CONFIG_HOME %q", got, xdgConfig)
+	}
+	if strings.HasPrefix(got, filepath.Join(home, ".config")) {
+		t.Errorf("fish completion path = %q, must not fall back to $HOME/.config when XDG_CONFIG_HOME is set", got)
+	}
+	if !fileutil.IsFile(got) {
+		t.Errorf("fish completion file was not written at %q", got)
+	}
+}
+
+// TestZshCompletionInstall_HonorsZDOTDIR verifies the #366 contract: zsh resolves
+// both the completion file and .zshrc via ZDOTDIR, the appended fpath snippet
+// points at ${ZDOTDIR}, and repeated appends do not duplicate the snippet.
+func TestZshCompletionInstall_HonorsZDOTDIR(t *testing.T) {
+	if IsWindows() {
+		t.Skip("zsh completion is not deployed on Windows")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	zdot := t.TempDir()
+	t.Setenv("ZDOTDIR", zdot)
+	cmd := testCompletionCmd()
+
+	if err := makeZshCompletionFileIfNeeded(cmd); err != nil {
+		t.Fatalf("makeZshCompletionFileIfNeeded() error = %v", err)
+	}
+
+	comp := zshCompletionFilePath()
+	if !strings.HasPrefix(comp, zdot) {
+		t.Errorf("zsh completion path = %q, want it rooted at ZDOTDIR %q", comp, zdot)
+	}
+	if !fileutil.IsFile(comp) {
+		t.Errorf("zsh completion file was not written at %q", comp)
+	}
+
+	rc := zshrcPath()
+	if !strings.HasPrefix(rc, zdot) {
+		t.Errorf(".zshrc path = %q, want it rooted at ZDOTDIR %q", rc, zdot)
+	}
+	if !fileutil.IsFile(rc) {
+		t.Fatalf(".zshrc was not created at %q", rc)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(rc))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "${ZDOTDIR}/.zsh/completion") {
+		t.Errorf("fpath snippet should reference ${ZDOTDIR}/.zsh/completion under ZDOTDIR, got:\n%s", data)
+	}
+
+	// Repeated install must not duplicate the snippet.
+	if err := appendFpathAtZshrcIfNeeded(); err != nil {
+		t.Fatalf("second appendFpathAtZshrcIfNeeded() error = %v", err)
+	}
+	data, err = os.ReadFile(filepath.Clean(rc))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(data), "auto generate"); got != 1 {
+		t.Errorf("fpath block appears %d times under ZDOTDIR, want 1 (no duplication)", got)
+	}
+}
+
 // TestDeployShellCompletionFileIfNeeded_unsetHOME verifies the #343 contract:
 // with HOME unset, deployment fails fast and writes nothing.
 func TestDeployShellCompletionFileIfNeeded_unsetHOME(t *testing.T) {
@@ -69,6 +192,32 @@ func TestDeployShellCompletionFileIfNeeded_unsetHOME(t *testing.T) {
 	err := DeployShellCompletionFileIfNeeded(cmd)
 	if err == nil || !strings.Contains(err.Error(), "HOME") {
 		t.Fatalf("expected an error mentioning HOME, got: %v", err)
+	}
+	for _, stray := range []string{".local", ".config", ".zsh", ".zshrc"} {
+		if _, statErr := os.Stat(stray); statErr == nil {
+			t.Errorf("no %q should be created under the working directory when HOME is unset", stray)
+		}
+	}
+}
+
+// TestDeployShellCompletionFileIfNeeded_unsetHOMEWithXDG locks in the #366 + #343
+// decision: even when XDG_DATA_HOME/XDG_CONFIG_HOME/ZDOTDIR are set, an empty
+// HOME still fails fast and writes nothing into relative paths under the working
+// directory.
+func TestDeployShellCompletionFileIfNeeded_unsetHOMEWithXDG(t *testing.T) {
+	if IsWindows() {
+		t.Skip("completion install is not supported on Windows")
+	}
+	t.Setenv("HOME", "")
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("ZDOTDIR", t.TempDir())
+	t.Chdir(t.TempDir())
+
+	cmd := testCompletionCmd()
+	err := DeployShellCompletionFileIfNeeded(cmd)
+	if err == nil || !strings.Contains(err.Error(), "HOME") {
+		t.Fatalf("expected an error mentioning HOME even with XDG/ZDOTDIR set, got: %v", err)
 	}
 	for _, stray := range []string{".local", ".config", ".zsh", ".zshrc"} {
 		if _, statErr := os.Stat(stray); statErr == nil {


### PR DESCRIPTION
## Overview

`gup completion --install` previously tied its install paths to `$HOME`-based defaults, so it didn't align with users who follow XDG conventions or use a custom `ZDOTDIR`. This makes the install paths track the user's active shell/config layout (#366).

## Changes

- **Bash** completion installs under `XDG_DATA_HOME` when set, falling back to `$HOME/.local/share/bash-completion/completions/gup`.
- **Fish** completion installs under `XDG_CONFIG_HOME` when set, falling back to `$HOME/.config/fish/completions/gup.fish`.
- **Zsh** resolves both the completion file (`<base>/.zsh/completion/_gup`) and `.zshrc` via `ZDOTDIR` when set, falling back to `$HOME`. The appended `fpath` snippet references `${ZDOTDIR}/.zsh/completion` under `ZDOTDIR` (zsh expands `~` to `$HOME`, not `$ZDOTDIR`), so completions actually load.
- **Idempotency** now keys on a stable marker line (`# setting for gup command (auto generate)`) rather than the full snippet text, so a re-run never appends a duplicate block even if the referenced completion directory differs between runs.

Preserved unchanged:
- Fail-fast when `HOME` is empty (no writes into the current directory), even when XDG/ZDOTDIR are set.
- No-rewrite when the generated completion content is unchanged.

## Tests
- Bash install honors `XDG_DATA_HOME`; fish install honors `XDG_CONFIG_HOME`.
- Zsh install resolves the completion path and `.zshrc` via `ZDOTDIR`, snippet references `${ZDOTDIR}`, and repeated installs do not duplicate the snippet.
- `HOME` empty still fails fast and writes nothing — including when XDG/ZDOTDIR are set.
- A package-level `TestMain` clears `XDG_DATA_HOME`/`XDG_CONFIG_HOME`/`ZDOTDIR` so the existing HOME-rooted path tests stay deterministic regardless of the ambient environment.

All unit tests and `golangci-lint` pass. README updated to document the resolution rules.

Closes #366


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shell completion installation now follows XDG Base Directory conventions for bash, fish, and zsh.

* **Bug Fixes**
  * Zsh completion setup is now idempotent, preventing duplicate `.zshrc` fpath entries on repeated installs.
  * Completion file locations correctly resolve using `ZDOTDIR` (and XDG data/config dirs) when present.

* **Documentation**
  * Updated shell completion installation docs to describe exact environment-variable behavior, failure cases (including `HOME`/write errors), and repeat-install behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->