### PR TITLE
refactor: drop archived github.com/pkg/errors and tighten golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,35 +5,52 @@ linters:
   default: none
   enable:
     - asciicheck
+    - bidichk
     - bodyclose
+    - copyloopvar
     - dogsled
     - durationcheck
     - errcheck
+    - errname
     - errorlint
     - exhaustive
+    - fatcontext
     - forcetypeassert
+    - gocheckcompilerdirectives
     - gochecknoglobals
     - gochecknoinits
     - goconst
     - gocritic
+    - godot
     - gosec
     - govet
     - ineffassign
+    - intrange
+    - makezero
+    - mirror
     - misspell
     - mnd
     - nakedret
+    - nilerr
+    - nilnesserr
     - noctx
     - nolintlint
     - paralleltest
+    - perfsprint
     - prealloc
+    - reassign
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
     - tagliatelle
+    - testableexamples
+    - testifylint
     - thelper
     - unconvert
     - unparam
     - unused
+    - usestdlibvars
+    - wastedassign
     - whitespace
   settings:
     tagliatelle:

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -34,10 +35,10 @@ Use --install to write bash/fish/zsh completion files to the user shell config p
 			}
 			if install {
 				if len(args) != 0 {
-					return fmt.Errorf("--install cannot be used with shell argument")
+					return errors.New("--install cannot be used with shell argument")
 				}
 				if isWindows() {
-					return fmt.Errorf("--install is not supported on Windows; run 'gup completion powershell' to output PowerShell completion to stdout")
+					return errors.New("--install is not supported on Windows; run 'gup completion powershell' to output PowerShell completion to stdout")
 				}
 				return completion.DeployShellCompletionFileIfNeeded(rootCmd)
 			}

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -307,7 +307,6 @@ func Test_versionFromConfig_NormalizeDevel(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -348,7 +347,6 @@ func Test_versionFromConfig_ErrorCases(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/cmd/jsonout_test.go
+++ b/cmd/jsonout_test.go
@@ -201,7 +201,7 @@ func Test_doCheckJSON_stableInputOrder(t *testing.T) {
 	const total = 6
 	pkgs := make([]goutil.Package, total)
 	sleepByModule := make(map[string]time.Duration, total)
-	for i := 0; i < total; i++ {
+	for i := range total {
 		p := newCheckPkg(fmt.Sprintf("tool-%d", i), testVersionTwo, goutil.UpdateChannelLatest)
 		pkgs[i] = p
 		// Earlier packages resolve slower so they complete last.

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -110,7 +110,7 @@ func listJSONRecords(pkgs []goutil.Package) []jsonPackage {
 	return recs
 }
 
-// PackageList list up command package in $GOPATH/bin or $GOBIN
+// PackageList list up command package in $GOPATH/bin or $GOBIN.
 func printPackageList(pkgs []goutil.Package) {
 	max := 0
 	for _, v := range pkgs {

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -317,7 +317,7 @@ func Test_migratePackages_addOnlySkip(t *testing.T) {
 	if called {
 		t.Fatal("installer should not run for an existing binary without --force")
 	}
-	if !bytes.Contains([]byte(out), []byte("skip")) {
+	if !strings.Contains(out, "skip") {
 		t.Fatalf("expected skip message, got: %s", out)
 	}
 }
@@ -579,7 +579,7 @@ func Test_runMigrate_sameDirError(t *testing.T) {
 			t.Fatalf("runMigrate() = %d, want 1 for same directory", got)
 		}
 	})
-	if !bytes.Contains([]byte(out), []byte("same directory")) {
+	if !strings.Contains(out, "same directory") {
 		t.Fatalf("expected 'same directory' error, got: %s", out)
 	}
 }

--- a/cmd/parallel.go
+++ b/cmd/parallel.go
@@ -144,7 +144,7 @@ func forEachPackage(ctx context.Context, pkgs []goutil.Package, cpus int, timeou
 	}
 
 	wg.Add(cpus)
-	for i := 0; i < cpus; i++ {
+	for range cpus {
 		go worker()
 	}
 

--- a/cmd/parallel_test.go
+++ b/cmd/parallel_test.go
@@ -43,7 +43,7 @@ func TestForEachPackage(t *testing.T) {
 		})
 
 		got := map[string]bool{}
-		for i := 0; i < len(pkgs); i++ {
+		for range pkgs {
 			r := <-ch
 			if r.err != nil {
 				t.Errorf("unexpected error for %s: %v", r.pkg.Name, r.err)
@@ -62,7 +62,7 @@ func TestForEachPackage(t *testing.T) {
 		t.Parallel()
 
 		pkgs := []goutil.Package{{Name: pkgFail}}
-		wantErr := fmt.Errorf("test error")
+		wantErr := errors.New("test error")
 
 		ch := forEachPackage(context.Background(), pkgs, 1, 0, func(_ context.Context, p goutil.Package) updateResult {
 			return updateResult{pkg: p, err: wantErr}
@@ -117,7 +117,7 @@ func TestForEachPackage(t *testing.T) {
 		ch := forEachPackage(context.Background(), pkgs, 1, 0,
 			func(ctx context.Context, p goutil.Package) updateResult {
 				if _, ok := ctx.Deadline(); ok {
-					return updateResult{pkg: p, err: fmt.Errorf("unexpected deadline with timeout=0")}
+					return updateResult{pkg: p, err: errors.New("unexpected deadline with timeout=0")}
 				}
 				return updateResult{pkg: p}
 			})
@@ -220,7 +220,6 @@ func TestForEachPackage_ResultCountInvariant(t *testing.T) {
 	const total = 64
 
 	for _, cpus := range []int{1, 3, 8, 64, 200} {
-		cpus := cpus
 		t.Run(fmt.Sprintf("cpus=%d", cpus), func(t *testing.T) {
 			t.Parallel()
 
@@ -335,7 +334,6 @@ func TestForEachPackage_CPUClamping(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/cmd/precheck_test.go
+++ b/cmd/precheck_test.go
@@ -17,7 +17,6 @@ func TestClampJobs(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := clampJobs(tt.in)

--- a/cmd/property_test.go
+++ b/cmd/property_test.go
@@ -34,14 +34,16 @@ func (importPathInput) Generate(rng *rand.Rand, _ int) reflect.Value {
 	seg := func() string {
 		n := 1 + rng.Intn(6)
 		var sb strings.Builder
-		for i := 0; i < n; i++ {
+		for range n {
 			sb.WriteRune(letters[rng.Intn(len(letters))])
 		}
 		return sb.String()
 	}
-	parts := []string{"example.com", seg()}
+	first := seg()
 	extra := rng.Intn(4)
-	for i := 0; i < extra; i++ {
+	parts := make([]string, 0, 2+extra)
+	parts = append(parts, "example.com", first)
+	for range extra {
 		parts = append(parts, seg())
 	}
 	return reflect.ValueOf(importPathInput(strings.Join(parts, "/")))

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -96,7 +97,7 @@ func removeLoop(gobin string, force bool, target []string) int {
 		}
 		if !force {
 			if !stdinIsTerminal() {
-				print.Err(fmt.Errorf("gup remove requires confirmation, but stdin is not a TTY.\nUse --force to skip confirmation"))
+				print.Err(errors.New("gup remove requires confirmation, but stdin is not a TTY.\nUse --force to skip confirmation"))
 				result = 1
 				continue
 			}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -113,7 +113,7 @@ func helper_stubImportInstaller(t *testing.T) {
 	})
 }
 
-// Runs a gup command, and return its output split by \n
+// Runs a gup command, and return its output split by \n.
 func helper_runGup(t *testing.T, args []string) ([]string, error) {
 	t.Helper()
 
@@ -451,8 +451,7 @@ func TestExecute_Remove_Force(t *testing.T) {
 	}
 	tests := []test{}
 
-	src := ""
-	dest := ""
+	var src, dest string
 	if runtime.GOOS == goosWindows {
 		tests = append(tests, test{
 			name:   testNameSuccess,
@@ -809,8 +808,7 @@ func TestExecute_Update(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	targetPath := ""
-	binName := ""
+	var targetPath, binName string
 	if runtime.GOOS == goosWindows {
 		binName = "gal.exe"
 		targetPath = filepath.Join("testdata", "check_success_for_windows", binName)
@@ -863,8 +861,7 @@ func TestExecute_Update_DryRunAndNotify(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	targetPath := ""
-	binName := ""
+	var targetPath, binName string
 	if runtime.GOOS == goosWindows {
 		binName = testBinPosixerExe
 		targetPath = filepath.Join("testdata", "check_success_for_windows", binName)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-version v1.9.0
 	github.com/mattn/go-colorable v0.1.15
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.10.2
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,6 @@ github.com/nikolaydubina/go-cover-treemap v1.5.0 h1:hBhNiUdEYTH2E3UIjnfTaUWt6MmN
 github.com/nikolaydubina/go-cover-treemap v1.5.0/go.mod h1:h0Y6pzBpZr7HIJmT/rj0xCdVAAyXKwtYm+L/BKXXkYc=
 github.com/nikolaydubina/treemap v1.2.5 h1:oSC5z/qnsGLbkU2IihSrh2pS7uDjUq7ipGj8aw8bfII=
 github.com/nikolaydubina/treemap v1.2.5/go.mod h1:8+wLGh917AyeJqBN1D5KM26tv6W/XfvsY+nfJd04/u8=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=

--- a/internal/assets/asset.go
+++ b/internal/assets/asset.go
@@ -40,17 +40,17 @@ func DeployIconIfNeeded() {
 	}
 }
 
-// InfoIconPath return absolute path of information.png
+// InfoIconPath return absolute path of information.png.
 func InfoIconPath() string {
 	return filepath.Join(assetsDirPath(), "information.png")
 }
 
-// WarningIconPath return absolute path of information.png
+// WarningIconPath return absolute path of information.png.
 func WarningIconPath() string {
 	return filepath.Join(assetsDirPath(), "warning.png")
 }
 
-// assetsDirPath return absolute path of assets directory
+// assetsDirPath return absolute path of assets directory.
 func assetsDirPath() string {
 	return filepath.Join(config.DirPath(), "assets")
 }

--- a/internal/binname/binname_test.go
+++ b/internal/binname/binname_test.go
@@ -92,7 +92,7 @@ func Test_NormalizeForMatch_idempotent(t *testing.T) {
 		letters := []rune("abABeExX012")
 		n := rng.Intn(8)
 		var sb strings.Builder
-		for i := 0; i < n; i++ {
+		for range n {
 			sb.WriteRune(letters[rng.Intn(len(letters))])
 		}
 		s := sb.String()

--- a/internal/cmdinfo/cmdinfo.go
+++ b/internal/cmdinfo/cmdinfo.go
@@ -5,10 +5,10 @@ import (
 	"runtime/debug"
 )
 
-// Version value is set by ldflags
+// Version value is set by ldflags.
 var Version string //nolint:gochecknoglobals
 
-// Name is command name
+// Name is command name.
 const Name = "gup"
 
 // GetVersion return gup command version.

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -27,7 +27,7 @@ func DeployShellCompletionFileIfNeeded(cmd *cobra.Command) error {
 		return nil
 	}
 	if strings.TrimSpace(os.Getenv("HOME")) == "" {
-		return fmt.Errorf("HOME environment variable is not set; cannot determine where to install shell completion files")
+		return errors.New("HOME environment variable is not set; cannot determine where to install shell completion files")
 	}
 
 	return errors.Join(

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,7 +22,7 @@ func ptr[T any](v T) *T {
 	return &v
 }
 
-// ConfigFileName is gup command configuration file
+// ConfigFileName is gup command configuration file.
 const ConfigFileName = "gup.json"
 const configSchemaVersion = 1
 
@@ -96,7 +96,7 @@ func ResolveExportFilePath(explicitPath string) string {
 	return FilePath()
 }
 
-// ReadConfFile return contents of configuration-file (package information)
+// ReadConfFile return contents of configuration-file (package information).
 func ReadConfFile(path string) ([]goutil.Package, error) {
 	raw, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -263,7 +263,6 @@ func TestReadConfFile_InvalidFormat(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/config/property_test.go
+++ b/internal/config/property_test.go
@@ -32,7 +32,7 @@ func (validPackageSet) Generate(rng *rand.Rand, _ int) reflect.Value {
 	versions := []string{verSemver, "v0.0.1", verLatest, "v2.0.0-rc.1"}
 
 	pkgs := make(validPackageSet, 0, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		pkgs = append(pkgs, goutil.Package{
 			Name:          fmt.Sprintf("tool%d", i),
 			ImportPath:    fmt.Sprintf("example.com/owner/tool%d", i),

--- a/internal/goutil/examples_test.go
+++ b/internal/goutil/examples_test.go
@@ -253,6 +253,7 @@ func ExampleGoPaths_StartDryRunMode() {
 //	Type: Package
 //
 // ----------------------------------------------------------------------------
+
 func ExamplePackage_SetLatestVer() {
 	packages, _ := goutil.GetPackageInformation([]string{"../../cmd/testdata/check_success/gal"})
 	if len(packages) == 0 {

--- a/internal/goutil/goutil.go
+++ b/internal/goutil/goutil.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"debug/buildinfo"
-	stderrors "errors"
+	"errors"
 	"fmt"
 	"go/build"
 	"os"
@@ -18,7 +18,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/hashicorp/go-version"
 	"github.com/nao1215/gup/internal/print"
-	"github.com/pkg/errors"
 )
 
 const unknown = "unknown"
@@ -289,19 +288,17 @@ func (gp *GoPaths) StartDryRunMode() error {
 			// Avoid leaking the temp dir when the env mutation fails.
 			_ = gp.removeTmpDir()
 			// Wrap error to avoid OS dependent error message during testing.
-			return errors.Wrapf(
-				err,
-				"failed to set GOBIN to env variable. key: %v, value: %v",
-				keyGoBin, tmpDir,
+			return fmt.Errorf(
+				"failed to set GOBIN to env variable. key: %v, value: %v: %w",
+				keyGoBin, tmpDir, err,
 			)
 		}
 	case gp.GOPATH != "":
 		if err := os.Setenv(keyGoPath, tmpDir); err != nil {
 			_ = gp.removeTmpDir()
-			return errors.Wrapf(
-				err,
-				"failed to set GOPATH to env variable. key: %v, value: %v",
-				keyGoPath, tmpDir,
+			return fmt.Errorf(
+				"failed to set GOPATH to env variable. key: %v, value: %v: %w",
+				keyGoPath, tmpDir, err,
 			)
 		}
 	default:
@@ -321,18 +318,16 @@ func (gp *GoPaths) EndDryRunMode() error {
 	case gp.GOBIN != "":
 		if err := os.Setenv(keyGoBin, gp.GOBIN); err != nil {
 			// Wrap error to avoid OS dependent error message during testing.
-			restoreErr = errors.Wrapf(
-				err,
-				"failed to set GOBIN to env variable. key: %v, value: %v",
-				keyGoBin, gp.GOBIN,
+			restoreErr = fmt.Errorf(
+				"failed to set GOBIN to env variable. key: %v, value: %v: %w",
+				keyGoBin, gp.GOBIN, err,
 			)
 		}
 	case gp.GOPATH != "":
 		if err := os.Setenv(keyGoPath, gp.GOPATH); err != nil {
-			restoreErr = errors.Wrapf(
-				err,
-				"failed to set GOPATH to env variable. key: %v, value: %v",
-				keyGoPath, gp.GOPATH,
+			restoreErr = fmt.Errorf(
+				"failed to set GOPATH to env variable. key: %v, value: %v: %w",
+				keyGoPath, gp.GOPATH, err,
 			)
 		}
 	default:
@@ -341,10 +336,10 @@ func (gp *GoPaths) EndDryRunMode() error {
 
 	var removeErr error
 	if err := gp.removeTmpDir(); err != nil {
-		removeErr = errors.Wrap(err, "temporary directory for dry run remains")
+		removeErr = fmt.Errorf("temporary directory for dry run remains: %w", err)
 	}
 
-	return stderrors.Join(restoreErr, removeErr)
+	return errors.Join(restoreErr, removeErr)
 }
 
 // removeTmpDir remove tmporary directory for dry run

--- a/internal/goutil/goutil.go
+++ b/internal/goutil/goutil.go
@@ -54,7 +54,7 @@ var (
 	}
 )
 
-// GoPaths has $GOBIN and $GOPATH
+// GoPaths has $GOBIN and $GOPATH.
 type GoPaths struct {
 	// GOBIN is $GOBIN
 	GOBIN string
@@ -64,7 +64,7 @@ type GoPaths struct {
 	TmpPath string
 }
 
-// Package is package information
+// Package is package information.
 type Package struct {
 	// Name is package name
 	Name string
@@ -117,7 +117,7 @@ func (p *Package) SetLatestVer() {
 	p.Version.Latest = GetPackageVersion(p.Name)
 }
 
-// CurrentToLatestStr returns string about the current version and the latest version
+// CurrentToLatestStr returns string about the current version and the latest version.
 func (p *Package) CurrentToLatestStr() string {
 	if p.IsPackageUpToDate() && p.IsGoUpToDate() {
 		return "Already up-to-date: " + color.GreenString(p.Version.Current) + " / " + color.GreenString(p.GoVersion.Current)
@@ -342,7 +342,7 @@ func (gp *GoPaths) EndDryRunMode() error {
 	return errors.Join(restoreErr, removeErr)
 }
 
-// removeTmpDir remove tmporary directory for dry run
+// removeTmpDir remove tmporary directory for dry run.
 func (gp *GoPaths) removeTmpDir() error {
 	if gp.TmpPath != "" {
 		return os.RemoveAll(gp.TmpPath)
@@ -356,7 +356,7 @@ func CanUseGoCmd() error {
 	return err
 }
 
-// InstallLatest execute "$ go install <importPath>@latest"
+// InstallLatest execute "$ go install <importPath>@latest".
 func InstallLatest(importPath string) error {
 	return InstallLatestWithContext(context.Background(), importPath)
 }
@@ -366,7 +366,7 @@ func InstallLatestWithContext(ctx context.Context, importPath string) error {
 	return InstallWithContext(ctx, importPath, "latest")
 }
 
-// InstallMainOrMaster execute "$ go install <importPath>@main" or "$ go install <importPath>@master"
+// InstallMainOrMaster execute "$ go install <importPath>@main" or "$ go install <importPath>@master".
 func InstallMainOrMaster(importPath string) error {
 	return InstallMainOrMasterWithContext(context.Background(), importPath)
 }
@@ -479,7 +479,7 @@ func InstallWithContext(ctx context.Context, importPath, version string) error {
 	return nil
 }
 
-// GetLatestVer execute "$ go list -m -f {{.Version}} <importPath>@latest"
+// GetLatestVer execute "$ go list -m -f {{.Version}} <importPath>@latest".
 func GetLatestVer(modulePath string) (string, error) {
 	return GetLatestVerWithContext(context.Background(), modulePath)
 }
@@ -632,7 +632,7 @@ func collectPackageInformation(binList []string, goVer string) []Package {
 	jobs := make(chan int, len(binList))
 	var wg sync.WaitGroup
 
-	for w := 0; w < numWorkers; w++ {
+	for range numWorkers {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -676,7 +676,7 @@ func collectPackageInformation(binList []string, goVer string) []Package {
 	return pkgs
 }
 
-// GetPackageVersion return golang package version
+// GetPackageVersion return golang package version.
 func GetPackageVersion(cmdName string) string {
 	goBin, err := GoBin()
 	if err != nil {

--- a/internal/goutil/goutil_test.go
+++ b/internal/goutil/goutil_test.go
@@ -1507,7 +1507,7 @@ func TestInstallWithContext_EmptyStderrFallback(t *testing.T) {
 	if !strings.Contains(err.Error(), "can't install") {
 		t.Errorf("error should report the install failure, got: %v", err)
 	}
-	prefix := fmt.Sprintf("can't install %s", timeoutTestImportPath)
+	prefix := "can't install " + timeoutTestImportPath
 	if errorCauseAfterPrefix(t, err, prefix) == "" {
 		t.Errorf("error should include a non-empty cause when stderr is empty, got: %v", err)
 	}
@@ -1527,7 +1527,7 @@ func TestGetVerWithContext_EmptyStderrFallback(t *testing.T) {
 	if !strings.Contains(err.Error(), "can't check") {
 		t.Errorf("error should report the version-check failure, got: %v", err)
 	}
-	prefix := fmt.Sprintf("can't check %s", timeoutTestImportPath)
+	prefix := "can't check " + timeoutTestImportPath
 	if errorCauseAfterPrefix(t, err, prefix) == "" {
 		t.Errorf("error should include a non-empty cause when stderr is empty, got: %v", err)
 	}
@@ -1557,7 +1557,7 @@ func benchSetupGobin(b *testing.B, n int) string {
 	b.Helper()
 	srcs := benchBinarySources(b)
 	dir := b.TempDir()
-	for i := 0; i < n; i++ {
+	for i := range n {
 		data, err := os.ReadFile(srcs[i%len(srcs)])
 		if err != nil {
 			b.Fatal(err)
@@ -1580,7 +1580,7 @@ func BenchmarkGetPackageInformation(b *testing.B) {
 				b.Fatal(err)
 			}
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				_, _ = GetPackageInformation(list)
 			}
 		})
@@ -1592,7 +1592,7 @@ func BenchmarkBinaryPathList(b *testing.B) {
 		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
 			dir := benchSetupGobin(b, n)
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				if _, err := BinaryPathList(dir); err != nil {
 					b.Fatal(err)
 				}
@@ -1602,7 +1602,7 @@ func BenchmarkBinaryPathList(b *testing.B) {
 }
 
 func BenchmarkGetInstalledGoVersion(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if _, err := GetInstalledGoVersion(); err != nil {
 			b.Fatal(err)
 		}
@@ -1612,7 +1612,7 @@ func BenchmarkGetInstalledGoVersion(b *testing.B) {
 func BenchmarkGoBin(b *testing.B) {
 	b.Setenv("GOBIN", b.TempDir())
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if _, err := GoBin(); err != nil {
 			b.Fatal(err)
 		}
@@ -1628,7 +1628,7 @@ func BenchmarkGetPackageInformationWithoutGoVersion(b *testing.B) {
 				b.Fatal(err)
 			}
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				_ = GetPackageInformationWithoutGoVersion(list)
 			}
 		})

--- a/internal/goutil/helperprocess_test.go
+++ b/internal/goutil/helperprocess_test.go
@@ -3,6 +3,7 @@ package goutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -293,13 +294,13 @@ func TestIsBranchNotFound(t *testing.T) {
 		want   bool
 	}{
 		{"nil error", nil, string(UpdateChannelMain), false},
-		{"main missing", fmt.Errorf("can't install x:\ngo: unknown revision main"), string(UpdateChannelMain), true},
-		{"master missing", fmt.Errorf("go: unknown revision master"), string(UpdateChannelMaster), true},
-		{"build failure is not branch-not-found", fmt.Errorf("build failed: compile error"), string(UpdateChannelMain), false},
-		{"network failure is not branch-not-found", fmt.Errorf("dial tcp: i/o timeout"), string(UpdateChannelMain), false},
-		{"wrong branch name does not match", fmt.Errorf("go: unknown revision master"), string(UpdateChannelMain), false},
-		{"longer branch name is not a partial match", fmt.Errorf("go: unknown revision mainline"), string(UpdateChannelMain), false},
-		{"branch token followed by newline matches", fmt.Errorf("go: unknown revision main\n"), string(UpdateChannelMain), true},
+		{"main missing", errors.New("can't install x:\ngo: unknown revision main"), string(UpdateChannelMain), true},
+		{"master missing", errors.New("go: unknown revision master"), string(UpdateChannelMaster), true},
+		{"build failure is not branch-not-found", errors.New("build failed: compile error"), string(UpdateChannelMain), false},
+		{"network failure is not branch-not-found", errors.New("dial tcp: i/o timeout"), string(UpdateChannelMain), false},
+		{"wrong branch name does not match", errors.New("go: unknown revision master"), string(UpdateChannelMain), false},
+		{"longer branch name is not a partial match", errors.New("go: unknown revision mainline"), string(UpdateChannelMain), false},
+		{"branch token followed by newline matches", errors.New("go: unknown revision main\n"), string(UpdateChannelMain), true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -8,7 +8,7 @@ import (
 	"github.com/nao1215/gup/internal/print"
 )
 
-// Info notify information message at desktop
+// Info notify information message at desktop.
 func Info(title, message string) {
 	assets.DeployIconIfNeeded()
 	err := beeep.Notify(title, message, assets.InfoIconPath())
@@ -17,7 +17,7 @@ func Info(title, message string) {
 	}
 }
 
-// Warn notify warning message at desktop
+// Warn notify warning message at desktop.
 func Warn(title, message string) {
 	assets.DeployIconIfNeeded()
 	err := beeep.Notify(title, message, assets.WarningIconPath())

--- a/internal/print/print.go
+++ b/internal/print/print.go
@@ -45,7 +45,7 @@ func Err(err interface{}) {
 var OsExit = os.Exit //nolint:gochecknoglobals
 
 // Fatal print dying message at STDERR in red.
-// After print message, process will exit
+// After print message, process will exit.
 func Fatal(err interface{}) {
 	_, _ = fmt.Fprintf(Stderr, "%s:%s: %v\n",
 		cmdinfo.Name, color.RedString("FATAL"), err)


### PR DESCRIPTION
This PR completes two related "last-mile" quality items: removing the only stale dependency and adding lint guardrails so similar staleness is caught automatically going forward.

## 1. Drop archived `github.com/pkg/errors`

`github.com/pkg/errors` has been **archived since December 2021**. It was the only place left using it — all call sites lived in `internal/goutil/goutil.go`, which already imported the standard `errors` package (as `stderrors`) alongside it (half-migrated).

`errorlint` passed only because `pkg/errors` implements `Unwrap` — "lint passes" ≠ "recommended".

- `errors.Wrap` / `Wrapf` → `fmt.Errorf("...: %w", err)`
- remaining `errors.New` / `Is` / `Join` → standard library `errors`
- drop the `stderrors` alias; remove `github.com/pkg/errors` from `go.mod` / `go.sum`

Error message prefixes are preserved, so the existing `strings.Contains`-based assertions are unaffected.

## 2. Tighten golangci-lint (16 new linters)

Now that the module targets Go 1.25, enable a curated set of stricter linters and apply the fixes (mostly via `golangci-lint --fix`):

- **Modernization:** `intrange`, `copyloopvar` (Go 1.22+ range-over-int / redundant loop-var copies), `usestdlibvars`, `perfsprint`, `mirror`
- **Correctness:** `nilerr`, `nilnesserr`, `makezero`, `fatcontext`, `reassign`, `wastedassign`, `gocheckcompilerdirectives`, `bidichk`
- **Hygiene:** `errname`, `godot`, `testableexamples`, `testifylint`

Resulting code changes: `fmt.Errorf`-without-args → `errors.New`, C-style loops → range, dropped redundant loop-var copies, `bytes.Contains([]byte(s), …)` → `strings.Contains`, one `prealloc` fix, dead `""` inits → `var`, doc comments terminated with a period.

`usetesting` and `predeclared` were **deliberately left off**: `usetesting` conflicts with an intentional `os.MkdirTemp` choice documented in `root_test.go`, and `predeclared` would force renaming the `internal/print` package.

## Verification

- `go build ./...` ✅ / `go vet ./...` ✅
- `go test ./...` ✅ (all green)
- `golangci-lint run ./...` → **0 issues** ✅
- `gofmt -l .` → clean ✅
- `grep -rn "pkg/errors"` → no references ✅

## Note on dependencies

Checked the full module graph: **all direct dependencies are current** — `pkg/errors` was the only stale direct dep. The remaining available updates are all transitive/indirect deps pulled by tooling, not declared requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error construction and wrapping to use standard library patterns consistently (including joined errors and preserved underlying errors).
  * Streamlined dependency usage by removing reliance on an external error library.
* **Tests**
  * Updated parallel and table-driven tests to avoid loop-variable capture pitfalls, improving reliability under concurrency.
* **Tooling**
  * Expanded static analysis coverage by enabling additional linters.
* **Documentation / Style**
  * Minor GoDoc and comment wording/punctuation cleanups across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->