### PR TITLE
feat(cmd): add failure diagnostics / next-step hints on update failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ go: gup.test/moved/cmd/tool@latest: module gup.test/moved@latest found (v1.1.0),
 gup:HINT : The module no longer provides this command at its import path. The project likely moved to a new major version (e.g. a `/v2` module path) or relocated the command; check its current install instructions and reinstall with the new path.
 ```
 
-Hints cover module renames/major-version moves, binaries not installed via `go install`, missing branch/tag, unresolvable/private/deleted repositories, permission and network errors, and an out-of-date Go toolchain. gup stays silent when it has nothing reliable to add (e.g. a timeout, whose message already names the remedy).
+Hints cover module renames/major-version moves, relocated commands, `go.mod` `replace` directives, binaries not installed via `go install`, missing branch/tag, unresolvable/private/deleted repositories, permission and network errors, and an out-of-date Go toolchain. gup stays silent when it has nothing reliable to add (e.g. a timeout, whose message already names the remedy).
 
 ### Behavior on an empty environment
 An empty global environment (no binaries installed by `go install` yet) is treated as a normal first-run condition, not an error:

--- a/README.md
+++ b/README.md
@@ -208,9 +208,23 @@ $ gup check --json
 ]
 ```
 
-Each element has these fields: `name`, `import_path`, `module_path`, `channel` (`latest`/`main`/`master`), `current_version`, `latest_version` (empty for `list`), `current_go_version`, `installed_go_version`, `status`, and `error` (omitted when absent). `status` is `installed` (list), `up-to-date`, `update-available` (check), `updated` (update), or `error`.
+Each element has these fields: `name`, `import_path`, `module_path`, `channel` (`latest`/`main`/`master`), `current_version`, `latest_version` (empty for `list`), `current_go_version`, `installed_go_version`, `status`, `error` (omitted when absent), and `hint` (a next-step suggestion, present only when one applies to the error). `status` is `installed` (list), `up-to-date`, `update-available` (check), `updated` (update), or `error`.
 
 The array is always valid JSON, including partial failures (those packages get `"status": "error"`; error detail also goes to STDERR so STDOUT stays pure JSON). Exit codes are unchanged—`check` reporting `update-available` still exits `0`.
+
+### Failure diagnostics / next-step hints
+When `check` or `update` cannot process a package, gup already holds the Go toolchain's full error output—so instead of leaving you to decipher messages like `no matching versions for query "latest"` or `unrecognized import path`, it prints a short, actionable next step right after the error:
+
+```shell
+$ gup update
+update binary under $GOPATH/bin or $GOBIN
+gup:ERROR: [1/1] air: can't install github.com/cosmtrek/air:
+        module declares its path as: github.com/air-verse/air
+                but was required as: github.com/cosmtrek/air
+gup:HINT : The module appears to have moved to github.com/air-verse/air. gup tries to follow renames automatically; if it still fails, reinstall manually with `go install github.com/air-verse/air@latest`.
+```
+
+Hints cover common, recoverable causes—module renames, a binary not installed via `go install`, a missing branch/tag for the chosen channel, an unresolvable/renamed repository, permission problems, an out-of-date Go toolchain, unsupported `GOOS`/`GOARCH`, and network/proxy errors. They are written to STDERR (so they never pollute `--json` STDOUT) and, in `--json` mode, are also exposed as the per-package `hint` field. gup stays quiet when it cannot offer a confident suggestion (for example, a timeout error already names the manual command and `--timeout` remedy), so a hint always adds signal.
 
 ### Behavior on an empty environment
 An empty global environment (no binaries installed by `go install` yet) is treated as a normal first-run condition, not an error:
@@ -401,7 +415,7 @@ Measured on AMD Ryzen AI Max+ 395 (32 cores) / 64 GB RAM / Ubuntu 26.04 / go 1.2
 | Shell completion generation/install | Yes | No | No |
 | `update` reinstalls up-to-date binaries | No | Yes | Yes |
 | `migrate --force` reinstalls when the target already exists | Yes | No | Manual |
-| Failure diagnostics / next-step hints | No | Yes | No |
+| Failure diagnostics / next-step hints | Yes | Yes | No |
 | `NO_COLOR` support | Yes | Yes | — |
 | No extra tool required (official toolchain only) | No | No | Yes |
 

