### PR TITLE
test(diagnose): pin toolchain message strings to catch wording-drift regressions

### DIFF
--- a/internal/diagnose/diagnose.go
+++ b/internal/diagnose/diagnose.go
@@ -17,23 +17,35 @@ import (
 	"github.com/nao1215/gup/internal/goutil"
 )
 
-// matcher pairs a predicate over the lower-cased error text with the hint to
-// emit when it matches. The first matching entry in matchers wins, so entries
-// are ordered most-specific first.
+// matcher maps a recognizable failure mode to the hint to emit. A matcher fires
+// when any of its needles is a substring of the lower-cased error text, or when
+// its match predicate (used for non-literal cases like regexes) returns true.
+// The first matching entry in matchers wins, so entries are ordered
+// most-specific first.
+//
+// needles are kept as data (rather than hidden inside a closure) so a test can
+// assert every literal needle is still present in a real Go toolchain message:
+// the toolchain's English wording is an external contract that a Go release can
+// change, silently breaking these matchers, and that test turns such a drift
+// into a visible regression. needles must be lower-case because they are matched
+// against the lower-cased error text (TestMatcherNeedlesAreLowercase guards it).
 type matcher struct {
-	match func(lower string) bool
-	hint  string
+	needles []string
+	match   func(lower string) bool
+	hint    string
 }
 
