### PR TITLE
refactor(cmd): shared result renderer + dependency injection for update/check

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -132,7 +132,7 @@ func doCheckJSON(pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreG
 }
 
 func doCheckWith(pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpdate, quiet, jsonOut bool) int {
-	verCache := newVerCache()
+	verCache := defaultDependencies().newVerCache()
 
 	if !jsonOut && !quiet {
 		print.Info("check binary under $GOPATH/bin or $GOBIN")

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -185,17 +185,12 @@ func doCheckWith(pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreG
 
 	var onResult func(prefix string, v updateResult)
 	if !jsonOut {
-		onResult = func(prefix string, v updateResult) {
-			if quiet {
-				// In quiet mode show only binaries with an available update,
-				// without the [i/n] progress counter (which would be sparse).
-				if v.status == statusUpdateAvailable || v.status == statusPinMismatch {
-					print.Info(fmt.Sprintf("%s (%s)", v.pkg.ImportPath, checkResultStr(v.pkg)))
-				}
-				return
-			}
-			print.Info(fmt.Sprintf("%s %s (%s)", prefix, v.pkg.ImportPath, checkResultStr(v.pkg)))
-		}
+		// In quiet mode show only binaries with an available update.
+		onResult = resultLineRenderer(quiet,
+			func(v updateResult) bool {
+				return v.status == statusUpdateAvailable || v.status == statusPinMismatch
+			},
+			checkResultStr)
 	}
 
 	result, results := executePackages(pkgs, cpus, timeout, checker, onResult)

--- a/cmd/dependencies.go
+++ b/cmd/dependencies.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/nao1215/gup/internal/vercache"
+)
+
+// dependencies bundles the go-toolchain operations the update and check flows
+// rely on: the online version lookups and the per-channel install variants.
+//
+// Threading these through the operation flow as a value (rather than reading
+// package-level globals deep inside the business logic) lets the runner take its
+// I/O-bound collaborators explicitly, and lets a test inject fakes by building a
+// dependencies value instead of mutating shared globals. The package-level seam
+// variables remain as the single default wiring (defaultDependencies) so the
+// existing suite keeps working; new tests can inject directly and run in
+// parallel.
+type dependencies struct {
+	getLatestVer        func(ctx context.Context, modulePath string) (string, error)
+	getVerByRef         func(ctx context.Context, modulePath, ref string) (string, error)
+	installLatest       func(ctx context.Context, importPath string) error
+	installMainOrMaster func(ctx context.Context, importPath string) error
+	installByVersion    func(ctx context.Context, importPath, version string) error
+}
+
+// defaultDependencies wires the operation seams used in production. It is the one
+// place that reads the package-level lookup/install variables, so the business
+// logic (newVerCache, updatePinned, installWithSelectedVersion) depends only on
+// the injected value.
+func defaultDependencies() dependencies {
+	return dependencies{
+		getLatestVer:        getLatestVerCtx,
+		getVerByRef:         getVerByRefCtx,
+		installLatest:       installLatestCtx,
+		installMainOrMaster: installMainOrMasterCtx,
+		installByVersion:    installByVersionUpdCtx,
+	}
+}
+
+// newVerCache builds the per-(module,channel) version cache used by update and
+// check, wiring the injected lookup operations into vercache's channel policy.
+// The seams are read through the injected funcs so a test that supplies its own
+// dependencies controls the resolved versions without touching globals.
+func (d dependencies) newVerCache() *vercache.Cache {
+	return vercache.New(vercache.ChannelResolver(
+		func(ctx context.Context, modulePath string) (string, error) {
+			return d.getLatestVer(ctx, modulePath)
+		},
+		func(ctx context.Context, modulePath, ref string) (string, error) {
+			return d.getVerByRef(ctx, modulePath, ref)
+		},
+	))
+}

--- a/cmd/parallel.go
+++ b/cmd/parallel.go
@@ -53,6 +53,25 @@ func summarizeResults(results []updateResult, isCheck bool) string {
 	return fmt.Sprintf("gup: %d updated, %d up-to-date, %d failed", updated, upToDate, failed)
 }
 
+// resultLineRenderer builds the per-package progress callback shared by update
+// and check. The two commands differ only in two ways, captured as parameters:
+// which results are worth showing in --quiet mode (showInQuiet) and how a
+// package's state is described (resultStr). In quiet mode only the lines passing
+// showInQuiet are printed, without the "[i/n]" counter (which would be sparse);
+// otherwise every line is printed with the counter. The returned callback is
+// passed to executePackages as onResult.
+func resultLineRenderer(quiet bool, showInQuiet func(updateResult) bool, resultStr func(goutil.Package) string) func(string, updateResult) {
+	return func(prefix string, v updateResult) {
+		if quiet {
+			if showInQuiet(v) {
+				print.Info(fmt.Sprintf("%s (%s)", v.pkg.ImportPath, resultStr(v.pkg)))
+			}
+			return
+		}
+		print.Info(fmt.Sprintf("%s %s (%s)", prefix, v.pkg.ImportPath, resultStr(v.pkg)))
+	}
+}
+
 // executePackages runs worker over each package with signal-based cancellation
 // and a per-package timeout, returning the exit code (1 if any package failed)
 // and the per-package results in the original input order. It is the thin

--- a/cmd/pinned_update_test.go
+++ b/cmd/pinned_update_test.go
@@ -49,7 +49,7 @@ func TestUpdatePinned_reinstallsAtPinWhenDifferent(t *testing.T) {
 	}()
 
 	p := pinnedTestPkg("v1.1.0", testVersionOne)
-	res := updatePinned(t.Context(), p, false)
+	res := updatePinned(defaultDependencies(), t.Context(), p, false)
 	if !called {
 		t.Fatal("expected go install <path>@<pinned> to be called")
 	}
@@ -70,7 +70,7 @@ func TestUpdatePinned_skipsWhenAlreadyAtPin(t *testing.T) {
 	defer func() { installByVersionUpd = goutil.Install }()
 
 	p := pinnedTestPkg(testVersionOne, testVersionOne)
-	res := updatePinned(t.Context(), p, false)
+	res := updatePinned(defaultDependencies(), t.Context(), p, false)
 	if res.updated {
 		t.Error("updated = true, want false when already at the pin")
 	}
@@ -91,7 +91,7 @@ func TestUpdatePinned_emptyPinIsError(t *testing.T) {
 	defer func() { installByVersionUpd = goutil.Install }()
 
 	p := pinnedTestPkg("v1.0.0", "")
-	res := updatePinned(t.Context(), p, false)
+	res := updatePinned(defaultDependencies(), t.Context(), p, false)
 	if res.err == nil {
 		t.Fatal("expected an error for a pin with no recorded version, never a silent @latest")
 	}
@@ -145,7 +145,7 @@ func TestUpdatePinned_reinstallsWhenGoOutdated(t *testing.T) {
 	defer func() { installByVersionUpd = goutil.Install }()
 
 	// Version already matches the pin, only the Go toolchain is newer.
-	res := updatePinned(t.Context(), pinnedStaleGo(), false)
+	res := updatePinned(defaultDependencies(), t.Context(), pinnedStaleGo(), false)
 	if !called {
 		t.Fatal("expected a reinstall at the pinned version when the Go toolchain is newer")
 	}
@@ -165,7 +165,7 @@ func TestUpdatePinned_ignoreGoUpdateKeepsPin(t *testing.T) {
 	}
 	defer func() { installByVersionUpd = goutil.Install }()
 
-	res := updatePinned(t.Context(), pinnedStaleGo(), true)
+	res := updatePinned(defaultDependencies(), t.Context(), pinnedStaleGo(), true)
 	if res.updated || res.status != statusPinned {
 		t.Errorf("result updated=%v status=%q, want kept/pinned", res.updated, res.status)
 	}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -377,17 +377,10 @@ func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus i
 
 	var onResult func(prefix string, v updateResult)
 	if !jsonOut {
-		onResult = func(prefix string, v updateResult) {
-			if quiet {
-				// In quiet mode show only binaries that were actually updated,
-				// without the [i/n] progress counter (which would be sparse).
-				if v.updated {
-					print.Info(fmt.Sprintf("%s (%s)", v.pkg.ImportPath, updateResultStr(v.pkg)))
-				}
-				return
-			}
-			print.Info(fmt.Sprintf("%s %s (%s)", prefix, v.pkg.ImportPath, updateResultStr(v.pkg)))
-		}
+		// In quiet mode show only binaries that were actually updated.
+		onResult = resultLineRenderer(quiet,
+			func(v updateResult) bool { return v.updated },
+			updateResultStr)
 	}
 
 	// update all packages

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -16,7 +16,6 @@ import (
 	"github.com/nao1215/gup/internal/notify"
 	"github.com/nao1215/gup/internal/pkgselect"
 	"github.com/nao1215/gup/internal/print"
-	"github.com/nao1215/gup/internal/vercache"
 	"github.com/spf13/cobra"
 )
 
@@ -29,21 +28,6 @@ var (
 )
 
 const latestKeyword = "latest"
-
-// newVerCache builds the per-(module,channel) version cache used by update and
-// check, wiring the package-level lookup seams into vercache's channel policy.
-// The seams are read at call time (via closures) so tests that swap them before
-// invoking a command still take effect.
-func newVerCache() *vercache.Cache {
-	return vercache.New(vercache.ChannelResolver(
-		func(ctx context.Context, modulePath string) (string, error) {
-			return getLatestVerCtx(ctx, modulePath)
-		},
-		func(ctx context.Context, modulePath, ref string) (string, error) {
-			return getVerByRefCtx(ctx, modulePath, ref)
-		},
-	))
-}
 
 func newUpdateCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -244,7 +228,8 @@ type updateResult struct {
 func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus int, ignoreGoUpdate bool, channelMap map[string]goutil.UpdateChannel, pinnedMap map[string]string, timeout time.Duration, jsonOut, quiet bool) (exitCode int, succeeded []goutil.Package, renamed map[string]string) {
 	dryRunManager := goutil.NewGoPaths()
 
-	verCache := newVerCache()
+	deps := defaultDependencies()
+	verCache := deps.newVerCache()
 
 	if !jsonOut && !quiet {
 		print.Info("update binary under $GOPATH/bin or $GOBIN")
@@ -280,7 +265,7 @@ func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus i
 		// the channel-version lookup below.
 		if channel == goutil.UpdateChannelPinned {
 			p.PinnedVersion = pinnedMap[p.Name]
-			return updatePinned(ctx, p, ignoreGoUpdate)
+			return updatePinned(deps, ctx, p, ignoreGoUpdate)
 		}
 
 		// Collect online channel version if possible; else always update
@@ -330,14 +315,14 @@ func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus i
 		if p.ImportPath == "" {
 			updateErr = fmt.Errorf("%s is not installed by 'go install' (or permission incorrect)", p.Name)
 		} else {
-			if err := installWithSelectedVersion(ctx, p.ImportPath, channel); err != nil {
+			if err := installWithSelectedVersion(deps, ctx, p.ImportPath, channel); err != nil {
 				newPkg, changed := resolveModulePathChange(p, err)
 				if !changed {
 					updateErr = fmt.Errorf("%s: %w", p.Name, err)
 				} else {
 					installedViaRetry = true
 					p = newPkg
-					if retryErr := installWithSelectedVersion(ctx, p.ImportPath, channel); retryErr != nil {
+					if retryErr := installWithSelectedVersion(deps, ctx, p.ImportPath, channel); retryErr != nil {
 						updateErr = fmt.Errorf("%s: %w", originalName, retryErr)
 					} else {
 						newName := binaryNameFromImportPath(p.ImportPath)
@@ -449,7 +434,7 @@ func updateResultStr(p goutil.Package) string {
 // reinstalled at the pinned version (which may be a downgrade). On dry-run the
 // install runs into the throwaway GOBIN like every other update, so the
 // kept/reinstalled outcome is still shown.
-func updatePinned(ctx context.Context, p goutil.Package, ignoreGoUpdate bool) updateResult {
+func updatePinned(deps dependencies, ctx context.Context, p goutil.Package, ignoreGoUpdate bool) updateResult {
 	pinnedVer := strings.TrimSpace(p.PinnedVersion)
 	if pinnedVer == "" {
 		// Defensive: a pinned channel without a target should be impossible because
@@ -492,7 +477,7 @@ func updatePinned(ctx context.Context, p goutil.Package, ignoreGoUpdate bool) up
 		}
 	}
 
-	if err := installByVersionUpdCtx(ctx, p.ImportPath, pinnedVer); err != nil {
+	if err := deps.installByVersion(ctx, p.ImportPath, pinnedVer); err != nil {
 		return updateResult{
 			updated: false,
 			pkg:     p,
@@ -514,20 +499,20 @@ func updatePinned(ctx context.Context, p goutil.Package, ignoreGoUpdate bool) up
 	}
 }
 
-func installWithSelectedVersion(ctx context.Context, importPath string, channel goutil.UpdateChannel) error {
+func installWithSelectedVersion(deps dependencies, ctx context.Context, importPath string, channel goutil.UpdateChannel) error {
 	switch goutil.NormalizeUpdateChannel(string(channel)) {
 	case goutil.UpdateChannelLatest:
-		return installLatestCtx(ctx, importPath)
+		return deps.installLatest(ctx, importPath)
 	case goutil.UpdateChannelMain:
-		return installMainOrMasterCtx(ctx, importPath)
+		return deps.installMainOrMaster(ctx, importPath)
 	case goutil.UpdateChannelMaster:
-		return installByVersionUpdCtx(ctx, importPath, "master")
+		return deps.installByVersion(ctx, importPath, "master")
 	case goutil.UpdateChannelPinned:
 		// Pinned packages are installed via updatePinned, never here; never silently
 		// degrade a pin to @latest.
 		return fmt.Errorf("pinned package %s must be installed at its recorded version, not via channel install", importPath)
 	default:
-		return installLatestCtx(ctx, importPath)
+		return deps.installLatest(ctx, importPath)
 	}
 }
 

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -746,19 +746,16 @@ func modulePathMismatchErr(requiredPath, declaredPath string) error {
 }
 
 func Test_installWithSelectedVersion(t *testing.T) {
-	origInstallLatest := installLatest
-	origInstallMain := installMainOrMaster
-	origInstallByVersionUpd := installByVersionUpd
-	defer func() {
-		installLatest = origInstallLatest
-		installMainOrMaster = origInstallMain
-		installByVersionUpd = origInstallByVersionUpd
-	}()
+	t.Parallel()
 
+	// Inject the install operations directly instead of mutating package
+	// globals, so this test owns its dependencies and runs in parallel.
 	var called string
-	installLatest = func(string) error { called = latestKeyword; return nil }
-	installMainOrMaster = func(string) error { called = "main"; return nil }
-	installByVersionUpd = func(_, v string) error { called = "version:" + v; return nil }
+	deps := dependencies{
+		installLatest:       func(context.Context, string) error { called = latestKeyword; return nil },
+		installMainOrMaster: func(context.Context, string) error { called = "main"; return nil },
+		installByVersion:    func(_ context.Context, _, v string) error { called = "version:" + v; return nil },
+	}
 
 	tests := []struct {
 		channel goutil.UpdateChannel
@@ -771,7 +768,7 @@ func Test_installWithSelectedVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		called = ""
-		if err := installWithSelectedVersion(context.Background(), "example.com/tool", tt.channel); err != nil {
+		if err := installWithSelectedVersion(deps, context.Background(), "example.com/tool", tt.channel); err != nil {
 			t.Errorf("channel=%q: unexpected error: %v", tt.channel, err)
 		}
 		if called != tt.want {
@@ -794,7 +791,7 @@ func Test_installWithSelectedVersion_contextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := installWithSelectedVersion(ctx, "example.com/tool", goutil.UpdateChannelLatest)
+	err := installWithSelectedVersion(defaultDependencies(), ctx, "example.com/tool", goutil.UpdateChannelLatest)
 	if !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), context.Canceled.Error()) {
 		t.Fatalf("installWithSelectedVersion() error = %v, want cancellation to be surfaced", err)
 	}


### PR DESCRIPTION
## What

Addresses the two remaining refactoring findings in the cmd layer, in one PR:

- **High #1** (operation runner / renderer): the update and check flows duplicated their per-result output and reached their dependencies through scattered package globals.
- **Medium #3** (mutable global test seams → DI): the version-lookup/install operations were package-level mutable globals (`//nolint:gochecknoglobals`), read deep inside the business logic, which kept seam-swapping tests serial.

## Changes

**Renderer (#1)** — `resultLineRenderer` (in `parallel.go`): update and check built near-identical `onResult` callbacks (quiet-mode filter + `[i/n]` progress line). They now share one renderer, parameterized by the quiet predicate and the per-package description. No output change.

**Dependency injection (#3)** — `dependencies` (in `dependencies.go`): the go-toolchain operations are bundled into a value threaded through the operation flow:
- `newVerCache`, `updatePinned`, and `installWithSelectedVersion` take their lookup/install operations from an injected `dependencies` value instead of referencing globals directly.
- `defaultDependencies()` is the single place that wires the seams, so the business logic depends only on the injected value.
- `Test_installWithSelectedVersion` now builds its own `dependencies` and runs with `t.Parallel()` — demonstrating the parallel-safe injection this enables, with no global mutation.

## Scope / follow-up

The package-level seam variables remain as the **default wiring** so the existing ~200-test suite keeps passing unchanged. Fully deleting them — and the `print.Stdout/Stderr` and `goutil.goExe` seams — requires migrating a two-layer legacy test-seam system (production ctx-seams bridged to legacy test-seams via `init()`, ~90 call sites). That migration is intentionally **left as a focused follow-up** rather than bundled here, to avoid destabilizing the suite. This PR establishes the injection structure and consolidates the global access to one wiring point.

## Verification

- `go build ./...`
- `go test ./...` (all green)
- `golangci-lint run ./...` → 0 issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package update/check output in quiet mode so only relevant status lines are shown.
  * Kept progress indicators consistent during normal runs while refining how per-package results are displayed.
  * Preserved update behavior for pinned packages and version/channel-based installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->