### PR TITLE
release: v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## [v1.7.0](https://github.com/nao1215/gup/compare/v1.6.0...v1.7.0) (2026-06-25)
+
+### Features
+
+* Add version pinning. `gup pin <tool> <version>` (also `gup pin <tool>@<version>`) records a tool in `gup.json` under a new `pinned` channel with a concrete version, and `gup unpin <tool>` clears it. `gup update` installs a pinned tool at its exact version with `go install <import_path>@<version>` (never `@latest`), keeps it there, and reinstalls it only when the installed version differs or the Go toolchain changed (suppressible with `--ignore-go-update`), while unpinned tools still update in parallel. `gup check` reports `pinned`/`pin-mismatch` without querying `@latest`, and `--json` gains a `pinned_version` field and the `pinned`/`pin-mismatch` statuses. Pinned state is preserved across `export`/`import`. (#384)
+
+### Bug Fixes
+
+* `gup.json` now uses `schema_version` `2` only when a package is pinned and otherwise stays at `1`, so older gup releases keep reading pin-free configs; channels are parsed strictly so an unknown channel, a `pinned` entry without a concrete version, or `channel: "pinned"` under `schema_version: 1` fails fast instead of being silently downgraded to `@latest`. (#384)
+
+### Code Refactoring
+
+* Split the `internal/goutil` monolith into concern-focused files and reuse `internal/parallel.Run` for package-information collection. No user-visible behavior change. (#380)
+* Consolidate the `update`/`check` flag parsing into `parseUpdateFlags`/`parseCheckFlags` so a flag error is handled in one place. No user-visible behavior change. (#381)
+
+### Docs
+
+* Refresh the README introduction and structure, rewrite `SECURITY.md` to fit gup, split the `go tool` comparison into its own section, fold the benchmark result into the feature-comparison table, and mirror the version-pinning documentation across all translated READMEs. (#383, #384)
+
+### CI
+
+* Pin GitHub Actions to commit SHAs, disable persisted checkout credentials, and cache the release smoke build. (#383)
+
 ## [v1.6.0](https://github.com/nao1215/gup/compare/v1.5.1...v1.6.0) (2026-06-24)
 
 ### Features


### PR DESCRIPTION
## Release v1.7.0

Prepares the v1.7.0 release by adding its `CHANGELOG.md` entry. Tagging `v1.7.0` after merge triggers the GoReleaser release workflow.

### Highlights since v1.6.0

- **Version pinning / lock (#384)** — `gup pin <tool> <version>` / `gup unpin <tool>`. A pinned tool is installed at its exact recorded version (`go install <import_path>@<version>`, never `@latest`), stored in `gup.json` under a new `pinned` channel (`schema_version: 2`). `gup update` keeps it pinned (reinstalling only on a version difference or a Go-toolchain change, suppressible with `--ignore-go-update`); `gup check` reports `pinned`/`pin-mismatch`; `--json` adds `pinned_version` and the new statuses; pins survive `export`/`import`. Strict config parsing means an unknown channel or an invalid/v1 pin fails fast instead of degrading to `@latest`.
- **Refactors (#380, #381)** — split the `internal/goutil` monolith and consolidate `update`/`check` flag parsing. No user-visible change.
- **Docs (#383, #384)** — README refresh, `SECURITY.md` rewrite, `go tool` section split, benchmark folded into the feature table, and version-pinning mirrored across all translated READMEs.
- **CI (#383)** — pin Actions to SHAs, disable persisted checkout credentials, cache the release smoke build.

### After merge
Tag and push `v1.7.0` on `main` to trigger the release.
