### PR TITLE
docs(changelog): prepare v1.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## [v1.6.0](https://github.com/nao1215/gup/compare/v1.5.1...v1.6.0) (2026-06-24)
+
+### Features
+
+* `gup update` and `gup check` now turn the Go toolchain's failure output into a short, actionable next-step hint printed on STDERR right after the error (and exposed as a per-package `hint` field in `--json` output). Hints cover module renames/major-version moves, relocated commands, `go.mod` `replace` directives, binaries not installed via `go install`, missing branch/tag for the selected channel, unresolvable/private/deleted repositories, SSH/auth and network/proxy errors, and an out-of-date Go toolchain. gup stays silent when it has nothing reliable to add (e.g. a timeout, whose message already names the remedy). (#378)
+
+### Bug Fixes
+
+* `gup update` and `gup check` no longer mislabel a binary that exists in `$GOBIN` but whose build info cannot be read (or that was not installed by `go install`) as "not found": such a binary is reported as unreadable, not missing. The "not found" notice is now derived from the installed binary paths rather than the resolved packages. (#378)
+* `gup update` no longer prints two "not found" notices for the same name when it is supplied both as a positional target and in `--main`/`--master`/`--latest`; the duplicate channel-flag notice is suppressed once the name has already been reported. (#378)
+
+### Code Refactoring
+
+* Extract package selection, online-version caching, and the parallel worker pool out of the `cmd/` layer into new reusable `internal/pkgselect`, `internal/vercache`, and `internal/parallel` packages, keeping `cmd/` a thin wiring/output shell. No user-visible behavior change. (#377)
+* Replace the archived `github.com/pkg/errors` dependency with the standard library `errors`/`fmt`. No user-visible behavior change. (#376)
+
+### CI
+
+* Tighten the golangci-lint configuration and modernize the codebase for Go 1.25. (#376)
+
 ## [v1.5.1](https://github.com/nao1215/gup/compare/v1.5.0...v1.5.1) (2026-06-23)
 
 ### Bug Fixes


### PR DESCRIPTION
## Release preparation for v1.6.0

Latest released tag is `v1.5.1`. Since then, three PRs landed on `main`; this PR adds the `CHANGELOG.md` section for the next release. As this introduces a new user-facing feature (failure diagnostics) with no breaking changes, the version is a **minor** bump: **v1.6.0**.

### Included since v1.5.1
- **Features** — `gup update`/`gup check` failure diagnostics / next-step hints, plus the `hint` field in `--json` output (#378).
- **Bug Fixes** — "not found" mislabeling of present-but-unreadable binaries, and duplicate "not found" notices for a name given both as a positional target and a channel flag (#378).
- **Code Refactoring** — extract `internal/pkgselect` / `internal/vercache` / `internal/parallel` (#377); drop the archived `github.com/pkg/errors` (#376).
- **CI** — tighten golangci-lint and modernize for Go 1.25 (#376).

### Release process (after merge)
Pushing the `v1.6.0` tag triggers `.github/workflows/release.yml` (GoReleaser: artifacts, checksums, cosign signing, SBOM, provenance, Homebrew tap).

No code or version-string changes — the version is injected via ldflags/build info, so only the changelog needs updating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved error messages for `gup update` and `gup check` commands with actionable hints and JSON output support

* **Bug Fixes**
  * Fixed binary status reporting to correctly distinguish between "not found" and "unreadable" states
  * Eliminated duplicate error notices

* **Chores**
  * Updated build configuration and modernized language runtime support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->