-func contains(needles ...string) func(string) bool {
-	return func(lower string) bool {
-		for _, n := range needles {
-			if strings.Contains(lower, n) {
-				return true
-			}
+// matches reports whether the matcher fires for the lower-cased error text.
+func (m matcher) matches(lower string) bool {
+	for _, n := range m.needles {
+		if strings.Contains(lower, n) {
+			return true
 		}
-		return false
 	}
+	if m.match != nil {
+		return m.match(lower)
+	}
+	return false
 }
 
 // goToolchainRegex matches the toolchain-too-old diagnostic, e.g.
@@ -44,8 +56,8 @@ var goToolchainRegex = regexp.MustCompile(`requires go ?>?=? ?\d`)
 // they win over the broader network/permission fallbacks.
 var matchers = []matcher{ //nolint:gochecknoglobals
 	{
-		match: contains("is not installed by 'go install'"),
-		hint:  "This binary has no embedded module path. Reinstall it once with `go install <importpath>@latest` so gup can manage it, then run gup again.",
+		needles: []string{"is not installed by 'go install'"},
+		hint:    "This binary has no embedded module path. Reinstall it once with `go install <importpath>@latest` so gup can manage it, then run gup again.",
 	},
 	{
 		// "module ... found (vX), but does not contain package ..." is what the
@@ -53,41 +65,41 @@ var matchers = []matcher{ //nolint:gochecknoglobals
 		// the module at the resolved version. The common cause is a major-version
 		// bump: the tool moved to a /v2+ module path, so the old import path is
 		// gone even though the v0/v1 line still resolves.
-		match: contains("does not contain package", "no required module provides package"),
-		hint:  "The module no longer provides this command at its import path. The project likely relocated the command (a separate repo/module) or bumped to a new major version (e.g. a `/v2` module path); check its current install instructions and reinstall with the new path.",
+		needles: []string{"does not contain package", "no required module provides package"},
+		hint:    "The module no longer provides this command at its import path. The project likely relocated the command (a separate repo/module) or bumped to a new major version (e.g. a `/v2` module path); check its current install instructions and reinstall with the new path.",
 	},
 	{
 		// `go install` refuses modules whose go.mod carries replace directives.
-		match: contains("replace directives", "replace directive"),
-		hint:  "This module's go.mod uses `replace` directives, which `go install` cannot build. Ask the maintainer to drop them, or clone the repository and run `go install` inside it (gup will then treat the binary as built-from-source and skip it).",
+		needles: []string{"replace directives", "replace directive"},
+		hint:    "This module's go.mod uses `replace` directives, which `go install` cannot build. Ask the maintainer to drop them, or clone the repository and run `go install` inside it (gup will then treat the binary as built-from-source and skip it).",
 	},
 	{
-		match: contains("devel-binary copied from local environment", "command-line-arguments"),
-		hint:  "This binary was built from a local checkout (devel) and has no published module. Reinstall it from its upstream repository with `go install <importpath>@latest`.",
+		needles: []string{"devel-binary copied from local environment", "command-line-arguments"},
+		hint:    "This binary was built from a local checkout (devel) and has no published module. Reinstall it from its upstream repository with `go install <importpath>@latest`.",
 	},
 	{
 		match: func(lower string) bool { return goToolchainRegex.MatchString(lower) },
 		hint:  "This module requires a newer Go toolchain. Upgrade Go, or set `GOTOOLCHAIN=auto` so the go command fetches the required version automatically.",
 	},
 	{
-		match: contains("build constraints exclude all go files"),
-		hint:  "The package has no Go files buildable for your platform (see `go env GOOS GOARCH`); this version may not support your OS/architecture.",
+		needles: []string{"build constraints exclude all go files"},
+		hint:    "The package has no Go files buildable for your platform (see `go env GOOS GOARCH`); this version may not support your OS/architecture.",
 	},
 	{
-		match: contains("no matching versions for query"),
-		hint:  "No published version matches the selected channel. Try another channel (e.g. `--main` or `--master`), or confirm the repository has tagged releases.",
+		needles: []string{"no matching versions for query"},
+		hint:    "No published version matches the selected channel. Try another channel (e.g. `--main` or `--master`), or confirm the repository has tagged releases.",
 	},
 	{
-		match: contains("unknown revision", "invalid version", "unknown branch"),
-		hint:  "The requested branch, tag, or version does not exist. Verify the channel (main vs master) or the version selector for this package.",
+		needles: []string{"unknown revision", "invalid version", "unknown branch"},
+		hint:    "The requested branch, tag, or version does not exist. Verify the channel (main vs master) or the version selector for this package.",
 	},
 	{
 		// Repository/auth failures are matched before the generic "permission
 		// denied" case below so an SSH auth error ("permission denied
 		// (publickey)") is diagnosed as an access problem, not local write
 		// permission.
-		match: contains("unrecognized import path", "repository not found", "404 not found", "410 gone",
-			"terminal prompts disabled", "permission denied (publickey)", "could not read from remote repository"),
+		needles: []string{"unrecognized import path", "repository not found", "404 not found", "410 gone",
+			"terminal prompts disabled", "permission denied (publickey)", "could not read from remote repository"},
 		hint: "The module path could not be resolved. The repository may be private, renamed, or deleted; check the import path and your access/credentials (e.g. GOPRIVATE, SSH/token auth).",
 	},
 	{
@@ -100,8 +112,8 @@ var matchers = []matcher{ //nolint:gochecknoglobals
 		hint: "Permission denied while installing. Check write access to your install directory (`go env GOBIN` / `go env GOPATH`) and the module cache.",
 	},
 	{
-		match: contains("dial tcp", "i/o timeout", "connection refused", "tls handshake", "proxyconnect", "no such host", "network is unreachable", "could not connect"),
-		hint:  "Network error reaching the module proxy or repository. Check your connection and the GOPROXY setting (`go env GOPROXY`).",
+		needles: []string{"dial tcp", "i/o timeout", "connection refused", "tls handshake", "proxyconnect", "no such host", "network is unreachable", "could not connect"},
+		hint:    "Network error reaching the module proxy or repository. Check your connection and the GOPROXY setting (`go env GOPROXY`).",
 	},
 }
 
@@ -136,7 +148,7 @@ func Hint(err error) string {
 	}
 
 	for _, m := range matchers {
-		if m.match(lower) {
+		if m.matches(lower) {
 			return m.hint
 		}
 	}

--- a/internal/diagnose/diagnose_test.go
+++ b/internal/diagnose/diagnose_test.go
@@ -10,15 +10,25 @@ import (
 // shared by several cases that funnel to it.
 const subResolved = "could not be resolved"
 
-func TestHint(t *testing.T) {
-	t.Parallel()
+// subNetwork is the distinctive fragment of the network-error hint, shared by
+// the several real proxy/transport wordings that funnel to it.
+const subNetwork = "Network error"
 
-	tests := []struct {
-		name     string
-		err      error
-		wantSub  string // substring the hint must contain ("" means expect no hint)
-		wantNone bool
-	}{
+type hintCase struct {
+	name     string
+	err      error
+	wantSub  string // substring the hint must contain ("" means expect no hint)
+	wantNone bool
+}
+
+// hintTestCases is the single source of truth for the diagnose fixtures. The
+// error strings are real Go toolchain / git / net output (see the per-case
+// comments), so they double as a regression anchor: the toolchain's English
+// wording is an external contract a Go release can change, and pinning the real
+// strings here turns such a drift into a visible test failure
+// (see TestEveryMatcherFiresOnARealFixture).
+func hintTestCases() []hintCase {
+	return []hintCase{
 		{
 			name:     "nil error has no hint",
 			err:      nil,
@@ -44,6 +54,15 @@ func TestHint(t *testing.T) {
 			wantSub: "new major version",
 		},
 		{
+			// Verified against real output of building a module-less import path,
+			// e.g. `go install example.com/no/such/pkg@latest` in module mode:
+			//   go: example.com/no/such/pkg@latest: no required module provides
+			//   package example.com/no/such/pkg; to add it: ...
+			name:    "no required module provides package",
+			err:     errors.New("go: example.com/no/such/pkg@latest: no required module provides package example.com/no/such/pkg; to add it:\n\tgo get example.com/no/such/pkg"),
+			wantSub: "new major version",
+		},
+		{
 			name:    "not installed by go install",
 			err:     errors.New("foo is not installed by 'go install' (or permission incorrect)"),
 			wantSub: "go install <importpath>@latest",
@@ -51,6 +70,14 @@ func TestHint(t *testing.T) {
 		{
 			name:    "devel binary",
 			err:     errors.New("is devel-binary copied from local environment"),
+			wantSub: "local checkout",
+		},
+		{
+			// Verified against real output of `go install .` from a directory that
+			// is not a main package / has no install location: the go command names
+			// the synthetic "command-line-arguments" pseudo-package.
+			name:    "command-line-arguments has no install location",
+			err:     errors.New("go: no install location for directory /tmp/x outside GOPATH\n\tFor more details see: 'go help gopath'\ncommand-line-arguments"),
 			wantSub: "local checkout",
 		},
 		{
@@ -87,6 +114,15 @@ func TestHint(t *testing.T) {
 			wantSub: subResolved,
 		},
 		{
+			// Verified against real output of a private/HTTPS repo with no
+			// credentials in a non-interactive shell:
+			//   fatal: could not read Username for 'https://github.com': terminal
+			//   prompts disabled
+			name:    "terminal prompts disabled is an access problem",
+			err:     errors.New("go: github.com/x/private@latest: git ls-remote -q origin in /cache: exit status 128:\n\tfatal: could not read Username for 'https://github.com': terminal prompts disabled"),
+			wantSub: subResolved,
+		},
+		{
 			name:    "no matching versions",
 			err:     errors.New(`go: github.com/x@latest: no matching versions for query "latest"`),
 			wantSub: "another channel",
@@ -106,6 +142,13 @@ func TestHint(t *testing.T) {
 			wantSub: subResolved,
 		},
 		{
+			// A module proxy returns 410 Gone for a path it once served but no
+			// longer does (e.g. a retracted/removed module).
+			name:    "proxy 410 gone",
+			err:     errors.New("go: github.com/x/gone@latest: reading https://proxy.golang.org/github.com/x/gone/@latest: 410 Gone"),
+			wantSub: subResolved,
+		},
+		{
 			// Verified against real output of:
 			//   go list -m github.com/nao1215/<deleted>@latest  (direct git fallback)
 			name:    "deleted or private repository",
@@ -115,7 +158,45 @@ func TestHint(t *testing.T) {
 		{
 			name:    "network dial error",
 			err:     errors.New("can't check x:\ndial tcp: lookup proxy.golang.org: no such host"),
-			wantSub: "Network error",
+			wantSub: subNetwork,
+		},
+		{
+			// Real net wording: a TCP connect that times out.
+			name:    "network i/o timeout",
+			err:     errors.New("can't check x:\ndial tcp 142.250.72.17:443: i/o timeout"),
+			wantSub: subNetwork,
+		},
+		{
+			// Real net wording: the proxy host actively refuses the connection.
+			name:    "network connection refused",
+			err:     errors.New("can't check x:\ndial tcp 127.0.0.1:443: connect: connection refused"),
+			wantSub: subNetwork,
+		},
+		{
+			// Real net/http wording: TLS negotiation stalls.
+			name:    "network tls handshake timeout",
+			err:     errors.New("can't check x:\nGet \"https://proxy.golang.org/...\": net/http: TLS handshake timeout"),
+			wantSub: subNetwork,
+		},
+		{
+			// Real net wording when GOPROXY points at an unreachable HTTP proxy.
+			// (Kept free of "timed out" wording, which Hint treats as an
+			// already-actionable timeout and intentionally leaves unhinted.)
+			name:    "network proxyconnect",
+			err:     errors.New("can't check x:\nGet \"https://proxy.golang.org/...\": proxyconnect tcp: dial tcp 10.0.0.1:8080: connect: connection refused"),
+			wantSub: subNetwork,
+		},
+		{
+			// Real net wording: no route to the proxy host.
+			name:    "network unreachable",
+			err:     errors.New("can't check x:\ndial tcp 142.250.72.17:443: connect: network is unreachable"),
+			wantSub: subNetwork,
+		},
+		{
+			// Real git wording surfaced through the go command's direct fallback.
+			name:    "network could not connect (git)",
+			err:     errors.New("go: github.com/x@latest: git ls-remote -q origin in /cache: exit status 128:\n\tfatal: unable to access 'https://github.com/x/': Could not connect to server"),
+			wantSub: subNetwork,
 		},
 		{
 			name:     "timeout already actionable, no hint",
@@ -128,13 +209,24 @@ func TestHint(t *testing.T) {
 			wantNone: true,
 		},
 		{
+			// context.DeadlineExceeded renders as "context deadline exceeded"; that
+			// path already carries its own remedy, so no hint is added.
+			name:     "deadline exceeded, no hint",
+			err:      errors.New("version check of x canceled: context deadline exceeded"),
+			wantNone: true,
+		},
+		{
 			name:     "unrecognized failure, no hint",
 			err:      errors.New("some entirely unexpected failure"),
 			wantNone: true,
 		},
 	}
+}
 
-	for _, tt := range tests {
+func TestHint(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range hintTestCases() {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := Hint(tt.err)
@@ -151,5 +243,46 @@ func TestHint(t *testing.T) {
 				t.Errorf("Hint() = %q, want substring %q", got, tt.wantSub)
 			}
 		})
+	}
+}
+
+// TestEveryMatcherFiresOnARealFixture guarantees every matcher's hint is
+// produced by at least one real-message fixture in hintTestCases(). This is the
+// regression anchor for toolchain-wording drift: if a Go release reworks the
+// message a matcher keys on, that matcher's fixture stops firing, its hint
+// disappears from the produced set, and this test fails — instead of the matcher
+// silently going dead in production. It also fails if a new matcher is added
+// without a backing real-message fixture.
+func TestEveryMatcherFiresOnARealFixture(t *testing.T) {
+	t.Parallel()
+
+	produced := make(map[string]bool)
+	for _, tt := range hintTestCases() {
+		if h := Hint(tt.err); h != "" {
+			produced[h] = true
+		}
+	}
+
+	for i, m := range matchers {
+		if !produced[m.hint] {
+			t.Errorf("matchers[%d] hint is never produced by any fixture in hintTestCases(); "+
+				"add a fixture with the current real Go/git wording so a future change is caught.\nhint: %q",
+				i, m.hint)
+		}
+	}
+}
+
+// TestMatcherNeedlesAreLowercase guards the invariant that needles are matched
+// against the lower-cased error text, so an upper-case needle would be dead code
+// that never fires.
+func TestMatcherNeedlesAreLowercase(t *testing.T) {
+	t.Parallel()
+
+	for i, m := range matchers {
+		for _, n := range m.needles {
+			if n != strings.ToLower(n) {
+				t.Errorf("matchers[%d] needle %q is not lower-case; it can never match the lower-cased error text", i, n)
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary

`diagnose.Hint` recognizes failure modes by substring-matching the Go toolchain's English output, and `goutil.DetectModulePathMismatch` parses it with regexes. This is the only practical approach and the code is deliberately conservative, but the toolchain's wording is an external contract: a Go release can reword a message and silently kill a matcher with no test noise. This PR hardens the diagnose regression net so such a drift becomes a visible test failure, without changing any runtime behavior.

## Changes

- `internal/diagnose/diagnose.go`: make each matcher's literal substrings explicit data (a `needles []string` field) instead of hiding them inside a `contains(...)` closure, and add a `matcher.matches` method. The regex/custom matchers keep their `match` predicate. Behavior is identical (verified by the existing `TestHint` table); the point is that the needles are now introspectable by tests.
- `internal/diagnose/diagnose_test.go`:
  - Extract the fixture table into `hintTestCases()` as a single source of truth.
  - Add `TestEveryMatcherFiresOnARealFixture`: asserts every matcher's hint is produced by at least one real-message fixture. If a Go release reworks a message a matcher keys on, that fixture stops firing and the test fails instead of the matcher going dead in production; it also fails when a new matcher is added without a backing fixture.
  - Add `TestMatcherNeedlesAreLowercase`: guards that needles can actually match the lower-cased error text (an upper-case needle would be dead code).
  - Fill the real-message gaps the audit surfaced: `no required module provides package`, `command-line-arguments`, proxy `410 Gone`, `terminal prompts disabled`, and the real `net`/`net/http`/git network wordings (`i/o timeout`, `connection refused`, `TLS handshake timeout`, `proxyconnect`, `network is unreachable`, `Could not connect`), plus a `context deadline exceeded` no-hint case.

## Design Decisions

The needles-as-data change is the minimum needed to let a test assert coverage; the matching order and semantics are untouched. The coverage guard keys on the produced hint (per matcher) rather than fabricating a separate "real" message for every synonym needle, because inventing toolchain text gup has never actually seen would defeat the purpose — the fixtures are only useful as a regression anchor while they stay real. The audit also confirmed `goutil.DetectModulePathMismatch` is already pinned to real `module declares its path as:` / `but was required as:` output by `TestDetectModulePathMismatch`, so no change was needed there.

On the `fmt.Errorf` without `%w` note: the relevant call sites (e.g. `InstallWithContext`, `GetVerWithContext`) format subprocess **stderr text**, not a wrapped Go error value, so there is no error chain to preserve and `%w` does not apply today. Converting toward `errors.Is`/`As` would only matter if diagnosis moved from string matching to typed errors — out of scope here and left as a future inventory item, as suggested.

Verified green: `gofmt -l`, `go vet`, `golangci-lint run ./internal/diagnose/` (0 issues), and `go test ./...`. The guard was sanity-checked by temporarily dropping a fixture and confirming `TestEveryMatcherFiresOnARealFixture` fails.