--- a/README.md
+++ b/README.md
@@ -213,18 +213,16 @@ Each element has these fields: `name`, `import_path`, `module_path`, `channel` (
 The array is always valid JSON, including partial failures (those packages get `"status": "error"`; error detail also goes to STDERR so STDOUT stays pure JSON). Exit codes are unchanged—`check` reporting `update-available` still exits `0`.
 
 ### Failure diagnostics / next-step hints
-When `check` or `update` cannot process a package, gup already holds the Go toolchain's full error output—so instead of leaving you to decipher messages like `no matching versions for query "latest"` or `unrecognized import path`, it prints a short, actionable next step right after the error:
+When `update` or `check` fails, gup turns the Go toolchain's cryptic output into a short, actionable next step printed on STDERR right after the error (and exposed as the `hint` field with `--json`):
 
 ```shell
 $ gup update
-update binary under $GOPATH/bin or $GOBIN
-gup:ERROR: [1/1] air: can't install github.com/cosmtrek/air:
-        module declares its path as: github.com/air-verse/air
-                but was required as: github.com/cosmtrek/air
-gup:HINT : The module appears to have moved to github.com/air-verse/air. gup tries to follow renames automatically; if it still fails, reinstall manually with `go install github.com/air-verse/air@latest`.
+gup:ERROR: [1/1] tool: can't install gup.test/moved/cmd/tool:
+go: gup.test/moved/cmd/tool@latest: module gup.test/moved@latest found (v1.1.0), but does not contain package gup.test/moved/cmd/tool
+gup:HINT : The module no longer provides this command at its import path. The project likely moved to a new major version (e.g. a `/v2` module path) or relocated the command; check its current install instructions and reinstall with the new path.
 ```
 
-Hints cover common, recoverable causes—module renames, a binary not installed via `go install`, a missing branch/tag for the chosen channel, an unresolvable/renamed repository, permission problems, an out-of-date Go toolchain, unsupported `GOOS`/`GOARCH`, and network/proxy errors. They are written to STDERR (so they never pollute `--json` STDOUT) and, in `--json` mode, are also exposed as the per-package `hint` field. gup stays quiet when it cannot offer a confident suggestion (for example, a timeout error already names the manual command and `--timeout` remedy), so a hint always adds signal.
+Hints cover module renames/major-version moves, binaries not installed via `go install`, missing branch/tag, unresolvable/private/deleted repositories, permission and network errors, and an out-of-date Go toolchain. gup stays silent when it has nothing reliable to add (e.g. a timeout, whose message already names the remedy).
 
 ### Behavior on an empty environment
 An empty global environment (no binaries installed by `go install` yet) is treated as a normal first-run condition, not an error:

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -91,7 +91,7 @@ func check(cmd *cobra.Command, args []string) int {
 		return 1
 	}
 
-	pkgs, goVersionAvailable, err := pkgselect.PackageInfoByTargets(args)
+	pkgs, missingTargets, goVersionAvailable, err := pkgselect.PackageInfoByTargets(args)
 	if err != nil {
 		print.Err(err)
 		return 1
@@ -100,7 +100,7 @@ func check(cmd *cobra.Command, args []string) int {
 	// --ignore-go-update so check does not report every binary as outdated
 	// (see issue #296).
 	ignoreGoUpdate = ignoreGoUpdate || !goVersionAvailable
-	pkgs = pkgselect.ExtractByTargets(pkgs, args, func(msg string) { print.Warn(msg) })
+	pkgselect.WarnMissing(missingTargets, func(msg string) { print.Warn(msg) })
 
 	if len(pkgs) == 0 {
 		// With explicit targets, an empty result means the user named binaries

--- a/cmd/jsonout.go
+++ b/cmd/jsonout.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 
+	"github.com/nao1215/gup/internal/diagnose"
 	"github.com/nao1215/gup/internal/goutil"
 	"github.com/nao1215/gup/internal/print"
 )
@@ -35,6 +36,7 @@ type jsonPackage struct {
 	InstalledGoVersion string `json:"installed_go_version"`
 	Status             string `json:"status"`
 	Error              string `json:"error,omitempty"`
+	Hint               string `json:"hint,omitempty"`
 }
 
 // newJSONPackage builds a jsonPackage from package information, the resolved
@@ -59,6 +61,7 @@ func newJSONPackage(p goutil.Package, status string, err error) jsonPackage {
 	if err != nil {
 		rec.Status = statusError
 		rec.Error = err.Error()
+		rec.Hint = diagnose.Hint(err)
 	}
 	return rec
 }

--- a/cmd/parallel.go
+++ b/cmd/parallel.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/nao1215/gup/internal/diagnose"
 	"github.com/nao1215/gup/internal/goutil"
 	"github.com/nao1215/gup/internal/parallel"
 	"github.com/nao1215/gup/internal/print"
@@ -77,6 +78,9 @@ func executePackages(pkgs []goutil.Package, cpus int, timeout time.Duration,
 			if v.err != nil {
 				exitCode = 1
 				print.Err(fmt.Errorf("%s %s", prefix, v.err.Error()))
+				if hint := diagnose.Hint(v.err); hint != "" {
+					print.Hint(hint)
+				}
 			} else if onResult != nil {
 				onResult(prefix, v)
 			}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -148,7 +148,7 @@ func gup(cmd *cobra.Command, args []string) int {
 		return 1
 	}
 
-	pkgs, goVersionAvailable, err := pkgselect.PackageInfoByTargets(args)
+	pkgs, missingTargets, goVersionAvailable, err := pkgselect.PackageInfoByTargets(args)
 	if err != nil {
 		print.Err(err)
 		return 1
@@ -186,7 +186,7 @@ func gup(cmd *cobra.Command, args []string) int {
 		return 1
 	}
 
-	pkgs = pkgselect.ExtractByTargets(pkgs, args, func(msg string) { print.Warn(msg) })
+	pkgselect.WarnMissing(missingTargets, func(msg string) { print.Warn(msg) })
 	// In JSON mode the human-readable "Exclude ..." notice is suppressed so
 	// STDOUT stays valid JSON (the notice goes to STDOUT via print.Info, which
 	// would otherwise break machine-readable output; see issue #291).
@@ -243,8 +243,11 @@ func gup(cmd *cobra.Command, args []string) int {
 		return 1
 	}
 
+	// missingTargets were already reported as "not found ... in $GOBIN" above;
+	// pass them so ResolveChannels does not emit a second, redundant notice for a
+	// name listed both as a positional target and in --main/--master/--latest.
 	channelMap, err := configstate.ResolveChannels(pkgs, confPkgs, mainPkgNames, masterPkgNames, latestPkgNames,
-		func(msg string) { print.Warn(msg) })
+		missingTargets, func(msg string) { print.Warn(msg) })
 	if err != nil {
 		print.Err(err)
 		return 1

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -76,7 +76,9 @@ echo "e2e: warming module cache..."
 		gup.test/badmaintool@main \
 		gup.test/badmaintool@master \
 		gup.test/moved/cmd/tool@v1.0.0 \
-		gup.test/moved@v1.1.0; do
+		gup.test/moved@v1.1.0 \
+		gup.test/replaced@v1.0.0 \
+		gup.test/replaced@v1.1.0; do
 		go install "$m" >/dev/null 2>&1 || true
 	done
 )

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -74,7 +74,9 @@ echo "e2e: warming module cache..."
 		gup.test/mastertool@master \
 		gup.test/badmaintool@v1.0.0 \
 		gup.test/badmaintool@main \
-		gup.test/badmaintool@master; do
+		gup.test/badmaintool@master \
+		gup.test/moved/cmd/tool@v1.0.0 \
+		gup.test/moved@v1.1.0; do
 		go install "$m" >/dev/null 2>&1 || true
 	done
 )

--- a/e2e/spec/check_spec.sh
+++ b/e2e/spec/check_spec.sh
@@ -22,4 +22,15 @@ Describe 'gup check'
     The output should include '"status": "update-available"'
     The output should include '"latest_version": "v1.1.0"'
   End
+
+  # A file present in $GOBIN whose build info can't be read (here a non-Go junk
+  # binary) must be reported as unreadable, NOT as "not found": it exists, it
+  # just can't be managed. Regression for the missing-target mislabeling.
+  It 'does not mislabel a present-but-unreadable binary as not found'
+    printf 'not a go binary' > "$GOBIN/junk"
+    When call gup check junk
+    The status should be failure
+    The stderr should include 'could not read Go build info'
+    The stderr should not include "not found 'junk'"
+  End
 End

--- a/e2e/spec/update_spec.sh
+++ b/e2e/spec/update_spec.sh
@@ -117,6 +117,7 @@ Describe 'gup update'
       The status should be failure
       The output should include 'update binary under'
       The stderr should include 'replace directive'
+      The stderr should include 'gup:'
       The stderr should include 'go install'
     End
   End

--- a/e2e/spec/update_spec.sh
+++ b/e2e/spec/update_spec.sh
@@ -106,5 +106,18 @@ Describe 'gup update'
       The stderr should include 'gup:'
       The stderr should include 'major version'
     End
+
+    # gup.test/replaced installs cleanly at v1.0.0, but its newer @latest
+    # (v1.1.0) adds a replace directive to go.mod, so the real go toolchain
+    # refuses it with "contains one or more replace directives" — the one
+    # diagnostic class go-global-update documented (E004) that gup lacked.
+    It 'prints a next-step hint when the module uses replace directives'
+      install_fixture gup.test/replaced@v1.0.0
+      When call gup update replaced
+      The status should be failure
+      The output should include 'update binary under'
+      The stderr should include 'replace directive'
+      The stderr should include 'go install'
+    End
   End
 End

--- a/e2e/spec/update_spec.sh
+++ b/e2e/spec/update_spec.sh
@@ -88,4 +88,23 @@ Describe 'gup update'
       The stderr should include '--file'
     End
   End
+
+  Describe 'failure diagnostics / next-step hints'
+    # gup.test/moved ships its command under cmd/tool at v1.0.0, but the newer
+    # @latest (v1.1.0) no longer contains that package, so the real go toolchain
+    # fails with "found (v1.1.0), but does not contain package ...". This is the
+    # realistic "the tool moved (e.g. /v2 bump)" failure; gup must turn that
+    # cryptic output into an actionable next step.
+    It 'prints a next-step hint when the command path moved away'
+      install_fixture gup.test/moved/cmd/tool@v1.0.0
+      When call gup update tool
+      The status should be failure
+      The output should include 'update binary under'
+      # The raw toolchain error is still surfaced...
+      The stderr should include 'does not contain package'
+      # ...followed by the actionable hint.
+      The stderr should include 'gup:'
+      The stderr should include 'major version'
+    End
+  End
 End

--- a/e2e/testproxy/main.go
+++ b/e2e/testproxy/main.go
@@ -35,6 +35,12 @@ type modVersion struct {
 	module  string // module path, e.g. "gup.test/outdated"
 	version string // semantic or pseudo version
 	mainGo  string // contents of main.go for this version
+	// pkgSubdir places main.go in a subdirectory of the module (e.g. "cmd/tool"),
+	// so the installable import path becomes module+"/"+pkgSubdir. Empty means the
+	// module root. A newer version that omits a previously present subdir lets the
+	// proxy reproduce the real "found (vX), but does not contain package ..."
+	// failure a tool hits after it moves its command (e.g. on a /v2 bump).
+	pkgSubdir string
 }
 
 // branchRef maps a VCS ref (branch name) to a concrete version the proxy
@@ -69,23 +75,31 @@ const badMain = "package main\n\nfunc main() { thisSymbolDoesNotExist() }\n"
 func fixtures() ([]modVersion, []branchRef, map[string][]string, map[string]string) {
 	versions := []modVersion{
 		// uptodate: a single version that is also @latest.
-		{"gup.test/uptodate", "v1.0.0", okMain("uptodate v1.0.0")},
+		{module: "gup.test/uptodate", version: "v1.0.0", mainGo: okMain("uptodate v1.0.0")},
 		// outdated: installed at v1.0.0, newer v1.1.0 available as @latest.
-		{"gup.test/outdated", "v1.0.0", okMain("outdated v1.0.0")},
-		{"gup.test/outdated", "v1.1.0", okMain("outdated v1.1.0")},
+		{module: "gup.test/outdated", version: "v1.0.0", mainGo: okMain("outdated v1.0.0")},
+		{module: "gup.test/outdated", version: "v1.1.0", mainGo: okMain("outdated v1.1.0")},
 		// maintool: tracked on @main (resolves to a pseudo-version).
-		{"gup.test/maintool", "v0.0.0-20240101000000-00000000000a", okMain("maintool main")},
+		{module: "gup.test/maintool", version: "v0.0.0-20240101000000-00000000000a", mainGo: okMain("maintool main")},
 		// mastertool: has only a master branch (no main).
-		{"gup.test/mastertool", "v0.0.0-20240101000000-00000000000b", okMain("mastertool master")},
+		{module: "gup.test/mastertool", version: "v0.0.0-20240101000000-00000000000b", mainGo: okMain("mastertool master")},
 		// badmaintool: installable at v1.0.0; @main resolves but does NOT compile;
 		// @master resolves and DOES compile. This proves gup must not fall back to
 		// the working @master when @main fails for a non-branch reason.
 		// The @main and @master pseudo-versions sort NEWER than v1.0.0 (they are
 		// "+1 commit after v1.0.0"), so gup actually attempts the install instead
 		// of treating the installed v1.0.0 as up-to-date.
-		{"gup.test/badmaintool", "v1.0.0", okMain("badmaintool v1.0.0")},
-		{"gup.test/badmaintool", "v1.0.1-0.20240102000000-00000000000c", badMain},
-		{"gup.test/badmaintool", "v1.0.1-0.20240102000000-00000000000d", okMain("badmaintool master")},
+		{module: "gup.test/badmaintool", version: "v1.0.0", mainGo: okMain("badmaintool v1.0.0")},
+		{module: "gup.test/badmaintool", version: "v1.0.1-0.20240102000000-00000000000c", mainGo: badMain},
+		{module: "gup.test/badmaintool", version: "v1.0.1-0.20240102000000-00000000000d", mainGo: okMain("badmaintool master")},
+		// moved: the command lives under cmd/tool at v1.0.0, but the newer
+		// @latest (v1.1.0) no longer contains that package. Installing
+		// gup.test/moved/cmd/tool@v1.1.0 therefore fails with the real
+		// "found (v1.1.0), but does not contain package ..." error a tool emits
+		// after relocating its command (e.g. on a major-version bump). This drives
+		// the diagnostics e2e for the next-step hint.
+		{module: "gup.test/moved", version: "v1.0.0", mainGo: okMain("moved tool v1.0.0"), pkgSubdir: "cmd/tool"},
+		{module: "gup.test/moved", version: "v1.1.0", mainGo: okMain("moved v1.1.0")},
 	}
 	branches := []branchRef{
 		{"gup.test/maintool", "main", "v0.0.0-20240101000000-00000000000a"},
@@ -101,6 +115,7 @@ func fixtures() ([]modVersion, []branchRef, map[string][]string, map[string]stri
 		"gup.test/maintool":    {},
 		"gup.test/mastertool":  {},
 		"gup.test/badmaintool": {"v1.0.0"},
+		"gup.test/moved":       {"v1.0.0", "v1.1.0"},
 	}
 	// @latest version per module. The go client resolves @latest even for a
 	// branch install (deprecation lookup), so branch-only modules point @latest
@@ -111,6 +126,7 @@ func fixtures() ([]modVersion, []branchRef, map[string][]string, map[string]stri
 		"gup.test/maintool":    "v0.0.0-20240101000000-00000000000a",
 		"gup.test/mastertool":  "v0.0.0-20240101000000-00000000000b",
 		"gup.test/badmaintool": "v1.0.0",
+		"gup.test/moved":       "v1.1.0",
 	}
 	return versions, branches, lists, latest
 }
@@ -147,7 +163,11 @@ func writeVersion(dir string, v modVersion) error {
 	defer func() { _ = zf.Close() }()
 	zw := zip.NewWriter(zf)
 	prefix := v.module + "@" + v.version + "/"
-	for name, content := range map[string]string{"go.mod": goMod(v.module), "main.go": v.mainGo} {
+	mainGoPath := "main.go"
+	if v.pkgSubdir != "" {
+		mainGoPath = v.pkgSubdir + "/main.go"
+	}
+	for name, content := range map[string]string{"go.mod": goMod(v.module), mainGoPath: v.mainGo} {
 		w, werr := zw.Create(prefix + name)
 		if werr != nil {
 			return werr

--- a/e2e/testproxy/main.go
+++ b/e2e/testproxy/main.go
@@ -41,6 +41,10 @@ type modVersion struct {
 	// proxy reproduce the real "found (vX), but does not contain package ..."
 	// failure a tool hits after it moves its command (e.g. on a /v2 bump).
 	pkgSubdir string
+	// replace, when true, adds a replace directive to this version's go.mod, so
+	// "go install" of this version fails with the real "go.mod file ... contains
+	// one or more replace directives" error.
+	replace bool
 }
 
 // branchRef maps a VCS ref (branch name) to a concrete version the proxy
@@ -58,6 +62,22 @@ const fixtureTime = "2024-01-01T00:00:00Z"
 
 func goMod(module string) string {
 	return "module " + module + "\n\ngo 1.21\n"
+}
+
+// goModWithReplace returns a go.mod carrying a replace directive, which makes
+// "go install" of the module reject it with the real "contains one or more
+// replace directives" error.
+func goModWithReplace(module string) string {
+	return goMod(module) + "\nreplace gup.test/replaced/dep => gup.test/replaced/dep v1.0.0\n"
+}
+
+// moduleGoMod renders the go.mod for one version, with or without a replace
+// directive.
+func moduleGoMod(v modVersion) string {
+	if v.replace {
+		return goModWithReplace(v.module)
+	}
+	return goMod(v.module)
 }
 
 func okMain(msg string) string {
@@ -100,6 +120,12 @@ func fixtures() ([]modVersion, []branchRef, map[string][]string, map[string]stri
 		// the diagnostics e2e for the next-step hint.
 		{module: "gup.test/moved", version: "v1.0.0", mainGo: okMain("moved tool v1.0.0"), pkgSubdir: "cmd/tool"},
 		{module: "gup.test/moved", version: "v1.1.0", mainGo: okMain("moved v1.1.0")},
+		// replaced: installable at v1.0.0, but the newer @latest (v1.1.0) adds a
+		// replace directive to go.mod, so "go install" rejects it with the real
+		// "contains one or more replace directives" error. Drives the diagnostics
+		// e2e for the replace-directive next-step hint.
+		{module: "gup.test/replaced", version: "v1.0.0", mainGo: okMain("replaced v1.0.0")},
+		{module: "gup.test/replaced", version: "v1.1.0", mainGo: okMain("replaced v1.1.0"), replace: true},
 	}
 	branches := []branchRef{
 		{"gup.test/maintool", "main", "v0.0.0-20240101000000-00000000000a"},
@@ -116,6 +142,7 @@ func fixtures() ([]modVersion, []branchRef, map[string][]string, map[string]stri
 		"gup.test/mastertool":  {},
 		"gup.test/badmaintool": {"v1.0.0"},
 		"gup.test/moved":       {"v1.0.0", "v1.1.0"},
+		"gup.test/replaced":    {"v1.0.0", "v1.1.0"},
 	}
 	// @latest version per module. The go client resolves @latest even for a
 	// branch install (deprecation lookup), so branch-only modules point @latest
@@ -127,6 +154,7 @@ func fixtures() ([]modVersion, []branchRef, map[string][]string, map[string]stri
 		"gup.test/mastertool":  "v0.0.0-20240101000000-00000000000b",
 		"gup.test/badmaintool": "v1.0.0",
 		"gup.test/moved":       "v1.1.0",
+		"gup.test/replaced":    "v1.1.0",
 	}
 	return versions, branches, lists, latest
 }
@@ -149,7 +177,7 @@ func writeVersion(dir string, v modVersion) error {
 	if err := writeFile(filepath.Join(vdir, v.version+".info"), infoJSON(v.version)); err != nil {
 		return err
 	}
-	if err := writeFile(filepath.Join(vdir, v.version+".mod"), goMod(v.module)); err != nil {
+	if err := writeFile(filepath.Join(vdir, v.version+".mod"), moduleGoMod(v)); err != nil {
 		return err
 	}
 	zipPath := filepath.Join(vdir, v.version+".zip")
@@ -167,7 +195,7 @@ func writeVersion(dir string, v modVersion) error {
 	if v.pkgSubdir != "" {
 		mainGoPath = v.pkgSubdir + "/main.go"
 	}
-	for name, content := range map[string]string{"go.mod": goMod(v.module), mainGoPath: v.mainGo} {
+	for name, content := range map[string]string{"go.mod": moduleGoMod(v), mainGoPath: v.mainGo} {
 		w, werr := zw.Create(prefix + name)
 		if werr != nil {
 			return werr

--- a/internal/configstate/configstate.go
+++ b/internal/configstate/configstate.go
@@ -204,12 +204,18 @@ func ApplySavedChannels(pkgs, confPkgs []goutil.Package) []goutil.Package {
 // A binary named in two conflicting channel flags is an error. A flag naming a
 // binary that is not an update target is reported through warn (a non-fatal
 // notice) and otherwise ignored. warn may be nil.
+//
+// reportedMissing holds target names the caller has already reported as
+// "not found" (e.g. missing positional targets). A flag naming one of those is
+// silently skipped instead of triggering a second, redundant notice for the
+// same name.
 func ResolveChannels(
 	pkgs []goutil.Package,
 	confPkgs []goutil.Package,
 	mainPkgNames []string,
 	masterPkgNames []string,
 	latestPkgNames []string,
+	reportedMissing []string,
 	warn func(string),
 ) (map[string]goutil.UpdateChannel, error) {
 	saved := indexSavedChannels(confPkgs)
@@ -222,6 +228,13 @@ func ResolveChannels(
 		}
 		channelMap[p.Name] = channel
 		normalizedToActual[binname.NormalizeForMatch(p.Name)] = p.Name
+	}
+
+	alreadyReported := make(map[string]struct{}, len(reportedMissing))
+	for _, name := range reportedMissing {
+		if normalized := binname.NormalizeForMatch(name); normalized != "" {
+			alreadyReported[normalized] = struct{}{}
+		}
 	}
 
 	assignedByFlag := map[string]string{}
@@ -239,7 +252,7 @@ func ResolveChannels(
 
 			actual, ok := normalizedToActual[normalized]
 			if !ok {
-				if warn != nil {
+				if _, reported := alreadyReported[normalized]; !reported && warn != nil {
 					warn("not found '" + name + "' package in update target")
 				}
 				continue

--- a/internal/configstate/configstate_test.go
+++ b/internal/configstate/configstate_test.go
@@ -19,6 +19,7 @@ const (
 	testToolA    = "tool-a"
 	testToolB    = "tool-b"
 	testToolC    = "tool-c"
+	testNope     = "nope"
 	testKeptTool = "kept-tool"
 	testNewTool  = "new-tool"
 	testVer100   = "v1.0.0"
@@ -222,7 +223,7 @@ func TestResolveChannels(t *testing.T) {
 
 	t.Run("assigns channels from flags", func(t *testing.T) {
 		t.Parallel()
-		got, err := ResolveChannels(pkgs, nil, []string{testToolA}, []string{testToolB}, nil, nil)
+		got, err := ResolveChannels(pkgs, nil, []string{testToolA}, []string{testToolB}, nil, nil, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -240,7 +241,7 @@ func TestResolveChannels(t *testing.T) {
 	t.Run("config channel is the default below flags", func(t *testing.T) {
 		t.Parallel()
 		confPkgs := []goutil.Package{{Name: testToolC, UpdateChannel: goutil.UpdateChannelMain}}
-		got, err := ResolveChannels(pkgs, confPkgs, nil, nil, nil, nil)
+		got, err := ResolveChannels(pkgs, confPkgs, nil, nil, nil, nil, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -252,7 +253,7 @@ func TestResolveChannels(t *testing.T) {
 	t.Run("flag overrides config channel", func(t *testing.T) {
 		t.Parallel()
 		confPkgs := []goutil.Package{{Name: testToolC, UpdateChannel: goutil.UpdateChannelMain}}
-		got, err := ResolveChannels(pkgs, confPkgs, nil, nil, []string{testToolC}, nil)
+		got, err := ResolveChannels(pkgs, confPkgs, nil, nil, []string{testToolC}, nil, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -263,7 +264,7 @@ func TestResolveChannels(t *testing.T) {
 
 	t.Run("conflicting flags error", func(t *testing.T) {
 		t.Parallel()
-		_, err := ResolveChannels(pkgs, nil, []string{testToolA}, []string{testToolA}, nil, nil)
+		_, err := ResolveChannels(pkgs, nil, []string{testToolA}, []string{testToolA}, nil, nil, nil)
 		if err == nil || !strings.Contains(err.Error(), "same binary") {
 			t.Fatalf("err = %v, want 'same binary'", err)
 		}
@@ -272,21 +273,21 @@ func TestResolveChannels(t *testing.T) {
 	t.Run("unknown flag name is warned and skipped", func(t *testing.T) {
 		t.Parallel()
 		var warned []string
-		got, err := ResolveChannels(pkgs, nil, []string{"nope"}, nil, nil, func(m string) { warned = append(warned, m) })
+		got, err := ResolveChannels(pkgs, nil, []string{testNope}, nil, nil, nil, func(m string) { warned = append(warned, m) })
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if len(warned) != 1 || !strings.Contains(warned[0], "nope") {
+		if len(warned) != 1 || !strings.Contains(warned[0], testNope) {
 			t.Fatalf("warn = %v, want a notice mentioning 'nope'", warned)
 		}
-		if _, ok := got["nope"]; ok {
+		if _, ok := got[testNope]; ok {
 			t.Fatal("unknown binary should not be added to the channel map")
 		}
 	})
 
 	t.Run("blank flag name is skipped", func(t *testing.T) {
 		t.Parallel()
-		got, err := ResolveChannels(pkgs, nil, []string{" "}, nil, nil, nil)
+		got, err := ResolveChannels(pkgs, nil, []string{" "}, nil, nil, nil, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -294,6 +295,37 @@ func TestResolveChannels(t *testing.T) {
 			if got[p.Name] != goutil.UpdateChannelLatest {
 				t.Errorf("%s = %q, want latest", p.Name, got[p.Name])
 			}
+		}
+	})
+
+	// A name already reported as a missing positional target must not be warned
+	// again when it also appears in a channel flag: the caller has surfaced it
+	// once already.
+	t.Run("does not re-warn a name already reported missing", func(t *testing.T) {
+		t.Parallel()
+		var warned []string
+		_, err := ResolveChannels(pkgs, nil, []string{testNope}, nil, nil,
+			[]string{testNope}, func(m string) { warned = append(warned, m) })
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(warned) != 0 {
+			t.Fatalf("warn = %v, want no second notice for an already-reported name", warned)
+		}
+	})
+
+	// A different unmatched flag name is still warned even when an unrelated name
+	// was reported missing.
+	t.Run("still warns a distinct unmatched flag name", func(t *testing.T) {
+		t.Parallel()
+		var warned []string
+		_, err := ResolveChannels(pkgs, nil, []string{"other"}, nil, nil,
+			[]string{testNope}, func(m string) { warned = append(warned, m) })
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(warned) != 1 || !strings.Contains(warned[0], "other") {
+			t.Fatalf("warn = %v, want a notice mentioning 'other'", warned)
 		}
 	})
 }
@@ -482,7 +514,7 @@ func TestResolveChannels_honorsSavedChannelByImportPath(t *testing.T) {
 	confPkgs := []goutil.Package{{Name: testOldName, ImportPath: testFooPath, UpdateChannel: goutil.UpdateChannelMain}}
 	pkgs := []goutil.Package{{Name: testNewName, ImportPath: testFooPath}}
 
-	got, err := ResolveChannels(pkgs, confPkgs, nil, nil, nil, nil)
+	got, err := ResolveChannels(pkgs, confPkgs, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -500,7 +532,7 @@ func TestResolveChannels_savedChannelOverridableByFlag(t *testing.T) {
 	pkgs := []goutil.Package{{Name: testNewName, ImportPath: testFooPath}}
 
 	// Without flags the saved @main (matched by import_path) wins over @latest.
-	base, err := ResolveChannels(pkgs, confPkgs, nil, nil, nil, nil)
+	base, err := ResolveChannels(pkgs, confPkgs, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -509,7 +541,7 @@ func TestResolveChannels_savedChannelOverridableByFlag(t *testing.T) {
 	}
 
 	// --latest for the installed binary still overrides the saved channel.
-	got, err := ResolveChannels(pkgs, confPkgs, nil, nil, []string{testNewName}, nil)
+	got, err := ResolveChannels(pkgs, confPkgs, nil, nil, []string{testNewName}, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -583,7 +615,7 @@ func TestIdentity_roundTripConsistency(t *testing.T) {
 	}
 
 	// ResolveChannels (update).
-	channelMap, err := ResolveChannels([]goutil.Package{installed}, confPkgs, nil, nil, nil, nil)
+	channelMap, err := ResolveChannels([]goutil.Package{installed}, confPkgs, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/diagnose/diagnose.go
+++ b/internal/diagnose/diagnose.go
@@ -74,10 +74,6 @@ var matchers = []matcher{ //nolint:gochecknoglobals
 		hint:  "The package has no Go files buildable for your platform (see `go env GOOS GOARCH`); this version may not support your OS/architecture.",
 	},
 	{
-		match: contains("permission denied", "operation not permitted"),
-		hint:  "Permission denied while installing. Check write access to your install directory (`go env GOBIN` / `go env GOPATH`) and the module cache.",
-	},
-	{
 		match: contains("no matching versions for query"),
 		hint:  "No published version matches the selected channel. Try another channel (e.g. `--main` or `--master`), or confirm the repository has tagged releases.",
 	},
@@ -86,8 +82,22 @@ var matchers = []matcher{ //nolint:gochecknoglobals
 		hint:  "The requested branch, tag, or version does not exist. Verify the channel (main vs master) or the version selector for this package.",
 	},
 	{
-		match: contains("unrecognized import path", "repository not found", "404 not found", "410 gone", "terminal prompts disabled"),
-		hint:  "The module path could not be resolved. The repository may be private, renamed, or deleted; check the import path and your access/credentials (e.g. GOPRIVATE, SSH/token auth).",
+		// Repository/auth failures are matched before the generic "permission
+		// denied" case below so an SSH auth error ("permission denied
+		// (publickey)") is diagnosed as an access problem, not local write
+		// permission.
+		match: contains("unrecognized import path", "repository not found", "404 not found", "410 gone",
+			"terminal prompts disabled", "permission denied (publickey)", "could not read from remote repository"),
+		hint: "The module path could not be resolved. The repository may be private, renamed, or deleted; check the import path and your access/credentials (e.g. GOPRIVATE, SSH/token auth).",
+	},
+	{
+		// Generic local install-permission error. Exclude the Git/SSH auth case,
+		// which is handled by the repository matcher above.
+		match: func(lower string) bool {
+			return (strings.Contains(lower, "permission denied") || strings.Contains(lower, "operation not permitted")) &&
+				!strings.Contains(lower, "permission denied (publickey)")
+		},
+		hint: "Permission denied while installing. Check write access to your install directory (`go env GOBIN` / `go env GOPATH`) and the module cache.",
 	},
 	{
 		match: contains("dial tcp", "i/o timeout", "connection refused", "tls handshake", "proxyconnect", "no such host", "network is unreachable", "could not connect"),
@@ -118,9 +128,10 @@ func Hint(err error) string {
 	msg := err.Error()
 	lower := strings.ToLower(msg)
 
-	// Timeout/cancellation messages already carry their own remedy.
+	// Timeout/cancellation messages already carry their own remedy. The go
+	// toolchain and context package spell it "canceled" (American).
 	if strings.Contains(lower, "timed out") || strings.Contains(lower, "canceled") ||
-		strings.Contains(lower, "cancelled") || strings.Contains(lower, "deadline exceeded") {
+		strings.Contains(lower, "deadline exceeded") {
 		return ""
 	}
 

--- a/internal/diagnose/diagnose.go
+++ b/internal/diagnose/diagnose.go
@@ -44,8 +44,17 @@ var goToolchainRegex = regexp.MustCompile(`requires go ?>?=? ?\d`)
 // they win over the broader network/permission fallbacks.
 var matchers = []matcher{ //nolint:gochecknoglobals
 	{
-		match: contains("is not installed by 'go install'", "no required module provides package"),
+		match: contains("is not installed by 'go install'"),
 		hint:  "This binary has no embedded module path. Reinstall it once with `go install <importpath>@latest` so gup can manage it, then run gup again.",
+	},
+	{
+		// "module ... found (vX), but does not contain package ..." is what the
+		// go command reports when the command's import path no longer exists in
+		// the module at the resolved version. The common cause is a major-version
+		// bump: the tool moved to a /v2+ module path, so the old import path is
+		// gone even though the v0/v1 line still resolves.
+		match: contains("does not contain package", "no required module provides package"),
+		hint:  "The module no longer provides this command at its import path. The project likely moved to a new major version (e.g. a `/v2` module path) or relocated the command; check its current install instructions and reinstall with the new path.",
 	},
 	{
 		match: contains("devel-binary copied from local environment", "command-line-arguments"),

--- a/internal/diagnose/diagnose.go
+++ b/internal/diagnose/diagnose.go
@@ -54,7 +54,12 @@ var matchers = []matcher{ //nolint:gochecknoglobals
 		// bump: the tool moved to a /v2+ module path, so the old import path is
 		// gone even though the v0/v1 line still resolves.
 		match: contains("does not contain package", "no required module provides package"),
-		hint:  "The module no longer provides this command at its import path. The project likely moved to a new major version (e.g. a `/v2` module path) or relocated the command; check its current install instructions and reinstall with the new path.",
+		hint:  "The module no longer provides this command at its import path. The project likely relocated the command (a separate repo/module) or bumped to a new major version (e.g. a `/v2` module path); check its current install instructions and reinstall with the new path.",
+	},
+	{
+		// `go install` refuses modules whose go.mod carries replace directives.
+		match: contains("replace directives", "replace directive"),
+		hint:  "This module's go.mod uses `replace` directives, which `go install` cannot build. Ask the maintainer to drop them, or clone the repository and run `go install` inside it (gup will then treat the binary as built-from-source and skip it).",
 	},
 	{
 		match: contains("devel-binary copied from local environment", "command-line-arguments"),

--- a/internal/diagnose/diagnose.go
+++ b/internal/diagnose/diagnose.go
@@ -1,0 +1,119 @@
+// Package diagnose turns the raw, often cryptic output of the Go toolchain
+// (surfaced when a package fails to update) into a short, actionable next-step
+// hint. gup already holds the full error context for every failed package, so
+// telling the user what to try next is nearly free and saves them from
+// deciphering "no matching versions for query" or "unrecognized import path"
+// by hand.
+//
+// Hint is intentionally conservative: it only returns text for failure modes it
+// can confidently recognize and returns "" otherwise, so a hint always adds
+// signal and never guesses.
+package diagnose
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/nao1215/gup/internal/goutil"
+)
+
+// matcher pairs a predicate over the lower-cased error text with the hint to
+// emit when it matches. The first matching entry in matchers wins, so entries
+// are ordered most-specific first.
+type matcher struct {
+	match func(lower string) bool
+	hint  string
+}
+
+func contains(needles ...string) func(string) bool {
+	return func(lower string) bool {
+		for _, n := range needles {
+			if strings.Contains(lower, n) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// goToolchainRegex matches the toolchain-too-old diagnostic, e.g.
+// "note: module requires Go 1.23" or "requires go >= 1.23".
+var goToolchainRegex = regexp.MustCompile(`requires go ?>?=? ?\d`)
+
+// matchers is consulted in order; keep the most specific failure modes first so
+// they win over the broader network/permission fallbacks.
+var matchers = []matcher{ //nolint:gochecknoglobals
+	{
+		match: contains("is not installed by 'go install'", "no required module provides package"),
+		hint:  "This binary has no embedded module path. Reinstall it once with `go install <importpath>@latest` so gup can manage it, then run gup again.",
+	},
+	{
+		match: contains("devel-binary copied from local environment", "command-line-arguments"),
+		hint:  "This binary was built from a local checkout (devel) and has no published module. Reinstall it from its upstream repository with `go install <importpath>@latest`.",
+	},
+	{
+		match: func(lower string) bool { return goToolchainRegex.MatchString(lower) },
+		hint:  "This module requires a newer Go toolchain. Upgrade Go, or set `GOTOOLCHAIN=auto` so the go command fetches the required version automatically.",
+	},
+	{
+		match: contains("build constraints exclude all go files"),
+		hint:  "The package has no Go files buildable for your platform (see `go env GOOS GOARCH`); this version may not support your OS/architecture.",
+	},
+	{
+		match: contains("permission denied", "operation not permitted"),
+		hint:  "Permission denied while installing. Check write access to your install directory (`go env GOBIN` / `go env GOPATH`) and the module cache.",
+	},
+	{
+		match: contains("no matching versions for query"),
+		hint:  "No published version matches the selected channel. Try another channel (e.g. `--main` or `--master`), or confirm the repository has tagged releases.",
+	},
+	{
+		match: contains("unknown revision", "invalid version", "unknown branch"),
+		hint:  "The requested branch, tag, or version does not exist. Verify the channel (main vs master) or the version selector for this package.",
+	},
+	{
+		match: contains("unrecognized import path", "repository not found", "404 not found", "410 gone", "terminal prompts disabled"),
+		hint:  "The module path could not be resolved. The repository may be private, renamed, or deleted; check the import path and your access/credentials (e.g. GOPRIVATE, SSH/token auth).",
+	},
+	{
+		match: contains("dial tcp", "i/o timeout", "connection refused", "tls handshake", "proxyconnect", "no such host", "network is unreachable", "could not connect"),
+		hint:  "Network error reaching the module proxy or repository. Check your connection and the GOPROXY setting (`go env GOPROXY`).",
+	},
+}
+
+// Hint returns a short, actionable next-step suggestion for a failed package
+// update, or "" when the cause is not confidently recognized.
+//
+// Two cases are deliberately skipped: a nil error, and timeout/cancellation
+// errors whose message already names the manual command and the --timeout
+// remedy (adding a hint there would only duplicate that guidance).
+func Hint(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	// Module path renames get a precise hint naming the new path, reusing the
+	// same detector gup uses to auto-follow renames. This is checked first
+	// because the raw error also contains "version constraints conflict" text
+	// that none of the substring matchers should claim.
+	if declared, _, ok := goutil.DetectModulePathMismatch(err); ok {
+		return "The module appears to have moved to " + declared +
+			". gup tries to follow renames automatically; if it still fails, reinstall manually with `go install " + declared + "@latest`."
+	}
+
+	msg := err.Error()
+	lower := strings.ToLower(msg)
+
+	// Timeout/cancellation messages already carry their own remedy.
+	if strings.Contains(lower, "timed out") || strings.Contains(lower, "canceled") ||
+		strings.Contains(lower, "cancelled") || strings.Contains(lower, "deadline exceeded") {
+		return ""
+	}
+
+	for _, m := range matchers {
+		if m.match(lower) {
+			return m.hint
+		}
+	}
+	return ""
+}

--- a/internal/diagnose/diagnose_test.go
+++ b/internal/diagnose/diagnose_test.go
@@ -50,6 +50,16 @@ func TestHint(t *testing.T) {
 			wantSub: "local checkout",
 		},
 		{
+			// Verified against real output of:
+			//   go install github.com/wagoodman/dive@v0.9.0
+			name: "go.mod replace directives",
+			err: errors.New(`go: github.com/wagoodman/dive@v0.9.0 (in github.com/wagoodman/dive@v0.9.0):
+	The go.mod file for the module providing named packages contains one or
+	more replace directives. It must not contain directives that would cause
+	it to be interpreted differently than if it were the main module.`),
+			wantSub: "`replace` directives",
+		},
+		{
 			name:    "go toolchain too old",
 			err:     errors.New("can't install x:\ngo: module requires go >= 1.23 (running go 1.21.0)"),
 			wantSub: "newer Go toolchain",

--- a/internal/diagnose/diagnose_test.go
+++ b/internal/diagnose/diagnose_test.go
@@ -6,6 +6,10 @@ import (
 	"testing"
 )
 
+// subResolved is the distinctive fragment of the repository-resolution hint,
+// shared by several cases that funnel to it.
+const subResolved = "could not be resolved"
+
 func TestHint(t *testing.T) {
 	t.Parallel()
 
@@ -75,6 +79,14 @@ func TestHint(t *testing.T) {
 			wantSub: "Permission denied",
 		},
 		{
+			// An SSH git auth failure also says "permission denied", but it is an
+			// access problem, not a local write-permission one, so it must get the
+			// repository/credentials hint instead.
+			name:    "ssh auth failure is not a write-permission error",
+			err:     errors.New("go: github.com/x@latest: git@github.com: Permission denied (publickey).\nfatal: Could not read from remote repository."),
+			wantSub: subResolved,
+		},
+		{
 			name:    "no matching versions",
 			err:     errors.New(`go: github.com/x@latest: no matching versions for query "latest"`),
 			wantSub: "another channel",
@@ -91,14 +103,14 @@ func TestHint(t *testing.T) {
 			//   go list -m example.com/nope/nope@latest
 			name:    "unrecognized import path",
 			err:     errors.New(`go: example.com/nope/nope@latest: unrecognized import path "example.com/nope/nope": reading https://example.com/nope/nope?go-get=1: 404 Not Found`),
-			wantSub: "could not be resolved",
+			wantSub: subResolved,
 		},
 		{
 			// Verified against real output of:
 			//   go list -m github.com/nao1215/<deleted>@latest  (direct git fallback)
 			name:    "deleted or private repository",
 			err:     errors.New("go: module github.com/nao1215/nope: git ls-remote -q https://github.com/nao1215/nope in /cache: exit status 128:\n\tremote: Repository not found.\n\tfatal: repository 'https://github.com/nao1215/nope/' not found"),
-			wantSub: "could not be resolved",
+			wantSub: subResolved,
 		},
 		{
 			name:    "network dial error",

--- a/internal/diagnose/diagnose_test.go
+++ b/internal/diagnose/diagnose_test.go
@@ -21,12 +21,23 @@ func TestHint(t *testing.T) {
 			wantNone: true,
 		},
 		{
+			// Verified against real output of:
+			//   go install github.com/cosmtrek/air@latest
 			name: "module path mismatch names the new path",
 			err: errors.New(`go: github.com/cosmtrek/air@latest: version constraints conflict:
-	github.com/cosmtrek/air@v1.52.2: parsing go.mod:
+	github.com/cosmtrek/air@v1.65.3: parsing go.mod:
 	module declares its path as: github.com/air-verse/air
 	        but was required as: github.com/cosmtrek/air`),
 			wantSub: "github.com/air-verse/air",
+		},
+		{
+			// Verified against real output of:
+			//   go install github.com/golang-migrate/migrate/cmd/migrate@latest
+			// (the tool moved to a /v4 module path, so its old v1 import path is
+			// gone). This is the realistic "v2+ appeared" failure.
+			name:    "command path gone after major version bump",
+			err:     errors.New("go: github.com/golang-migrate/migrate/cmd/migrate@latest: module github.com/golang-migrate/migrate@latest found (v3.5.4+incompatible), but does not contain package github.com/golang-migrate/migrate/cmd/migrate"),
+			wantSub: "new major version",
 		},
 		{
 			name:    "not installed by go install",
@@ -59,18 +70,24 @@ func TestHint(t *testing.T) {
 			wantSub: "another channel",
 		},
 		{
-			name:    "unknown revision",
-			err:     errors.New("go: github.com/x@main: unknown revision main"),
+			// Verified against real output of:
+			//   go list -m github.com/nao1215/gup@v999.0.0
+			name:    "invalid version",
+			err:     errors.New("go: github.com/nao1215/gup@v999.0.0: invalid version: unknown revision v999.0.0"),
 			wantSub: "does not exist",
 		},
 		{
+			// Verified against real output of:
+			//   go list -m example.com/nope/nope@latest
 			name:    "unrecognized import path",
-			err:     errors.New(`go: github.com/x@latest: unrecognized import path "github.com/x"`),
+			err:     errors.New(`go: example.com/nope/nope@latest: unrecognized import path "example.com/nope/nope": reading https://example.com/nope/nope?go-get=1: 404 Not Found`),
 			wantSub: "could not be resolved",
 		},
 		{
-			name:    "repository not found",
-			err:     errors.New("remote: Repository not found.\nfatal: repository not found"),
+			// Verified against real output of:
+			//   go list -m github.com/nao1215/<deleted>@latest  (direct git fallback)
+			name:    "deleted or private repository",
+			err:     errors.New("go: module github.com/nao1215/nope: git ls-remote -q https://github.com/nao1215/nope in /cache: exit status 128:\n\tremote: Repository not found.\n\tfatal: repository 'https://github.com/nao1215/nope/' not found"),
 			wantSub: "could not be resolved",
 		},
 		{

--- a/internal/diagnose/diagnose_test.go
+++ b/internal/diagnose/diagnose_test.go
@@ -1,0 +1,116 @@
+package diagnose
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestHint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		err      error
+		wantSub  string // substring the hint must contain ("" means expect no hint)
+		wantNone bool
+	}{
+		{
+			name:     "nil error has no hint",
+			err:      nil,
+			wantNone: true,
+		},
+		{
+			name: "module path mismatch names the new path",
+			err: errors.New(`go: github.com/cosmtrek/air@latest: version constraints conflict:
+	github.com/cosmtrek/air@v1.52.2: parsing go.mod:
+	module declares its path as: github.com/air-verse/air
+	        but was required as: github.com/cosmtrek/air`),
+			wantSub: "github.com/air-verse/air",
+		},
+		{
+			name:    "not installed by go install",
+			err:     errors.New("foo is not installed by 'go install' (or permission incorrect)"),
+			wantSub: "go install <importpath>@latest",
+		},
+		{
+			name:    "devel binary",
+			err:     errors.New("is devel-binary copied from local environment"),
+			wantSub: "local checkout",
+		},
+		{
+			name:    "go toolchain too old",
+			err:     errors.New("can't install x:\ngo: module requires go >= 1.23 (running go 1.21.0)"),
+			wantSub: "newer Go toolchain",
+		},
+		{
+			name:    "build constraints exclude all go files",
+			err:     errors.New("can't install x:\nbuild constraints exclude all Go files in /tmp/foo"),
+			wantSub: "buildable for your platform",
+		},
+		{
+			name:    "permission denied",
+			err:     errors.New("can't install x:\nmkdir /usr/local/bin: permission denied"),
+			wantSub: "Permission denied",
+		},
+		{
+			name:    "no matching versions",
+			err:     errors.New(`go: github.com/x@latest: no matching versions for query "latest"`),
+			wantSub: "another channel",
+		},
+		{
+			name:    "unknown revision",
+			err:     errors.New("go: github.com/x@main: unknown revision main"),
+			wantSub: "does not exist",
+		},
+		{
+			name:    "unrecognized import path",
+			err:     errors.New(`go: github.com/x@latest: unrecognized import path "github.com/x"`),
+			wantSub: "could not be resolved",
+		},
+		{
+			name:    "repository not found",
+			err:     errors.New("remote: Repository not found.\nfatal: repository not found"),
+			wantSub: "could not be resolved",
+		},
+		{
+			name:    "network dial error",
+			err:     errors.New("can't check x:\ndial tcp: lookup proxy.golang.org: no such host"),
+			wantSub: "Network error",
+		},
+		{
+			name:     "timeout already actionable, no hint",
+			err:      errors.New("install of x timed out; run `go install x@latest` manually or raise --timeout (0 disables it)"),
+			wantNone: true,
+		},
+		{
+			name:     "canceled, no hint",
+			err:      errors.New("install of x canceled: context canceled"),
+			wantNone: true,
+		},
+		{
+			name:     "unrecognized failure, no hint",
+			err:      errors.New("some entirely unexpected failure"),
+			wantNone: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := Hint(tt.err)
+			if tt.wantNone {
+				if got != "" {
+					t.Fatalf("Hint() = %q, want empty", got)
+				}
+				return
+			}
+			if got == "" {
+				t.Fatalf("Hint() = %q, want a hint containing %q", got, tt.wantSub)
+			}
+			if !strings.Contains(got, tt.wantSub) {
+				t.Errorf("Hint() = %q, want substring %q", got, tt.wantSub)
+			}
+		})
+	}
+}

--- a/internal/pkgselect/pkgselect.go
+++ b/internal/pkgselect/pkgselect.go
@@ -49,18 +49,25 @@ func PackageInfo() ([]goutil.Package, error) {
 }
 
 // PackageInfoByTargets returns package information for the installed binaries
-// matching targets (all binaries when targets is empty) together with a bool
-// reporting whether the installed Go version was detected. When the bool is
-// false, callers must disable Go-version comparison (see issue #296).
-func PackageInfoByTargets(targets []string) ([]goutil.Package, bool, error) {
+// matching targets (all binaries when targets is empty), the targets that match
+// no installed binary (for "not found" reporting), and a bool reporting whether
+// the installed Go version was detected. When the bool is false, callers must
+// disable Go-version comparison (see issue #296).
+//
+// "missing" is derived from the binary paths, not from the resolved packages, so
+// a binary that exists in $GOBIN but whose build info can't be read (or that was
+// not installed by 'go install') is never mislabeled as "not found"; it is
+// present but unmanageable, and GetPackageInformation already warns about it.
+func PackageInfoByTargets(targets []string) (pkgs []goutil.Package, missing []string, goVersionAvailable bool, err error) {
 	binList, err := BinaryPaths()
 	if err != nil {
-		return nil, false, fmt.Errorf("%s: %w", "can't get package info", err)
+		return nil, nil, false, fmt.Errorf("%s: %w", "can't get package info", err)
 	}
 
 	filtered := FilterBinaryPaths(binList, targets)
-	pkgs, goVersionAvailable := goutil.GetPackageInformation(filtered)
-	return pkgs, goVersionAvailable, nil
+	pkgs, goVersionAvailable = goutil.GetPackageInformation(filtered)
+	missing = MissingTargets(binList, targets)
+	return pkgs, missing, goVersionAvailable, nil
 }
 
 // FilterBinaryPaths returns the subset of binList whose base name matches one of
@@ -95,44 +102,51 @@ func FilterBinaryPaths(binList, targets []string) []string {
 	return filtered
 }
 
-// ExtractByTargets returns the packages whose names match targets, preserving
-// the order of pkgs. When targets is empty pkgs is returned unchanged. For each
-// target that matches no package, warn is called exactly once (duplicate targets
-// are collapsed).
-func ExtractByTargets(pkgs []goutil.Package, targets []string, warn func(string)) []goutil.Package {
-	result := []goutil.Package{}
+// MissingTargets returns the user-specified targets that match no installed
+// binary in binList, preserving first-seen order and collapsing duplicate
+// targets. The returned names are the trimmed originals, suitable for display.
+//
+// A target is "missing" only when no binary in $GOBIN shares its name. A binary
+// that exists but never becomes a Package (build info unreadable, or not
+// installed by 'go install') is NOT reported here: it is present, just
+// unmanageable. Matching the resolved packages instead would mislabel such a
+// binary as "not found", which is the wrong next step for the user.
+func MissingTargets(binList, targets []string) []string {
 	if len(targets) == 0 {
-		return pkgs
+		return nil
 	}
 
-	targetSet := make(map[string]string, len(targets)) // normalized target -> original (first seen)
-	targetOrder := make([]string, 0, len(targets))
+	present := make(map[string]struct{}, len(binList))
+	for _, path := range binList {
+		present[binname.NormalizeForMatch(filepath.Base(path))] = struct{}{}
+	}
+
+	var missing []string
+	seen := make(map[string]struct{}, len(targets))
 	for _, rawTarget := range targets {
-		target := binname.NormalizeForMatch(rawTarget)
-		if target == "" {
+		normalized := binname.NormalizeForMatch(rawTarget)
+		if normalized == "" {
 			continue
 		}
-		if _, exists := targetSet[target]; !exists {
-			targetSet[target] = strings.TrimSpace(rawTarget)
-			targetOrder = append(targetOrder, target)
+		if _, dup := seen[normalized]; dup {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		if _, ok := present[normalized]; !ok {
+			missing = append(missing, strings.TrimSpace(rawTarget))
 		}
 	}
+	return missing
+}
 
-	matched := make(map[string]struct{}, len(targetSet))
-	for _, v := range pkgs {
-		pkg := binname.NormalizeForMatch(v.Name)
-		if _, ok := targetSet[pkg]; ok {
-			result = append(result, v)
-			matched[pkg] = struct{}{}
-		}
+// WarnMissing reports each missing target name (as returned by MissingTargets)
+// through warn, using the standard "not found ... in $GOBIN" wording. warn is
+// called once per name; centralizing the message keeps update and check
+// consistent.
+func WarnMissing(missing []string, warn func(string)) {
+	for _, name := range missing {
+		warn("not found '" + name + "' package in $GOPATH/bin or $GOBIN")
 	}
-
-	for _, target := range targetOrder {
-		if _, ok := matched[target]; !ok {
-			warn("not found '" + targetSet[target] + "' package in $GOPATH/bin or $GOBIN")
-		}
-	}
-	return result
 }
 
 // Exclude returns pkgs with the binaries named in excludeList removed. For each

--- a/internal/pkgselect/pkgselect_test.go
+++ b/internal/pkgselect/pkgselect_test.go
@@ -78,53 +78,68 @@ func TestFilterBinaryPaths_windowsExe(t *testing.T) {
 	}
 }
 
-func TestExtractByTargets(t *testing.T) {
+func TestMissingTargets(t *testing.T) {
 	t.Parallel()
 
-	pkgs := []goutil.Package{
-		{Name: "test1"},
-		{Name: nameTest2},
-		{Name: "test3"},
+	binList := []string{
+		filepath.Join("bin", "test1"),
+		filepath.Join("bin", nameTest2),
+		filepath.Join("bin", "test3"),
 	}
 
-	t.Run("returns the matching package", func(t *testing.T) {
+	t.Run("returns nothing when every target matches a binary", func(t *testing.T) {
 		t.Parallel()
-		got := ExtractByTargets(pkgs, []string{nameTest2}, func(string) {})
-		want := []goutil.Package{{Name: nameTest2}}
+		if got := MissingTargets(binList, []string{nameTest2, "test1"}); len(got) != 0 {
+			t.Fatalf("MissingTargets() = %v, want none", got)
+		}
+	})
+
+	t.Run("returns targets that match no binary, in order", func(t *testing.T) {
+		t.Parallel()
+		got := MissingTargets(binList, []string{"test4", nameTest2, "test5"})
+		want := []string{"test4", "test5"}
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Fatalf("value is mismatch (-want +got):\n%s", diff)
 		}
 	})
 
-	t.Run("returns an empty slice when nothing matches", func(t *testing.T) {
+	t.Run("returns nothing when no targets are given", func(t *testing.T) {
 		t.Parallel()
-		got := ExtractByTargets(pkgs, []string{"test4"}, func(string) {})
-		if diff := cmp.Diff([]goutil.Package{}, got); diff != "" {
-			t.Fatalf("value is mismatch (-want +got):\n%s", diff)
+		if got := MissingTargets(binList, nil); got != nil {
+			t.Fatalf("MissingTargets() = %v, want nil", got)
 		}
 	})
 
-	t.Run("returns the input unchanged when no targets are given", func(t *testing.T) {
+	// A binary present in $GOBIN but absent from the resolved packages (e.g. its
+	// build info can't be read, or it was not installed by 'go install') must NOT
+	// be reported as missing: it is present, just unmanageable. MissingTargets
+	// keys off the binary paths, so naming such a binary yields no "not found"
+	// entry even though GetPackageInformation would drop it.
+	t.Run("present-but-unmanageable binary is not reported missing", func(t *testing.T) {
 		t.Parallel()
-		got := ExtractByTargets(pkgs, nil, func(string) {})
-		if diff := cmp.Diff(pkgs, got); diff != "" {
-			t.Fatalf("value is mismatch (-want +got):\n%s", diff)
+		bins := []string{filepath.Join("bin", "broken")}
+		if got := MissingTargets(bins, []string{"broken"}); len(got) != 0 {
+			t.Fatalf("MissingTargets() = %v, want none (binary exists on disk)", got)
 		}
 	})
 }
 
-func TestExtractByTargets_warnsOncePerMissingTarget(t *testing.T) {
+func TestMissingTargets_dedupAndTrim(t *testing.T) {
 	t.Parallel()
 
-	pkgs := []goutil.Package{{Name: "present"}}
+	binList := []string{filepath.Join("bin", "present")}
+	got := MissingTargets(binList, []string{" " + nameMissing, nameMissing})
+	want := []string{nameMissing}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("value is mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestWarnMissing(t *testing.T) {
+	t.Parallel()
 
 	var warnings []string
-	got := ExtractByTargets(pkgs, []string{nameMissing, nameMissing}, func(msg string) {
-		warnings = append(warnings, msg)
-	})
-	if len(got) != 0 {
-		t.Fatalf("ExtractByTargets() should return no packages, got: %+v", got)
-	}
+	WarnMissing([]string{nameMissing}, func(msg string) { warnings = append(warnings, msg) })
 
 	want := []string{"not found '" + nameMissing + "' package in $GOPATH/bin or $GOBIN"}
 	if diff := cmp.Diff(want, warnings); diff != "" {
@@ -132,18 +147,20 @@ func TestExtractByTargets_warnsOncePerMissingTarget(t *testing.T) {
 	}
 }
 
-func TestExtractByTargets_windowsCaseInsensitive(t *testing.T) {
+func TestMissingTargets_windowsCaseInsensitive(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS != goosWindows {
 		t.Skip("windows only")
 	}
 
-	pkgs := []goutil.Package{
-		{Name: "gopls.exe"},
-		{Name: "dlv.exe"},
+	binList := []string{
+		filepath.Join("bin", "gopls.exe"),
+		filepath.Join("bin", "dlv.exe"),
 	}
-	got := ExtractByTargets(pkgs, []string{"GOPLS"}, func(string) {})
-	want := []goutil.Package{{Name: "gopls.exe"}}
+	// "GOPLS" matches "gopls.exe" case-insensitively (so it is not missing),
+	// while "MISSING" matches nothing.
+	got := MissingTargets(binList, []string{"GOPLS", "MISSING"})
+	want := []string{"MISSING"}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatalf("value is mismatch (-want +got):\n%s", diff)
 	}
@@ -246,7 +263,7 @@ func TestBinaryPaths(t *testing.T) {
 func TestPackageInfoByTargets_filtersToTarget(t *testing.T) {
 	t.Setenv("GOBIN", filepath.Join("..", "..", "cmd", "testdata", "check_success"))
 
-	pkgs, _, err := PackageInfoByTargets([]string{"gal"})
+	pkgs, missing, _, err := PackageInfoByTargets([]string{"gal"})
 	if err != nil {
 		t.Fatalf("PackageInfoByTargets() error = %v", err)
 	}
@@ -255,5 +272,27 @@ func TestPackageInfoByTargets_filtersToTarget(t *testing.T) {
 	}
 	if pkgs[0].Name != "gal" {
 		t.Fatalf("PackageInfoByTargets() name = %q, want gal", pkgs[0].Name)
+	}
+	if len(missing) != 0 {
+		t.Fatalf("PackageInfoByTargets() missing = %v, want none", missing)
+	}
+}
+
+// A target that names a binary present on disk but whose build info can't be
+// read must not be reported as missing (it exists, just can't be managed). This
+// is the regression for the "not found" mislabeling: check_fail/dummy is a
+// non-Go file, so GetPackageInformation drops it, yet it is present.
+func TestPackageInfoByTargets_presentButUnreadableIsNotMissing(t *testing.T) {
+	t.Setenv("GOBIN", filepath.Join("..", "..", "cmd", "testdata", "check_fail"))
+
+	pkgs, missing, _, err := PackageInfoByTargets([]string{"dummy"})
+	if err != nil {
+		t.Fatalf("PackageInfoByTargets() error = %v", err)
+	}
+	if len(pkgs) != 0 {
+		t.Fatalf("PackageInfoByTargets() returned %d packages, want 0: %+v", len(pkgs), pkgs)
+	}
+	if len(missing) != 0 {
+		t.Fatalf("PackageInfoByTargets() missing = %v, want none (dummy exists on disk)", missing)
 	}
 }

--- a/internal/print/print.go
+++ b/internal/print/print.go
@@ -41,6 +41,14 @@ func Err(err interface{}) {
 		cmdinfo.Name, color.HiYellowString("ERROR"), err)
 }
 
+// Hint print a next-step suggestion at STDERR in cyan. It is used to follow up
+// an error with actionable guidance (e.g. which command to run next) so a
+// failure is not just reported but explained.
+func Hint(msg string) {
+	_, _ = fmt.Fprintf(Stderr, "%s:%s : %v\n",
+		cmdinfo.Name, color.CyanString("HINT"), msg)
+}
+
 // OsExit is wrapper for  os.Exit(). It's for unit test.
 var OsExit = os.Exit //nolint:gochecknoglobals
 

--- a/internal/print/print_test.go
+++ b/internal/print/print_test.go
@@ -167,6 +167,55 @@ func TestErr(t *testing.T) {
 		})
 	}
 }
+func TestHint(t *testing.T) {
+	type args struct {
+		msg string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: testPrintMessage,
+			args: args{
+				msg: testMessage,
+			},
+			want: []string{"gup:HINT : test message", ""},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orgStdout := Stdout
+			orgStderr := Stderr
+			pr, pw, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			Stdout = pw
+			Stderr = pw
+
+			Hint(tt.args.msg)
+			if err := pw.Close(); err != nil {
+				t.Fatal(err)
+			}
+			Stdout = orgStdout
+			Stderr = orgStderr
+
+			buf := bytes.Buffer{}
+			_, err = io.Copy(&buf, pr)
+			if err != nil {
+				t.Error(err)
+			}
+			got := strings.Split(buf.String(), "\n")
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("value is mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestFatal(t *testing.T) {
 	type args struct {
 		msg string


### PR DESCRIPTION
## Why

In the README feature comparison table, the only row where gup honestly answered **No** to a real *feature* (not a deliberate design choice) was **Failure diagnostics / next-step hints** — a capability go-global-update has and gup didn't. gup already holds the Go toolchain's full error output for every failed package (it even has `DetectModulePathMismatch` to auto-follow module renames), so emitting "here's what to try next" is low-cost. Closing the gap is a stronger completeness claim than listing it.

## What

- New `internal/diagnose` package: `Hint(err error) string` classifies common, **recoverable** failure modes and returns a short, actionable next step, or `""` when it can't offer a confident suggestion.
  - Covered: module renames (reuses `goutil.DetectModulePathMismatch`, names the new path), binary not installed via `go install`, missing branch/tag for the chosen channel, unresolvable/renamed/private repository, permission problems, out-of-date Go toolchain, unsupported `GOOS`/`GOARCH`, network/proxy errors.
  - Deliberately silent on timeout/cancel errors, whose messages already name the manual command and `--timeout` remedy — so a hint always adds signal, never noise.
- `print.Hint` renders the suggestion in cyan on **STDERR** (keeps `--json` STDOUT pure).
- Wired into `executePackages`, so both `gup update` and `gup check` surface hints.
- `--json` output gains a per-package `hint` field (`omitempty`).
- README: comparison table row flipped to **Yes**, plus a new "Failure diagnostics / next-step hints" section and the `hint` JSON field documented.

## Real behavior

Verified end-to-end against the real Go toolchain (binary with embedded module info pointing at a non-existent repo):

```
gup:ERROR: [1/1] faketool: can't check github.com/.../faketool:
        ... remote: Repository not found. ...
gup:HINT : The module path could not be resolved. The repository may be private, renamed, or deleted; check the import path and your access/credentials (e.g. GOPRIVATE, SSH/token auth).
```

`--json` mode emits the same suggestion as `"hint": "..."`.

## Tests

- `internal/diagnose`: table-driven coverage of every classified failure mode plus the no-hint cases (nil, timeout, unknown).
- `internal/print`: `TestHint`.
- Full suite green; `golangci-lint` clean on changed packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added actionable “next-step hints” when a package update fails; shown on failure output and included as an optional `hint` field in `--json`.
* **Bug Fixes**
  * `check` no longer mislabels unreadable binaries as “not found.”
  * Missing-target warnings are de-duplicated to avoid repeated notices.
* **Documentation**
  * Updated the `--json` schema/status mapping and documented failure-diagnostics behavior.
* **Tests**
  * Extended unit and end-to-end coverage for hints, failure diagnostics, and “moved module” scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->