### PR TITLE
docs(changelog): cut v1.5.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## [v1.5.1](https://github.com/nao1215/gup/compare/v1.5.0...v1.5.1) (2026-06-23)
+
+### Bug Fixes
+
+* `gup check`, `gup update`, and `gup list --json` now fail fast when the resolved `gup.json` is malformed or has an unsupported `schema_version`, instead of silently falling back to `@latest`, and reject a directory passed where a `gup.json` file is expected instead of clobbering it. (#370)
+* `--json` output for the parallel commands (`check`/`update`/`import`/`migrate`) is now emitted in the original input order, making machine-readable output deterministic across runs without changing exit codes, status values, or error semantics. (#371)
+* `gup completion --install` now honors `XDG_DATA_HOME` (bash), `XDG_CONFIG_HOME` (fish), and `ZDOTDIR` (zsh) when choosing where to write completion files and the `.zshrc` snippet. (#372)
+* `gup completion --install` now repairs a deleted, stale, or hand-broken zsh `.zshrc` fpath block on re-install instead of leaving zsh completion broken; an already-correct block is left byte-for-byte unchanged. (#373)
+* Fix a config data-loss case in `gup update`: persisting `gup.json` after a binary rename that kept the same `import_path` could drop the package from the saved config entirely. (#374)
+
+### Code Refactoring
+
+* Centralize the config/state logic that was spread across the `cmd/` commands into a new `internal/configstate` package (config-path resolution, update-channel resolution/merge, and persistence) and unify binary-name matching in `internal/binname`, so `update`/`check`/`list`/`export` interpret the same `gup.json` entry through one consistent package-identity model. No user-visible behavior change. (#374)
+
+### CI
+
+* Generate sigstore bundles during release signing. (#363)
+
 ## [v1.5.0](https://github.com/nao1215/gup/compare/v1.4.0...v1.5.0) (2026-06-22)
 
 ### Features


### PR DESCRIPTION
## Summary

Cut the `v1.5.1` release notes. This is a patch release: everything merged since `v1.5.0` is bug fixes, an internal refactor, and release-signing tooling — no new features and no user-facing CLI changes, so the patch level is correct per SemVer.

## Changes

- Add the `v1.5.1` section to [CHANGELOG.md](CHANGELOG.md) covering #370, #371, #372, #373, #374, and #363.

## Release Contents

- Bug Fixes: malformed/ambiguous `gup.json` fail-fast and directory-destination rejection (#370), deterministic `--json` ordering for parallel commands (#371), `completion --install` honoring `XDG_*`/`ZDOTDIR` (#372) and self-healing the zsh `.zshrc` fpath block (#373), and a config data-loss fix when a rename keeps the same `import_path` (#374).
- Code Refactoring: config/state logic centralized into `internal/configstate` and binary-name matching unified in `internal/binname`, with one consistent package-identity model across `update`/`check`/`list`/`export` and no user-visible behavior change (#374).
- CI: sigstore bundle generation during release signing (#363).

## Release Steps

After this PR is merged, tag `v1.5.1` on `main` to trigger the GoReleaser release workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release v1.5.1

* **Bug Fixes**
  * Enhanced error handling for malformed or invalid configuration files
  * Fixed deterministic output ordering for parallel operations
  * Improved shell completion installation with environment variable support
  * Corrected shell initialization file compatibility issues
  * Resolved potential configuration data loss during updates

* **CI**
  * Added release signing with sigstore bundle generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->