### PR TITLE
fix(completion): self-heal zsh .zshrc fpath block on re-install

### DIFF
--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 
@@ -90,74 +91,95 @@ func makeFishCompletionFileIfNeeded(cmd *cobra.Command) error {
 }
 
 func makeZshCompletionFileIfNeeded(cmd *cobra.Command) error {
-	if isSameZshCompletionFile(cmd) {
-		return nil
-	}
-
-	path := zshCompletionFilePath()
-	if err := os.MkdirAll(filepath.Dir(path), fileutil.FileModeCreatingDir); err != nil {
-		return fmt.Errorf("can not create zsh-completion file: %w", err)
-	}
-
-	if err := cmd.GenZshCompletionFile(path); err != nil {
-		return fmt.Errorf("can not create zsh-completion file: %w", err)
+	// Regenerate the completion file only when it is missing or stale, but always
+	// reconcile the .zshrc fpath block afterwards. Skipping the reconcile when
+	// _gup is already up to date would leave a deleted or broken block unrepaired,
+	// so a re-run of --install could exit successfully without actually fixing
+	// completion (self-healing install).
+	if !isSameZshCompletionFile(cmd) {
+		path := zshCompletionFilePath()
+		if err := os.MkdirAll(filepath.Dir(path), fileutil.FileModeCreatingDir); err != nil {
+			return fmt.Errorf("can not create zsh-completion file: %w", err)
+		}
+		if err := cmd.GenZshCompletionFile(path); err != nil {
+			return fmt.Errorf("can not create zsh-completion file: %w", err)
+		}
 	}
 	return appendFpathAtZshrcIfNeeded()
 }
 
 // zshFpathMarker is the comment line that uniquely identifies gup's fpath block
-// in .zshrc. Idempotency keys on this marker rather than the full snippet text so
-// a re-run never appends a second block even if the referenced completion
-// directory differs between runs (e.g. ZDOTDIR toggled while .zshrc resolves to
-// the same file).
+// in .zshrc. The reconcile logic keys on this marker so a re-run replaces an
+// existing block in place rather than appending a second one, even if the
+// referenced completion directory differs between runs (e.g. ZDOTDIR toggled
+// while .zshrc resolves to the same file).
 const zshFpathMarker = "# setting for gup command (auto generate)"
 
-// zshFpathSnippet returns the fpath block written to .zshrc. The completion
-// directory it references tracks zshCompletionFilePath: under ZDOTDIR it expands
-// via ${ZDOTDIR} (zsh expands ~ to $HOME, not $ZDOTDIR), otherwise it uses the
-// portable ~/.zsh/completion form (#366).
-func zshFpathSnippet() string {
+// zshFpathBlockRE matches gup's managed fpath block: the marker line plus the
+// fpath and autoload lines it writes. The fpath/autoload lines are optional so a
+// hand-broken block (e.g. with those lines deleted) is still recognized and
+// repaired during reconcile. The pattern deliberately does NOT consume the
+// newline that precedes the marker, so replacing it can never merge the previous
+// line into the block's neighbor.
+var zshFpathBlockRE = regexp.MustCompile(
+	`[ \t]*` + regexp.QuoteMeta(zshFpathMarker) + `[ \t]*\n` +
+		`(?:[ \t]*fpath=\([^\n]*\)[ \t]*\n)?` +
+		`(?:[ \t]*autoload -Uz compinit[^\n]*\n?)?`)
+
+// zshFpathBlockBody returns gup's managed block (marker + fpath + autoload),
+// without a leading blank line. The completion directory it references tracks
+// zshCompletionFilePath: under ZDOTDIR it expands via ${ZDOTDIR} (zsh expands ~
+// to $HOME, not $ZDOTDIR), otherwise it uses the portable ~/.zsh/completion form
+// (#366).
+func zshFpathBlockBody() string {
 	completionDir := "~/.zsh/completion"
 	if strings.TrimSpace(os.Getenv("ZDOTDIR")) != "" {
 		completionDir = "${ZDOTDIR}/.zsh/completion"
 	}
-	return fmt.Sprintf(`
-%s
-fpath=(%s $fpath)
-autoload -Uz compinit && compinit -i
-`, zshFpathMarker, completionDir)
+	return fmt.Sprintf("%s\nfpath=(%s $fpath)\nautoload -Uz compinit && compinit -i\n", zshFpathMarker, completionDir)
+}
+
+// zshFpathSnippet is the block as appended to a new or block-less .zshrc, with a
+// leading blank line so it is visually separated from any preceding content.
+func zshFpathSnippet() string {
+	return "\n" + zshFpathBlockBody()
 }
 
 func appendFpathAtZshrcIfNeeded() (err error) {
-	zshFpath := zshFpathSnippet()
 	zshrcPath := zshrcPath()
-	if !fileutil.IsFile(zshrcPath) {
-		fp, openErr := os.OpenFile(filepath.Clean(zshrcPath), os.O_RDWR|os.O_CREATE, fileutil.FileModeCreatingFile)
-		if openErr != nil {
-			return fmt.Errorf("can not open .zshrc: %w", openErr)
-		}
-		defer func() {
-			if closeErr := fp.Close(); closeErr != nil {
-				err = errors.Join(err, fmt.Errorf("can not close .zshrc: %w", closeErr))
-			}
-		}()
 
-		if _, writeErr := fp.WriteString(zshFpath); writeErr != nil {
-			return fmt.Errorf("can not write zsh $fpath in .zshrc: %w", writeErr)
-		}
-		return err
+	// New .zshrc: write the snippet into a freshly created file.
+	if !fileutil.IsFile(zshrcPath) {
+		return writeZshrcString(zshrcPath, zshFpathSnippet(), os.O_RDWR|os.O_CREATE)
 	}
 
-	zshrc, readErr := os.ReadFile(filepath.Clean(zshrcPath))
+	raw, readErr := os.ReadFile(filepath.Clean(zshrcPath))
 	if readErr != nil {
 		return fmt.Errorf("can not read .zshrc: %w", readErr)
 	}
+	content := string(raw)
 
-	if strings.Contains(string(zshrc), zshFpathMarker) {
-		return nil
+	if zshFpathBlockRE.MatchString(content) {
+		// A gup block already exists (current, stale, or hand-broken). Replace it
+		// in place so the user's surrounding lines keep their position, and repair
+		// an outdated or partial block. ReplaceAllLiteralString avoids treating the
+		// literal "$fpath" in the body as a capture-group reference. When the block
+		// is already correct the content is unchanged and the file is not rewritten.
+		updated := zshFpathBlockRE.ReplaceAllLiteralString(content, zshFpathBlockBody())
+		if updated == content {
+			return nil
+		}
+		return writeZshrcString(zshrcPath, updated, os.O_RDWR|os.O_TRUNC)
 	}
 
-	fp, openErr := os.OpenFile(filepath.Clean(zshrcPath), os.O_RDWR|os.O_APPEND, fileutil.FileModeCreatingFile)
+	// No gup block yet: append a fresh one without disturbing existing content.
+	return writeZshrcString(zshrcPath, zshFpathSnippet(), os.O_RDWR|os.O_APPEND)
+}
+
+// writeZshrcString writes data to .zshrc using the given open flags, joining any
+// close error so a failed flush is surfaced.
+func writeZshrcString(path, data string, flag int) (err error) {
+	fp, openErr := os.OpenFile(filepath.Clean(path), flag, fileutil.FileModeCreatingFile)
 	if openErr != nil {
 		return fmt.Errorf("can not open .zshrc: %w", openErr)
 	}
@@ -167,7 +189,7 @@ func appendFpathAtZshrcIfNeeded() (err error) {
 		}
 	}()
 
-	if _, writeErr := fp.WriteString(zshFpath); writeErr != nil {
+	if _, writeErr := fp.WriteString(data); writeErr != nil {
 		return fmt.Errorf("can not write zsh $fpath in .zshrc: %w", writeErr)
 	}
 	return err

--- a/internal/completion/completion_more_test.go
+++ b/internal/completion/completion_more_test.go
@@ -281,6 +281,170 @@ func TestIsSameZshCompletionFile(t *testing.T) {
 	}
 }
 
+// TestMakeZshCompletionFileIfNeeded_RepairsMissingZshrcBlock verifies the
+// self-healing contract: when _gup is already up to date but the .zshrc fpath
+// block has been removed, re-running the install restores the block instead of
+// early-returning and leaving completion broken.
+func TestMakeZshCompletionFileIfNeeded_RepairsMissingZshrcBlock(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if IsWindows() {
+		t.Skip("zsh completion is not deployed on Windows")
+	}
+	cmd := testCompletionCmd()
+
+	// First install creates _gup and the .zshrc block.
+	if err := makeZshCompletionFileIfNeeded(cmd); err != nil {
+		t.Fatalf("first makeZshCompletionFileIfNeeded() error = %v", err)
+	}
+	if !isSameZshCompletionFile(cmd) {
+		t.Fatal("precondition: _gup should be up to date after the first install")
+	}
+
+	// Simulate the user deleting gup's block from .zshrc (keeping other config).
+	if err := os.WriteFile(zshrcPath(), []byte("# unrelated config\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-running must restore the block even though _gup itself is unchanged.
+	if err := makeZshCompletionFileIfNeeded(cmd); err != nil {
+		t.Fatalf("second makeZshCompletionFileIfNeeded() error = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(zshrcPath()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "fpath=(~/.zsh/completion") {
+		t.Errorf("deleted .zshrc block was not repaired, got:\n%s", data)
+	}
+	if !strings.Contains(string(data), "# unrelated config") {
+		t.Errorf("unrelated .zshrc content was dropped, got:\n%s", data)
+	}
+	if got := strings.Count(string(data), "auto generate"); got != 1 {
+		t.Errorf("fpath block appears %d times, want exactly 1", got)
+	}
+}
+
+// TestAppendFpathAtZshrcIfNeeded_RepairsStaleBlock verifies that a marker that is
+// present but points at an out-of-date completion directory is replaced in place
+// (updated, not duplicated), so the marker-based reconcile actually self-heals an
+// old block.
+func TestAppendFpathAtZshrcIfNeeded_RepairsStaleBlock(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	stale := "# existing config\n\n" + zshFpathMarker + "\n" +
+		"fpath=(/old/wrong/path $fpath)\n" +
+		"autoload -Uz compinit && compinit -i\n"
+	if err := os.WriteFile(zshrcPath(), []byte(stale), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := appendFpathAtZshrcIfNeeded(); err != nil {
+		t.Fatalf("appendFpathAtZshrcIfNeeded() error = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(zshrcPath()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "/old/wrong/path") {
+		t.Errorf("stale fpath was not replaced, got:\n%s", data)
+	}
+	if !strings.Contains(string(data), "fpath=(~/.zsh/completion") {
+		t.Errorf("fresh fpath line is missing, got:\n%s", data)
+	}
+	if !strings.Contains(string(data), "# existing config") {
+		t.Errorf("unrelated content was dropped, got:\n%s", data)
+	}
+	if got := strings.Count(string(data), "auto generate"); got != 1 {
+		t.Errorf("fpath block appears %d times, want exactly 1 (replaced, not duplicated)", got)
+	}
+
+	// Repairing again must be a no-op: the now-correct block is left untouched.
+	before := string(data)
+	if err := appendFpathAtZshrcIfNeeded(); err != nil {
+		t.Fatalf("second appendFpathAtZshrcIfNeeded() error = %v", err)
+	}
+	after, err := os.ReadFile(filepath.Clean(zshrcPath()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != before {
+		t.Errorf("re-running on a correct .zshrc rewrote it:\nbefore:\n%q\nafter:\n%q", before, string(after))
+	}
+}
+
+// TestAppendFpathAtZshrcIfNeeded_PreservesSurroundingLines guards against the
+// reconcile merging adjacent user lines: a stale block wedged between user lines
+// with single-newline spacing (no blank separators) must be repaired in place
+// while every surrounding line keeps its own line.
+func TestAppendFpathAtZshrcIfNeeded_PreservesSurroundingLines(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	before := "export PATH=$PATH\n"
+	after := "export EDITOR=vim\n"
+	staleBlock := zshFpathMarker + "\n" +
+		"fpath=(/old/wrong/path $fpath)\n" +
+		"autoload -Uz compinit && compinit -i\n"
+	if err := os.WriteFile(zshrcPath(), []byte(before+staleBlock+after), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := appendFpathAtZshrcIfNeeded(); err != nil {
+		t.Fatalf("appendFpathAtZshrcIfNeeded() error = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(zshrcPath()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	for _, line := range []string{"export PATH=$PATH", "export EDITOR=vim"} {
+		if !strings.Contains(got, line+"\n") {
+			t.Errorf("surrounding line %q lost its own line (possible merge), got:\n%q", line, got)
+		}
+	}
+	if strings.Contains(got, "$PATHexport") || strings.Contains(got, "compinit && compinit -iexport") {
+		t.Errorf("adjacent user lines were merged into the block, got:\n%q", got)
+	}
+	if strings.Contains(got, "/old/wrong/path") {
+		t.Errorf("stale fpath was not replaced, got:\n%q", got)
+	}
+	if got2 := strings.Count(got, "auto generate"); got2 != 1 {
+		t.Errorf("fpath block appears %d times, want exactly 1", got2)
+	}
+}
+
+// TestAppendFpathAtZshrcIfNeeded_RepairsBrokenBlock verifies that a marker left
+// behind without its fpath/autoload lines (a hand-broken block) is reconciled
+// into a complete, single block.
+func TestAppendFpathAtZshrcIfNeeded_RepairsBrokenBlock(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	broken := "# existing config\n\n" + zshFpathMarker + "\n"
+	if err := os.WriteFile(zshrcPath(), []byte(broken), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := appendFpathAtZshrcIfNeeded(); err != nil {
+		t.Fatalf("appendFpathAtZshrcIfNeeded() error = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(zshrcPath()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "fpath=(~/.zsh/completion") {
+		t.Errorf("broken block was not repaired with the fpath line, got:\n%s", data)
+	}
+	if !strings.Contains(string(data), "autoload -Uz compinit") {
+		t.Errorf("broken block was not repaired with the autoload line, got:\n%s", data)
+	}
+	if got := strings.Count(string(data), "auto generate"); got != 1 {
+		t.Errorf("fpath block appears %d times, want exactly 1", got)
+	}
+}
+
 func TestAppendFpathAtZshrcIfNeeded(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 

--- a/internal/completion/completion_more_test.go
+++ b/internal/completion/completion_more_test.go
@@ -287,6 +287,9 @@ func TestIsSameZshCompletionFile(t *testing.T) {
 // early-returning and leaving completion broken.
 func TestMakeZshCompletionFileIfNeeded_RepairsMissingZshrcBlock(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	// Pin .zshrc/fpath resolution to the temp HOME even if ZDOTDIR is exported,
+	// so the test never touches a real $ZDOTDIR/.zshrc.
+	t.Setenv("ZDOTDIR", "")
 	if IsWindows() {
 		t.Skip("zsh completion is not deployed on Windows")
 	}
@@ -331,6 +334,7 @@ func TestMakeZshCompletionFileIfNeeded_RepairsMissingZshrcBlock(t *testing.T) {
 // old block.
 func TestAppendFpathAtZshrcIfNeeded_RepairsStaleBlock(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	t.Setenv("ZDOTDIR", "") // pin .zshrc resolution to the temp HOME
 
 	stale := "# existing config\n\n" + zshFpathMarker + "\n" +
 		"fpath=(/old/wrong/path $fpath)\n" +
@@ -380,6 +384,7 @@ func TestAppendFpathAtZshrcIfNeeded_RepairsStaleBlock(t *testing.T) {
 // while every surrounding line keeps its own line.
 func TestAppendFpathAtZshrcIfNeeded_PreservesSurroundingLines(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	t.Setenv("ZDOTDIR", "") // pin .zshrc resolution to the temp HOME
 
 	before := "export PATH=$PATH\n"
 	after := "export EDITOR=vim\n"
@@ -420,6 +425,7 @@ func TestAppendFpathAtZshrcIfNeeded_PreservesSurroundingLines(t *testing.T) {
 // into a complete, single block.
 func TestAppendFpathAtZshrcIfNeeded_RepairsBrokenBlock(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	t.Setenv("ZDOTDIR", "") // pin .zshrc resolution to the temp HOME
 
 	broken := "# existing config\n\n" + zshFpathMarker + "\n"
 	if err := os.WriteFile(zshrcPath(), []byte(broken), 0o600); err != nil {


### PR DESCRIPTION
## Problem

`gup completion --install` could exit successfully while leaving zsh completion broken, because the install was not self-healing:

1. **`makeZshCompletionFileIfNeeded` early-returned** when `_gup` was already up to date, skipping the `.zshrc` reconcile entirely. So if the user (or another tool) deleted gup's `fpath` block from `.zshrc`, re-running `--install` never restored it.
2. **`appendFpathAtZshrcIfNeeded` only checked for the marker line.** A block that was present but **stale** (outdated `fpath` path, e.g. after a `ZDOTDIR`/path-format change) or **hand-broken** (the `fpath`/`autoload` lines removed) was left untouched.

Reproduction: `--install` once → delete or corrupt the auto-generated `.zshrc` block → `--install` again. It succeeded but completion stayed broken.

## Fix

- `makeZshCompletionFileIfNeeded` now regenerates `_gup` only when it is missing/stale, but **always** reconciles the `.zshrc` block afterwards.
- `appendFpathAtZshrcIfNeeded` now **replaces an existing block in place** via a marker-anchored regex:
  - an out-of-date or hand-broken block is repaired,
  - an already-correct block is left **byte-for-byte unchanged** (no needless rewrite),
  - a missing block is appended (append-only, no truncation) without disturbing existing content.

The block regex deliberately does **not** consume the newline preceding the marker, so an in-place replace can never merge adjacent user lines, and replacing in place preserves the position of the user's surrounding `.zshrc` content. Only the rare stale-repair path rewrites the file; the common missing-block path stays append-only.

## Tests
- Repair a deleted `.zshrc` block when `_gup` is already current.
- Replace a stale `fpath` path (updated, not duplicated) + idempotency after repair.
- Repair a marker-only (broken) block into a complete one.
- Preserve tightly-packed surrounding user lines (guards against line-merge corruption).

All unit tests (incl. `-race`) and `golangci-lint` pass.

This addresses review feedback on the zsh `--install` flow that followed #366.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Zsh completion installation: completion files are regenerated only when missing or outdated.
  * Enhanced `.zshrc` “self-healing” by repairing or replacing the managed fpath block when stale, broken, or partially modified—without duplicating or disturbing surrounding user lines.
* **Tests**
  * Added broader Zsh completion and `.zshrc` repair scenarios to validate missing, stale, preserved-adjacent, and broken block handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->