### PR TITLE
refactor: remove mutable global test seams via dependency injection (#393)

### DIFF
--- a/cmd/bug_report.go
+++ b/cmd/bug_report.go
@@ -71,8 +71,9 @@ Any other useful data to share.
 	url := "https://github.com/nao1215/gup/issues/new?" + q.Encode()
 
 	if !openBrowser(url) {
-		fmt.Print("Please file a new issue at https://github.com/nao1215/gup/issues/new using this template:\n\n")
-		fmt.Print(body)
+		out := cmd.OutOrStdout()
+		_, _ = fmt.Fprint(out, "Please file a new issue at https://github.com/nao1215/gup/issues/new using this template:\n\n")
+		_, _ = fmt.Fprint(out, body)
 	}
 
 	return 0

--- a/cmd/bug_report_test.go
+++ b/cmd/bug_report_test.go
@@ -115,34 +115,21 @@ func Test_bugReport_fallbackVersion(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // This test temporarily replaces os.Stdout.
 func Test_bugReport_fallbackOutput(t *testing.T) {
+	t.Parallel()
 	cmd := newBugReportCmd()
 	cmd.Version = "v9.9.9"
 
-	orgStdout := os.Stdout
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	os.Stdout = pw
-	t.Cleanup(func() {
-		os.Stdout = orgStdout
-	})
+	// bugReport writes the fallback guide to cmd.OutOrStdout(), so capture it via
+	// the command's output writer instead of redirecting the process os.Stdout.
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
 
 	if got := bugReport(cmd, nil, func(string) bool { return false }); got != 0 {
 		t.Fatalf("bugReport() = %d, want 0", got)
 	}
-	if err := pw.Close(); err != nil {
-		t.Fatal(err)
-	}
 
-	body, err := io.ReadAll(pr)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	gotOutput := string(body)
+	gotOutput := buf.String()
 	if !strings.Contains(gotOutput, "Please file a new issue at https://github.com/nao1215/gup/issues/new using this template:") {
 		t.Fatalf("fallback guide is missing: %s", gotOutput)
 	}

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -28,7 +28,7 @@ and displays the name of the binary that needs to be updated.
 It does not update them.`,
 		ValidArgsFunction: completePathBinaries,
 		Run: func(cmd *cobra.Command, args []string) {
-			OsExit(check(cmd, args))
+			OsExit(check(defaultDependencies(), cmd, args))
 		},
 	}
 
@@ -82,7 +82,10 @@ func parseCheckFlags(cmd *cobra.Command) (checkOpts, error) {
 	return opts, nil
 }
 
-func check(cmd *cobra.Command, args []string) int {
+// check runs the check command. deps carries the go-toolchain version lookups so
+// the flow takes its collaborators explicitly: production passes
+// defaultDependencies(); tests inject fakes.
+func check(deps dependencies, cmd *cobra.Command, args []string) int {
 	if err := ensureGoCommandAvailable(); err != nil {
 		print.Err(err)
 		return 1
@@ -116,23 +119,23 @@ func check(cmd *cobra.Command, args []string) int {
 		return 1
 	}
 	if opts.jsonOut {
-		return doCheckJSON(pkgs, opts.cpus, opts.timeout, ignoreGoUpdate)
+		return doCheckJSON(deps, pkgs, opts.cpus, opts.timeout, ignoreGoUpdate)
 	}
-	return doCheck(pkgs, opts.cpus, opts.timeout, ignoreGoUpdate, opts.quiet)
+	return doCheck(deps, pkgs, opts.cpus, opts.timeout, ignoreGoUpdate, opts.quiet)
 }
 
-func doCheck(pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpdate, quiet bool) int {
-	return doCheckWith(pkgs, cpus, timeout, ignoreGoUpdate, quiet, false)
+func doCheck(deps dependencies, pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpdate, quiet bool) int {
+	return doCheckWith(deps, pkgs, cpus, timeout, ignoreGoUpdate, quiet, false)
 }
 
 // doCheckJSON runs the same check as doCheck but emits a JSON array of package
 // records to STDOUT instead of human-readable progress lines.
-func doCheckJSON(pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpdate bool) int {
-	return doCheckWith(pkgs, cpus, timeout, ignoreGoUpdate, false, true)
+func doCheckJSON(deps dependencies, pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpdate bool) int {
+	return doCheckWith(deps, pkgs, cpus, timeout, ignoreGoUpdate, false, true)
 }
 
-func doCheckWith(pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpdate, quiet, jsonOut bool) int {
-	verCache := defaultDependencies().newVerCache()
+func doCheckWith(deps dependencies, pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpdate, quiet, jsonOut bool) int {
+	verCache := deps.newVerCache()
 
 	if !jsonOut && !quiet {
 		print.Info("check binary under $GOPATH/bin or $GOBIN")

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -28,7 +28,7 @@ and displays the name of the binary that needs to be updated.
 It does not update them.`,
 		ValidArgsFunction: completePathBinaries,
 		Run: func(cmd *cobra.Command, args []string) {
-			OsExit(check(defaultDependencies(), print.NewColorable(), cmd, args))
+			OsExit(check(defaultDependencies(), printerFor(cmd), cmd, args))
 		},
 	}
 
@@ -271,7 +271,10 @@ func printUpdatablePkgInfo(p *print.Printer, pkgs []goutil.Package) {
 	}
 
 	const indentSpaces = 11
-	fmt.Println("")
+	// Emit the blank separator line through the Printer (not fmt.Println, which
+	// writes to the real stdout) so all of this command's output flows through
+	// one sink and is captured together in tests.
+	p.Info("")
 	p.Info("If you want to update binaries, run the following command.\n" +
 		strings.Repeat(" ", indentSpaces) +
 		"$ gup update " + b.String())

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -28,7 +28,7 @@ and displays the name of the binary that needs to be updated.
 It does not update them.`,
 		ValidArgsFunction: completePathBinaries,
 		Run: func(cmd *cobra.Command, args []string) {
-			OsExit(check(defaultDependencies(), cmd, args))
+			OsExit(check(defaultDependencies(), print.NewColorable(), cmd, args))
 		},
 	}
 
@@ -85,60 +85,60 @@ func parseCheckFlags(cmd *cobra.Command) (checkOpts, error) {
 // check runs the check command. deps carries the go-toolchain version lookups so
 // the flow takes its collaborators explicitly: production passes
 // defaultDependencies(); tests inject fakes.
-func check(deps dependencies, cmd *cobra.Command, args []string) int {
+func check(deps dependencies, p *print.Printer, cmd *cobra.Command, args []string) int {
 	if err := ensureGoCommandAvailable(); err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
 	opts, err := parseCheckFlags(cmd)
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
-	pkgs, missingTargets, goVersionAvailable, err := pkgselect.PackageInfoByTargets(args)
+	pkgs, missingTargets, goVersionAvailable, err := pkgselect.PackageInfoByTargets(p, args)
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 	// When the installed Go version can't be detected, behave as
 	// --ignore-go-update so check does not report every binary as outdated
 	// (see issue #296).
 	ignoreGoUpdate := opts.ignoreGoUpdate || !goVersionAvailable
-	pkgselect.WarnMissing(missingTargets, func(msg string) { print.Warn(msg) })
+	pkgselect.WarnMissing(missingTargets, func(msg string) { p.Warn(msg) })
 
 	if len(pkgs) == 0 {
-		return handleEmptyEnvironment(opts.confFile, opts.jsonOut, len(args) != 0,
+		return handleEmptyEnvironment(p, opts.confFile, opts.jsonOut, len(args) != 0,
 			"unable to check package: no package information")
 	}
 
 	pkgs, err = configstate.ResolveAndApplyChannels(pkgs, opts.confFile)
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 	if opts.jsonOut {
-		return doCheckJSON(deps, pkgs, opts.cpus, opts.timeout, ignoreGoUpdate)
+		return doCheckJSON(deps, p, pkgs, opts.cpus, opts.timeout, ignoreGoUpdate)
 	}
-	return doCheck(deps, pkgs, opts.cpus, opts.timeout, ignoreGoUpdate, opts.quiet)
+	return doCheck(deps, p, pkgs, opts.cpus, opts.timeout, ignoreGoUpdate, opts.quiet)
 }
 
-func doCheck(deps dependencies, pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpdate, quiet bool) int {
-	return doCheckWith(deps, pkgs, cpus, timeout, ignoreGoUpdate, quiet, false)
+func doCheck(deps dependencies, p *print.Printer, pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpdate, quiet bool) int {
+	return doCheckWith(deps, p, pkgs, cpus, timeout, ignoreGoUpdate, quiet, false)
 }
 
 // doCheckJSON runs the same check as doCheck but emits a JSON array of package
 // records to STDOUT instead of human-readable progress lines.
-func doCheckJSON(deps dependencies, pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpdate bool) int {
-	return doCheckWith(deps, pkgs, cpus, timeout, ignoreGoUpdate, false, true)
+func doCheckJSON(deps dependencies, p *print.Printer, pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpdate bool) int {
+	return doCheckWith(deps, p, pkgs, cpus, timeout, ignoreGoUpdate, false, true)
 }
 
-func doCheckWith(deps dependencies, pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpdate, quiet, jsonOut bool) int {
+func doCheckWith(deps dependencies, p *print.Printer, pkgs []goutil.Package, cpus int, timeout time.Duration, ignoreGoUpdate, quiet, jsonOut bool) int {
 	verCache := deps.newVerCache()
 
 	if !jsonOut && !quiet {
-		print.Info("check binary under $GOPATH/bin or $GOBIN")
+		p.Info("check binary under $GOPATH/bin or $GOBIN")
 	}
 
 	checker := func(ctx context.Context, p goutil.Package) updateResult {
@@ -189,26 +189,26 @@ func doCheckWith(deps dependencies, pkgs []goutil.Package, cpus int, timeout tim
 	var onResult func(prefix string, v updateResult)
 	if !jsonOut {
 		// In quiet mode show only binaries with an available update.
-		onResult = resultLineRenderer(quiet,
+		onResult = resultLineRenderer(p, quiet,
 			func(v updateResult) bool {
 				return v.status == statusUpdateAvailable || v.status == statusPinMismatch
 			},
 			checkResultStr)
 	}
 
-	result, results := executePackages(pkgs, cpus, timeout, checker, onResult)
+	result, results := executePackages(p, pkgs, cpus, timeout, checker, onResult)
 
 	if jsonOut {
-		if err := encodeJSONPackages(resultsToJSONPackages(results)); err != nil {
-			print.Err(err)
+		if err := encodeJSONPackages(p, resultsToJSONPackages(results)); err != nil {
+			p.Err(err)
 			return 1
 		}
 		return result
 	}
 
-	printUpdatablePkgInfo(collectNeedUpdatePkgs(results))
+	printUpdatablePkgInfo(p, collectNeedUpdatePkgs(results))
 	if quiet {
-		print.Info(summarizeResults(results, true))
+		p.Info(summarizeResults(results, true))
 	}
 	return result
 }
@@ -259,7 +259,7 @@ func collectNeedUpdatePkgs(results []updateResult) []goutil.Package {
 	return needUpdate
 }
 
-func printUpdatablePkgInfo(pkgs []goutil.Package) {
+func printUpdatablePkgInfo(p *print.Printer, pkgs []goutil.Package) {
 	if len(pkgs) == 0 {
 		return
 	}
@@ -272,7 +272,7 @@ func printUpdatablePkgInfo(pkgs []goutil.Package) {
 
 	const indentSpaces = 11
 	fmt.Println("")
-	print.Info("If you want to update binaries, run the following command.\n" +
+	p.Info("If you want to update binaries, run the following command.\n" +
 		strings.Repeat(" ", indentSpaces) +
 		"$ gup update " + b.String())
 }

--- a/cmd/check_channel_test.go
+++ b/cmd/check_channel_test.go
@@ -1,11 +1,9 @@
-//nolint:paralleltest // tests capture the package-level print.Stdout/Stderr writers
+//nolint:paralleltest // tests mutate process-global state (GOBIN/XDG env, cwd)
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -41,29 +39,13 @@ func newCheckPkg(name, current string, channel goutil.UpdateChannel) goutil.Pack
 	}
 }
 
-// captureCheckOutput runs fn while capturing everything printed to stdout/stderr.
-func captureCheckOutput(t *testing.T, fn func() int) string {
+// captureCheckOutput runs fn with a buffer-backed Printer and returns everything
+// it wrote to stdout/stderr (both go to the same buffer, mirroring the previous
+// single-pipe capture).
+func captureCheckOutput(t *testing.T, fn func(p *print.Printer) int) string {
 	t.Helper()
-	orgStdout := print.Stdout
-	orgStderr := print.Stderr
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	print.Stdout = pw
-	print.Stderr = pw
-
-	fn()
-
-	_ = pw.Close()
-	print.Stdout = orgStdout
-	print.Stderr = orgStderr
-
-	buf := bytes.Buffer{}
-	if _, err := io.Copy(&buf, pr); err != nil {
-		t.Fatal(err)
-	}
-	_ = pr.Close()
+	p, buf := newTestPrinter()
+	fn(p)
 	return buf.String()
 }
 
@@ -94,8 +76,8 @@ func Test_doCheck_respectsSavedChannels(t *testing.T) {
 		newCheckPkg(testBinMasterTool, testVersionTwo, goutil.UpdateChannelMaster),
 	}
 
-	out := captureCheckOutput(t, func() int {
-		return doCheck(deps, pkgs, 1, 0, true, false)
+	out := captureCheckOutput(t, func(p *print.Printer) int {
+		return doCheck(deps, p, pkgs, 1, 0, true, false)
 	})
 
 	idx := strings.Index(out, "$ gup update ")
@@ -136,8 +118,8 @@ func Test_check_ambiguousConfigFailsFast(t *testing.T) {
 	}
 
 	var got int
-	out := captureCheckOutput(t, func() int {
-		got = check(defaultDependencies(), newCheckCmd(), []string{})
+	out := captureCheckOutput(t, func(p *print.Printer) int {
+		got = check(defaultDependencies(), p, newCheckCmd(), []string{})
 		return got
 	})
 
@@ -167,8 +149,8 @@ func Test_check_emptyEnv_validatesExplicitMalformedFile(t *testing.T) {
 	}
 
 	var got int
-	out := captureCheckOutput(t, func() int {
-		got = check(defaultDependencies(), cmd, []string{})
+	out := captureCheckOutput(t, func(p *print.Printer) int {
+		got = check(defaultDependencies(), p, cmd, []string{})
 		return got
 	})
 	if got != 1 {
@@ -196,8 +178,8 @@ func Test_check_emptyEnv_validatesExplicitDirectoryFile(t *testing.T) {
 	}
 
 	got := 0
-	_ = captureCheckOutput(t, func() int {
-		got = check(defaultDependencies(), cmd, []string{})
+	_ = captureCheckOutput(t, func(p *print.Printer) int {
+		got = check(defaultDependencies(), p, cmd, []string{})
 		return got
 	})
 	if got != 1 {
@@ -213,8 +195,8 @@ func Test_check_emptyEnv_succeedsWithoutExplicitConfigProblem(t *testing.T) {
 	t.Setenv("GOBIN", t.TempDir()) // empty environment
 
 	got := 0
-	_ = captureCheckOutput(t, func() int {
-		got = check(defaultDependencies(), newCheckCmd(), []string{})
+	_ = captureCheckOutput(t, func(p *print.Printer) int {
+		got = check(defaultDependencies(), p, newCheckCmd(), []string{})
 		return got
 	})
 	if got != 0 {
@@ -243,8 +225,8 @@ func Test_check_failsFastOnMalformedConfig(t *testing.T) {
 	}
 
 	var got int
-	out := captureCheckOutput(t, func() int {
-		got = check(defaultDependencies(), newCheckCmd(), []string{})
+	out := captureCheckOutput(t, func(p *print.Printer) int {
+		got = check(defaultDependencies(), p, newCheckCmd(), []string{})
 		return got
 	})
 	if got != 1 {

--- a/cmd/check_channel_test.go
+++ b/cmd/check_channel_test.go
@@ -1,4 +1,4 @@
-//nolint:paralleltest // tests mutate global function variables for stubbing
+//nolint:paralleltest // tests capture the package-level print.Stdout/Stderr writers
 package cmd
 
 import (
@@ -68,19 +68,13 @@ func captureCheckOutput(t *testing.T, fn func() int) string {
 }
 
 func Test_doCheck_respectsSavedChannels(t *testing.T) {
-	origLatest := getLatestVerCtx
-	origRef := getVerByRefCtx
-	t.Cleanup(func() {
-		getLatestVerCtx = origLatest
-		getVerByRefCtx = origRef
-	})
-
+	deps := testDeps()
 	// @latest always reports v1.0.0 so a main/master binary would look
 	// up-to-date if check wrongly ignored the saved channel.
-	getLatestVerCtx = func(_ context.Context, _ string) (string, error) {
+	deps.getLatestVer = func(_ context.Context, _ string) (string, error) {
 		return testVersionOne, nil
 	}
-	getVerByRefCtx = func(_ context.Context, _ string, ref string) (string, error) {
+	deps.getVerByRef = func(_ context.Context, _ string, ref string) (string, error) {
 		switch ref {
 		case refMain:
 			return "v1.5.0", nil
@@ -101,7 +95,7 @@ func Test_doCheck_respectsSavedChannels(t *testing.T) {
 	}
 
 	out := captureCheckOutput(t, func() int {
-		return doCheck(pkgs, 1, 0, true, false)
+		return doCheck(deps, pkgs, 1, 0, true, false)
 	})
 
 	idx := strings.Index(out, "$ gup update ")
@@ -143,7 +137,7 @@ func Test_check_ambiguousConfigFailsFast(t *testing.T) {
 
 	var got int
 	out := captureCheckOutput(t, func() int {
-		got = check(newCheckCmd(), []string{})
+		got = check(defaultDependencies(), newCheckCmd(), []string{})
 		return got
 	})
 
@@ -174,7 +168,7 @@ func Test_check_emptyEnv_validatesExplicitMalformedFile(t *testing.T) {
 
 	var got int
 	out := captureCheckOutput(t, func() int {
-		got = check(cmd, []string{})
+		got = check(defaultDependencies(), cmd, []string{})
 		return got
 	})
 	if got != 1 {
@@ -203,7 +197,7 @@ func Test_check_emptyEnv_validatesExplicitDirectoryFile(t *testing.T) {
 
 	got := 0
 	_ = captureCheckOutput(t, func() int {
-		got = check(cmd, []string{})
+		got = check(defaultDependencies(), cmd, []string{})
 		return got
 	})
 	if got != 1 {
@@ -220,7 +214,7 @@ func Test_check_emptyEnv_succeedsWithoutExplicitConfigProblem(t *testing.T) {
 
 	got := 0
 	_ = captureCheckOutput(t, func() int {
-		got = check(newCheckCmd(), []string{})
+		got = check(defaultDependencies(), newCheckCmd(), []string{})
 		return got
 	})
 	if got != 0 {
@@ -250,7 +244,7 @@ func Test_check_failsFastOnMalformedConfig(t *testing.T) {
 
 	var got int
 	out := captureCheckOutput(t, func() int {
-		got = check(newCheckCmd(), []string{})
+		got = check(defaultDependencies(), newCheckCmd(), []string{})
 		return got
 	})
 	if got != 1 {

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -1,11 +1,9 @@
-//nolint:paralleltest,errcheck,gosec
+//nolint:paralleltest,gosec
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -40,28 +38,11 @@ func Test_check(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("GOBIN", tt.gobin)
 
-			orgStdout := print.Stdout
-			orgStderr := print.Stderr
-			pr, pw, err := os.Pipe()
-			if err != nil {
-				t.Fatal(err)
-			}
-			print.Stdout = pw
-			print.Stderr = pw
+			p, buf := newTestPrinter()
 
-			if got := check(defaultDependencies(), newCheckCmd(), tt.args); got != tt.want {
+			if got := check(defaultDependencies(), p, newCheckCmd(), tt.args); got != tt.want {
 				t.Errorf("check() = %v, want %v", got, tt.want)
 			}
-			pw.Close()
-			print.Stdout = orgStdout
-			print.Stderr = orgStderr
-
-			buf := bytes.Buffer{}
-			_, err = io.Copy(&buf, pr)
-			if err != nil {
-				t.Error(err)
-			}
-			defer pr.Close()
 
 			// An environment with no manageable binaries reports the friendly
 			// first-run note and exits 0 (#350).
@@ -79,8 +60,8 @@ func Test_check_namedTargetNotInstalled(t *testing.T) {
 	t.Setenv("GOBIN", filepath.Join("testdata", "check_success"))
 
 	var got int
-	out := captureCheckOutput(t, func() int {
-		got = check(defaultDependencies(), newCheckCmd(), []string{"doesnotexist"})
+	out := captureCheckOutput(t, func(p *print.Printer) int {
+		got = check(defaultDependencies(), p, newCheckCmd(), []string{"doesnotexist"})
 		return got
 	})
 	if got != 1 {
@@ -122,28 +103,12 @@ func Test_CheckOption(t *testing.T) {
 				OsExit = os.Exit
 			}()
 
-			orgStdout := print.Stdout
-			orgStderr := print.Stderr
-			pr, pw, err := os.Pipe()
-			if err != nil {
-				t.Fatal(err)
-			}
-			print.Stdout = pw
-			print.Stderr = pw
+			p, buf := newTestPrinter()
 
-			if got := check(defaultDependencies(), tt.args.cmd, tt.args.args); got != tt.want {
+			if got := check(defaultDependencies(), p, tt.args.cmd, tt.args.args); got != tt.want {
 				t.Errorf("check() = %v, want %v", got, tt.want)
 			}
-			pw.Close()
-			print.Stdout = orgStdout
-			print.Stderr = orgStderr
 
-			buf := bytes.Buffer{}
-			_, err = io.Copy(&buf, pr)
-			if err != nil {
-				t.Error(err)
-			}
-			defer pr.Close()
 			got := strings.Split(buf.String(), "\n")
 
 			if diff := cmp.Diff(tt.stderr, got); diff != "" {
@@ -157,28 +122,12 @@ func Test_check_not_use_go_cmd(t *testing.T) {
 	t.Run("Not found go command", func(t *testing.T) {
 		t.Setenv("PATH", "")
 
-		orgStdout := print.Stdout
-		orgStderr := print.Stderr
-		pr, pw, err := os.Pipe()
-		if err != nil {
-			t.Fatal(err)
-		}
-		print.Stdout = pw
-		print.Stderr = pw
+		p, buf := newTestPrinter()
 
-		if got := check(defaultDependencies(), &cobra.Command{}, []string{}); got != 1 {
+		if got := check(defaultDependencies(), p, &cobra.Command{}, []string{}); got != 1 {
 			t.Errorf("check() = %v, want %v", got, 1)
 		}
-		pw.Close()
-		print.Stdout = orgStdout
-		print.Stderr = orgStderr
 
-		buf := bytes.Buffer{}
-		_, err = io.Copy(&buf, pr)
-		if err != nil {
-			t.Error(err)
-		}
-		defer pr.Close()
 		got := strings.Split(buf.String(), "\n")
 
 		want := []string{}
@@ -264,28 +213,12 @@ func Test_check_gobin_is_empty(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("GOBIN", tt.gobin)
 
-			orgStdout := print.Stdout
-			orgStderr := print.Stderr
-			pr, pw, err := os.Pipe()
-			if err != nil {
-				t.Fatal(err)
-			}
-			print.Stdout = pw
-			print.Stderr = pw
+			p, buf := newTestPrinter()
 
-			if got := check(defaultDependencies(), newCheckCmd(), tt.args.args); got != tt.want {
+			if got := check(defaultDependencies(), p, newCheckCmd(), tt.args.args); got != tt.want {
 				t.Errorf("check() = %v, want %v", got, tt.want)
 			}
-			pw.Close()
-			print.Stdout = orgStdout
-			print.Stderr = orgStderr
 
-			buf := bytes.Buffer{}
-			_, err = io.Copy(&buf, pr)
-			if err != nil {
-				t.Error(err)
-			}
-			defer pr.Close()
 			got := strings.Split(buf.String(), "\n")
 
 			if diff := cmp.Diff(tt.stderr, got); diff != "" {
@@ -317,7 +250,8 @@ func Test_printUpdatablePkgInfo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			printUpdatablePkgInfo(tt.args.pkgs)
+			p, _ := newTestPrinter()
+			printUpdatablePkgInfo(p, tt.args.pkgs)
 		})
 	}
 }
@@ -325,26 +259,9 @@ func Test_printUpdatablePkgInfo(t *testing.T) {
 func Test_check_success(t *testing.T) {
 	t.Setenv("GOBIN", filepath.Join("testdata", "check_success"))
 
-	orgStdout := print.Stdout
-	orgStderr := print.Stderr
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	print.Stdout = pw
-	print.Stderr = pw
+	p, _ := newTestPrinter()
 
-	got := check(defaultDependencies(), newCheckCmd(), []string{})
-	pw.Close()
-	print.Stdout = orgStdout
-	print.Stderr = orgStderr
-
-	buf := bytes.Buffer{}
-	_, err = io.Copy(&buf, pr)
-	if err != nil {
-		t.Error(err)
-	}
-	pr.Close()
+	got := check(defaultDependencies(), p, newCheckCmd(), []string{})
 
 	// Should succeed (exit 0) or fail (exit 1) but not crash.
 	// The check command runs network calls so we accept either result.
@@ -361,26 +278,9 @@ func Test_check_ignoreGoUpdateFlag(t *testing.T) {
 		t.Fatalf("failed to set ignore-go-update flag: %v", err)
 	}
 
-	orgStdout := print.Stdout
-	orgStderr := print.Stderr
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	print.Stdout = pw
-	print.Stderr = pw
+	p, _ := newTestPrinter()
 
-	got := check(defaultDependencies(), cmd, []string{})
-	pw.Close()
-	print.Stdout = orgStdout
-	print.Stderr = orgStderr
-
-	buf := bytes.Buffer{}
-	_, err = io.Copy(&buf, pr)
-	if err != nil {
-		t.Error(err)
-	}
-	pr.Close()
+	got := check(defaultDependencies(), p, cmd, []string{})
 
 	if got != 0 && got != 1 {
 		t.Errorf("check() = %v, want 0 or 1", got)
@@ -395,21 +295,10 @@ func Test_check_jobsClamp(t *testing.T) {
 		t.Fatalf("failed to set jobs flag: %v", err)
 	}
 
-	orgStdout := print.Stdout
-	orgStderr := print.Stderr
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	print.Stdout = pw
-	print.Stderr = pw
+	p, _ := newTestPrinter()
 
 	// Should not hang with jobs=0 (clamped to 1)
-	got := check(defaultDependencies(), cmd, []string{})
-	pw.Close()
-	print.Stdout = orgStdout
-	print.Stderr = orgStderr
-	pr.Close()
+	got := check(defaultDependencies(), p, cmd, []string{})
 
 	if got != 0 && got != 1 {
 		t.Errorf("check() = %v, want 0 or 1", got)
@@ -435,14 +324,7 @@ func Test_doCheck_modulePathChanged(t *testing.T) {
 		return "", errors.New("unexpected module path")
 	}
 
-	orgStdout := print.Stdout
-	orgStderr := print.Stderr
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	print.Stdout = pw
-	print.Stderr = pw
+	p, buf := newTestPrinter()
 
 	pkgs := []goutil.Package{
 		{
@@ -458,17 +340,7 @@ func Test_doCheck_modulePathChanged(t *testing.T) {
 			},
 		},
 	}
-	got := doCheck(deps, pkgs, 1, 0, true, false)
-
-	pw.Close()
-	print.Stdout = orgStdout
-	print.Stderr = orgStderr
-
-	buf := bytes.Buffer{}
-	if _, err := io.Copy(&buf, pr); err != nil {
-		t.Fatal(err)
-	}
-	_ = pr.Close()
+	got := doCheck(deps, p, pkgs, 1, 0, true, false)
 
 	if got != 0 {
 		t.Fatalf("doCheck() = %v, want 0", got)
@@ -482,14 +354,7 @@ func Test_doCheck_customGoBuildTag_noFalsePositiveUpdate(t *testing.T) {
 	deps := testDeps()
 	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionOne, nil }
 
-	orgStdout := print.Stdout
-	orgStderr := print.Stderr
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	print.Stdout = pw
-	print.Stderr = pw
+	p, buf := newTestPrinter()
 
 	pkgs := []goutil.Package{
 		{
@@ -505,19 +370,7 @@ func Test_doCheck_customGoBuildTag_noFalsePositiveUpdate(t *testing.T) {
 			},
 		},
 	}
-	got := doCheck(deps, pkgs, 1, 0, false, false)
-
-	if err := pw.Close(); err != nil {
-		t.Fatal(err)
-	}
-	print.Stdout = orgStdout
-	print.Stderr = orgStderr
-
-	buf := bytes.Buffer{}
-	if _, err := io.Copy(&buf, pr); err != nil {
-		t.Fatal(err)
-	}
-	_ = pr.Close()
+	got := doCheck(deps, p, pkgs, 1, 0, false, false)
 
 	if got != 0 {
 		t.Fatalf("doCheck() = %v, want 0", got)
@@ -538,14 +391,7 @@ func Test_doCheck_customGoBuildTag_goVersionDiffColor(t *testing.T) {
 	deps := testDeps()
 	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionOne, nil }
 
-	orgStdout := print.Stdout
-	orgStderr := print.Stderr
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	print.Stdout = pw
-	print.Stderr = pw
+	p, buf := newTestPrinter()
 
 	pkgs := []goutil.Package{
 		{
@@ -562,18 +408,7 @@ func Test_doCheck_customGoBuildTag_goVersionDiffColor(t *testing.T) {
 		},
 	}
 
-	got := doCheck(deps, pkgs, 1, 0, false, false)
-	if err := pw.Close(); err != nil {
-		t.Fatal(err)
-	}
-	print.Stdout = orgStdout
-	print.Stderr = orgStderr
-
-	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, pr); err != nil {
-		t.Fatal(err)
-	}
-	_ = pr.Close()
+	got := doCheck(deps, p, pkgs, 1, 0, false, false)
 
 	if got != 0 {
 		t.Fatalf("doCheck() = %v, want 0", got)

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -3,6 +3,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"os"
@@ -48,7 +49,7 @@ func Test_check(t *testing.T) {
 			print.Stdout = pw
 			print.Stderr = pw
 
-			if got := check(newCheckCmd(), tt.args); got != tt.want {
+			if got := check(defaultDependencies(), newCheckCmd(), tt.args); got != tt.want {
 				t.Errorf("check() = %v, want %v", got, tt.want)
 			}
 			pw.Close()
@@ -79,7 +80,7 @@ func Test_check_namedTargetNotInstalled(t *testing.T) {
 
 	var got int
 	out := captureCheckOutput(t, func() int {
-		got = check(newCheckCmd(), []string{"doesnotexist"})
+		got = check(defaultDependencies(), newCheckCmd(), []string{"doesnotexist"})
 		return got
 	})
 	if got != 1 {
@@ -130,7 +131,7 @@ func Test_CheckOption(t *testing.T) {
 			print.Stdout = pw
 			print.Stderr = pw
 
-			if got := check(tt.args.cmd, tt.args.args); got != tt.want {
+			if got := check(defaultDependencies(), tt.args.cmd, tt.args.args); got != tt.want {
 				t.Errorf("check() = %v, want %v", got, tt.want)
 			}
 			pw.Close()
@@ -165,7 +166,7 @@ func Test_check_not_use_go_cmd(t *testing.T) {
 		print.Stdout = pw
 		print.Stderr = pw
 
-		if got := check(&cobra.Command{}, []string{}); got != 1 {
+		if got := check(defaultDependencies(), &cobra.Command{}, []string{}); got != 1 {
 			t.Errorf("check() = %v, want %v", got, 1)
 		}
 		pw.Close()
@@ -272,7 +273,7 @@ func Test_check_gobin_is_empty(t *testing.T) {
 			print.Stdout = pw
 			print.Stderr = pw
 
-			if got := check(newCheckCmd(), tt.args.args); got != tt.want {
+			if got := check(defaultDependencies(), newCheckCmd(), tt.args.args); got != tt.want {
 				t.Errorf("check() = %v, want %v", got, tt.want)
 			}
 			pw.Close()
@@ -333,7 +334,7 @@ func Test_check_success(t *testing.T) {
 	print.Stdout = pw
 	print.Stderr = pw
 
-	got := check(newCheckCmd(), []string{})
+	got := check(defaultDependencies(), newCheckCmd(), []string{})
 	pw.Close()
 	print.Stdout = orgStdout
 	print.Stderr = orgStderr
@@ -369,7 +370,7 @@ func Test_check_ignoreGoUpdateFlag(t *testing.T) {
 	print.Stdout = pw
 	print.Stderr = pw
 
-	got := check(cmd, []string{})
+	got := check(defaultDependencies(), cmd, []string{})
 	pw.Close()
 	print.Stdout = orgStdout
 	print.Stderr = orgStderr
@@ -404,7 +405,7 @@ func Test_check_jobsClamp(t *testing.T) {
 	print.Stderr = pw
 
 	// Should not hang with jobs=0 (clamped to 1)
-	got := check(cmd, []string{})
+	got := check(defaultDependencies(), cmd, []string{})
 	pw.Close()
 	print.Stdout = orgStdout
 	print.Stderr = orgStderr
@@ -421,12 +422,8 @@ func Test_doCheck_modulePathChanged(t *testing.T) {
 		newModule = testNewModule
 	)
 
-	origGetLatest := getLatestVer
-	defer func() {
-		getLatestVer = origGetLatest
-	}()
-
-	getLatestVer = func(modulePath string) (string, error) {
+	deps := testDeps()
+	deps.getLatestVer = func(_ context.Context, modulePath string) (string, error) {
 		if modulePath == oldModule {
 			return "", errors.New("version constraints conflict:\n" +
 				"module declares its path as: " + newModule + "\n" +
@@ -461,7 +458,7 @@ func Test_doCheck_modulePathChanged(t *testing.T) {
 			},
 		},
 	}
-	got := doCheck(pkgs, 1, 0, true, false)
+	got := doCheck(deps, pkgs, 1, 0, true, false)
 
 	pw.Close()
 	print.Stdout = orgStdout
@@ -482,11 +479,8 @@ func Test_doCheck_modulePathChanged(t *testing.T) {
 }
 
 func Test_doCheck_customGoBuildTag_noFalsePositiveUpdate(t *testing.T) {
-	origGetLatest := getLatestVer
-	defer func() {
-		getLatestVer = origGetLatest
-	}()
-	getLatestVer = func(string) (string, error) { return testVersionOne, nil }
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionOne, nil }
 
 	orgStdout := print.Stdout
 	orgStderr := print.Stderr
@@ -511,7 +505,7 @@ func Test_doCheck_customGoBuildTag_noFalsePositiveUpdate(t *testing.T) {
 			},
 		},
 	}
-	got := doCheck(pkgs, 1, 0, false, false)
+	got := doCheck(deps, pkgs, 1, 0, false, false)
 
 	if err := pw.Close(); err != nil {
 		t.Fatal(err)
@@ -541,11 +535,8 @@ func Test_doCheck_customGoBuildTag_goVersionDiffColor(t *testing.T) {
 	color.NoColor = false
 	t.Cleanup(func() { color.NoColor = oldNoColor })
 
-	origGetLatest := getLatestVer
-	defer func() {
-		getLatestVer = origGetLatest
-	}()
-	getLatestVer = func(string) (string, error) { return testVersionOne, nil }
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionOne, nil }
 
 	orgStdout := print.Stdout
 	orgStderr := print.Stderr
@@ -571,7 +562,7 @@ func Test_doCheck_customGoBuildTag_goVersionDiffColor(t *testing.T) {
 		},
 	}
 
-	got := doCheck(pkgs, 1, 0, false, false)
+	got := doCheck(deps, pkgs, 1, 0, false, false)
 	if err := pw.Close(); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/nao1215/gup/internal/completion"
 	"github.com/spf13/cobra"
@@ -48,15 +47,19 @@ Use --install to write bash/fish/zsh completion files to the user shell config p
 					"gup completion bash",
 					"gup completion --install")
 			}
+			// Write to the command's configured output (cobra propagates the root's
+			// writer) so completion output flows through the same sink as the rest
+			// of gup and tests can capture it without redirecting os.Stdout.
+			out := cmd.OutOrStdout()
 			switch args[0] {
 			case shellBash:
-				return rootCmd.GenBashCompletionV2(os.Stdout, false)
+				return rootCmd.GenBashCompletionV2(out, false)
 			case "fish":
-				return rootCmd.GenFishCompletion(os.Stdout, false)
+				return rootCmd.GenFishCompletion(out, false)
 			case "zsh":
-				return rootCmd.GenZshCompletion(os.Stdout)
+				return rootCmd.GenZshCompletion(out)
 			case "powershell":
-				return rootCmd.GenPowerShellCompletionWithDesc(os.Stdout)
+				return rootCmd.GenPowerShellCompletionWithDesc(out)
 			default:
 				return fmt.Errorf("internal error, should not happen with arg %q", args[0])
 			}

--- a/cmd/dependencies.go
+++ b/cmd/dependencies.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 
+	"github.com/nao1215/gup/internal/goutil"
 	"github.com/nao1215/gup/internal/vercache"
 )
 
@@ -12,10 +13,10 @@ import (
 // Threading these through the operation flow as a value (rather than reading
 // package-level globals deep inside the business logic) lets the runner take its
 // I/O-bound collaborators explicitly, and lets a test inject fakes by building a
-// dependencies value instead of mutating shared globals. The package-level seam
-// variables remain as the single default wiring (defaultDependencies) so the
-// existing suite keeps working; new tests can inject directly and run in
-// parallel.
+// dependencies value instead of mutating shared globals. defaultDependencies is
+// the single place that names the real goutil operations, so the rest of the
+// package depends only on the injected value and tests inject directly and run
+// in parallel.
 type dependencies struct {
 	getLatestVer        func(ctx context.Context, modulePath string) (string, error)
 	getVerByRef         func(ctx context.Context, modulePath, ref string) (string, error)
@@ -24,17 +25,17 @@ type dependencies struct {
 	installByVersion    func(ctx context.Context, importPath, version string) error
 }
 
-// defaultDependencies wires the operation seams used in production. It is the one
-// place that reads the package-level lookup/install variables, so the business
-// logic (newVerCache, updatePinned, installWithSelectedVersion) depends only on
-// the injected value.
+// defaultDependencies wires the real goutil operations used in production. It is
+// the one place that names them, so the business logic (newVerCache,
+// updatePinned, installWithSelectedVersion) and the command entry points depend
+// only on the injected value.
 func defaultDependencies() dependencies {
 	return dependencies{
-		getLatestVer:        getLatestVerCtx,
-		getVerByRef:         getVerByRefCtx,
-		installLatest:       installLatestCtx,
-		installMainOrMaster: installMainOrMasterCtx,
-		installByVersion:    installByVersionUpdCtx,
+		getLatestVer:        goutil.GetLatestVerWithContext,
+		getVerByRef:         goutil.GetVerWithContext,
+		installLatest:       goutil.InstallLatestWithContext,
+		installMainOrMaster: goutil.InstallMainOrMasterWithContext,
+		installByVersion:    goutil.InstallWithContext,
 	}
 }
 

--- a/cmd/dependencies_test.go
+++ b/cmd/dependencies_test.go
@@ -1,0 +1,30 @@
+package cmd
+
+import "context"
+
+// testDeps returns a dependencies value whose operations are harmless stubs: the
+// version lookups return an empty version and the installs are no-ops. A test
+// overrides only the fields it exercises and passes the value in directly, so it
+// owns its dependencies instead of mutating package globals.
+func testDeps() dependencies {
+	return dependencies{
+		getLatestVer:        func(context.Context, string) (string, error) { return "", nil },
+		getVerByRef:         func(context.Context, string, string) (string, error) { return "", nil },
+		installLatest:       func(context.Context, string) error { return nil },
+		installMainOrMaster: func(context.Context, string) error { return nil },
+		installByVersion:    func(context.Context, string, string) error { return nil },
+	}
+}
+
+// stubUpdateDeps returns dependencies that make every package look outdated
+// (latest == v9.9.9) with no-op installs, so an update/check run reaches the
+// install path without performing real installs or network lookups. It replaces
+// the old helper_stubUpdateOps global-swap helper.
+func stubUpdateDeps() dependencies {
+	d := testDeps()
+	d.getLatestVer = func(context.Context, string) (string, error) { return testVersionNine, nil }
+	// The channel-aware skip/update decision resolves @main/@master versions
+	// through this ref lookup, so stub it alongside the @latest lookup.
+	d.getVerByRef = func(context.Context, string, string) (string, error) { return testVersionNine, nil }
+	return d
+}

--- a/cmd/dependencies_test.go
+++ b/cmd/dependencies_test.go
@@ -1,6 +1,29 @@
 package cmd
 
-import "context"
+import (
+	"bytes"
+	"context"
+	"io"
+
+	"github.com/nao1215/gup/internal/print"
+)
+
+// discardPrinter returns a Printer that throws away all output, for tests that
+// exercise a function's behavior or exit code but do not assert on its output.
+func discardPrinter() *print.Printer {
+	return print.New(io.Discard, io.Discard)
+}
+
+// newTestPrinter returns a Printer whose normal and error output both go to a
+// single buffer, plus the buffer for assertions. It replaces the old pattern of
+// pointing the package-level print.Stdout/Stderr writers at one pipe: a test
+// constructs the Printer, passes it to the function under test, and reads the
+// buffer. The progress callbacks that drive parallel output are invoked from a
+// single consumer goroutine, so the shared buffer is never written concurrently.
+func newTestPrinter() (*print.Printer, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	return print.New(buf, buf), buf
+}
 
 // testDeps returns a dependencies value whose operations are harmless stubs: the
 // version lookups return an empty version and the installs are no-ops. A test

--- a/cmd/emptyenv.go
+++ b/cmd/emptyenv.go
@@ -16,22 +16,22 @@ import (
 // still validated so honoring explicit user input does not depend on unrelated
 // environment state (#368), and the command emits an empty JSON array (--json)
 // or an informational note before exiting 0.
-func handleEmptyEnvironment(confFile string, jsonOut, explicitSelection bool, usageErr string) int {
+func handleEmptyEnvironment(p *print.Printer, confFile string, jsonOut, explicitSelection bool, usageErr string) int {
 	if explicitSelection {
-		print.Err(usageErr)
+		p.Err(usageErr)
 		return 1
 	}
 	if err := configstate.ValidateExplicitFile(confFile); err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 	if jsonOut {
-		if err := encodeJSONPackages(nil); err != nil {
-			print.Err(err)
+		if err := encodeJSONPackages(p, nil); err != nil {
+			p.Err(err)
 			return 1
 		}
 		return 0
 	}
-	print.Info(emptyEnvMessage)
+	p.Info(emptyEnvMessage)
 	return 0
 }

--- a/cmd/emptyenv_test.go
+++ b/cmd/emptyenv_test.go
@@ -3,17 +3,19 @@ package cmd
 import (
 	"strings"
 	"testing"
+
+	"github.com/nao1215/gup/internal/print"
 )
 
 // TestHandleEmptyEnvironment locks in the shared "no manageable binaries"
 // behavior that update and check delegate to.
 //
-//nolint:paralleltest // captureCheckOutput swaps the print.Stdout/Stderr globals
+//nolint:paralleltest // captureCheckOutput drives a shared buffer-backed Printer
 func TestHandleEmptyEnvironment(t *testing.T) {
 	t.Run("explicit selection is a usage error", func(t *testing.T) {
 		var code int
-		out := captureCheckOutput(t, func() int {
-			code = handleEmptyEnvironment("", false, true, "boom: nothing selected")
+		out := captureCheckOutput(t, func(p *print.Printer) int {
+			code = handleEmptyEnvironment(p, "", false, true, "boom: nothing selected")
 			return code
 		})
 		if code != 1 {
@@ -26,8 +28,8 @@ func TestHandleEmptyEnvironment(t *testing.T) {
 
 	t.Run("first-run note on empty environment", func(t *testing.T) {
 		var code int
-		out := captureCheckOutput(t, func() int {
-			code = handleEmptyEnvironment("", false, false, "unused")
+		out := captureCheckOutput(t, func(p *print.Printer) int {
+			code = handleEmptyEnvironment(p, "", false, false, "unused")
 			return code
 		})
 		if code != 0 {
@@ -40,8 +42,8 @@ func TestHandleEmptyEnvironment(t *testing.T) {
 
 	t.Run("json mode emits an empty array", func(t *testing.T) {
 		var code int
-		out := captureCheckOutput(t, func() int {
-			code = handleEmptyEnvironment("", true, false, "unused")
+		out := captureCheckOutput(t, func(p *print.Printer) int {
+			code = handleEmptyEnvironment(p, "", true, false, "unused")
 			return code
 		})
 		if code != 0 {
@@ -55,8 +57,8 @@ func TestHandleEmptyEnvironment(t *testing.T) {
 	t.Run("explicit --file pointing at a directory fails fast", func(t *testing.T) {
 		dir := t.TempDir()
 		var code int
-		_ = captureCheckOutput(t, func() int {
-			code = handleEmptyEnvironment(dir, false, false, "unused")
+		_ = captureCheckOutput(t, func(p *print.Printer) int {
+			code = handleEmptyEnvironment(p, dir, false, false, "unused")
 			return code
 		})
 		if code != 1 {

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -24,7 +24,7 @@ apply it with 'gup import'.`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
 		Run: func(cmd *cobra.Command, args []string) {
-			OsExit(export(cmd, args))
+			OsExit(export(print.NewColorable(), cmd, args))
 		},
 	}
 	cmd.Flags().BoolP("output", "o", false, "print command path information at STDOUT")
@@ -34,30 +34,30 @@ apply it with 'gup import'.`,
 	return cmd
 }
 
-func export(cmd *cobra.Command, _ []string) int {
+func export(p *print.Printer, cmd *cobra.Command, _ []string) int {
 	if err := ensureGoCommandAvailable(); err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
 	output, err := getFlagBool(cmd, "output")
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 	configPath, err := getFlagString(cmd, "file")
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 	configPath = config.ResolveExportFilePath(configPath)
 
-	pkgs, err := pkgselect.PackageInfo()
+	pkgs, err := pkgselect.PackageInfo(p)
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
-	pkgs = validPkgInfo(pkgs)
+	pkgs = validPkgInfo(p, pkgs)
 	// The source of truth for saved channels is always the canonical user-level
 	// config; --file/--output only change the export destination, not where
 	// channels are read from (#341).
@@ -67,7 +67,7 @@ func export(cmd *cobra.Command, _ []string) int {
 	// channels such as @main from the written gup.json (#369).
 	confPkgs, err := configstate.ReadFileIfExists(channelSource)
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 	pkgs = configstate.ApplySavedChannels(pkgs, confPkgs)
@@ -75,33 +75,33 @@ func export(cmd *cobra.Command, _ []string) int {
 	// An empty-but-valid environment is a normal first-run condition, not an
 	// error (#350): export still succeeds and writes an empty configuration.
 	if len(pkgs) == 0 {
-		print.Warn(emptyEnvMessage + "; exporting an empty configuration")
+		p.Warn(emptyEnvMessage + "; exporting an empty configuration")
 	}
 
 	if output {
-		err = outputConfig(pkgs)
+		err = outputConfig(p, pkgs)
 	} else {
 		err = writeConfigFile(configPath, pkgs)
 	}
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 	if !output {
-		print.Info("Export " + configPath)
+		p.Info("Export " + configPath)
 	}
 	return 0
 }
 
-func outputConfig(pkgs []goutil.Package) error {
-	return config.WriteConfFile(print.Stdout, pkgs)
+func outputConfig(p *print.Printer, pkgs []goutil.Package) error {
+	return config.WriteConfFile(p.Out(), pkgs)
 }
 
-func validPkgInfo(pkgs []goutil.Package) []goutil.Package {
+func validPkgInfo(p *print.Printer, pkgs []goutil.Package) []goutil.Package {
 	result := []goutil.Package{}
 	for _, v := range pkgs {
 		if v.ImportPath == "" {
-			print.Warn("can't get '" + v.Name + "' package path information. old go version binary")
+			p.Warn("can't get '" + v.Name + "' package path information. old go version binary")
 			continue
 		}
 		result = append(result, goutil.Package{Name: v.Name, ImportPath: v.ImportPath, Version: v.Version})

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -24,7 +24,7 @@ apply it with 'gup import'.`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
 		Run: func(cmd *cobra.Command, args []string) {
-			OsExit(export(print.NewColorable(), cmd, args))
+			OsExit(export(printerFor(cmd), cmd, args))
 		},
 	}
 	cmd.Flags().BoolP("output", "o", false, "print command path information at STDOUT")

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -2,7 +2,6 @@
 package cmd
 
 import (
-	"bytes"
 	"errors"
 	"io"
 	"os"
@@ -16,7 +15,6 @@ import (
 	"github.com/nao1215/gup/internal/config"
 	"github.com/nao1215/gup/internal/fileutil"
 	"github.com/nao1215/gup/internal/goutil"
-	"github.com/nao1215/gup/internal/print"
 	"github.com/spf13/cobra"
 )
 
@@ -48,7 +46,8 @@ func Test_validPkgInfo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := validPkgInfo(tt.args.pkgs)
+			p, _ := newTestPrinter()
+			got := validPkgInfo(p, tt.args.pkgs)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("value is mismatch (-want +got):\n%s", diff)
 			}
@@ -60,32 +59,11 @@ func Test_export_not_use_go_cmd(t *testing.T) {
 	t.Run("Not found go command", func(t *testing.T) {
 		t.Setenv("PATH", "")
 
-		orgStdout := print.Stdout
-		orgStderr := print.Stderr
-		pr, pw, err := os.Pipe()
-		if err != nil {
-			t.Fatal(err)
-		}
-		print.Stdout = pw
-		print.Stderr = pw
+		p, buf := newTestPrinter()
 
-		if got := export(&cobra.Command{}, []string{}); got != 1 {
+		if got := export(p, &cobra.Command{}, []string{}); got != 1 {
 			t.Errorf("export() = %v, want %v", got, 1)
 		}
-		if err := pw.Close(); err != nil {
-			t.Fatal(err)
-		}
-		print.Stdout = orgStdout
-		print.Stderr = orgStderr
-
-		buf := bytes.Buffer{}
-		_, err = io.Copy(&buf, pr)
-		if err != nil {
-			t.Error(err)
-		}
-		defer func() {
-			_ = pr.Close()
-		}()
 		got := strings.Split(buf.String(), "\n")
 
 		want := []string{}
@@ -175,32 +153,11 @@ func Test_export(t *testing.T) {
 				}()
 			}
 
-			orgStdout := print.Stdout
-			orgStderr := print.Stderr
-			pr, pw, err := os.Pipe()
-			if err != nil {
-				t.Fatal(err)
-			}
-			print.Stdout = pw
-			print.Stderr = pw
+			p, buf := newTestPrinter()
 
-			if got := export(newExportCmd(), tt.args); got != tt.want {
+			if got := export(p, newExportCmd(), tt.args); got != tt.want {
 				t.Errorf("export() = %v, want %v", got, tt.want)
 			}
-			if err := pw.Close(); err != nil {
-				t.Fatal(err)
-			}
-			print.Stdout = orgStdout
-			print.Stderr = orgStderr
-
-			buf := bytes.Buffer{}
-			_, err = io.Copy(&buf, pr)
-			if err != nil {
-				t.Error(err)
-			}
-			defer func() {
-				_ = pr.Close()
-			}()
 			got := strings.Split(buf.String(), "\n")
 
 			if tt.name != testNoConfigDir {
@@ -250,7 +207,8 @@ func Test_export_preservesChannelsFromCanonicalConfig(t *testing.T) {
 		t.Fatalf("failed to set --file: %v", err)
 	}
 
-	if got := export(cmd, []string{}); got != 0 {
+	p, _ := newTestPrinter()
+	if got := export(p, cmd, []string{}); got != 0 {
 		t.Fatalf("export() = %d, want 0", got)
 	}
 
@@ -299,7 +257,8 @@ func Test_export_rejectsDirectoryDestination(t *testing.T) {
 	if err := cmd.Flags().Set("file", dest); err != nil {
 		t.Fatalf("failed to set --file: %v", err)
 	}
-	if got := export(cmd, []string{}); got != 1 {
+	p, _ := newTestPrinter()
+	if got := export(p, cmd, []string{}); got != 1 {
 		t.Fatalf("export() = %d, want 1 when --file points to a directory", got)
 	}
 
@@ -336,7 +295,8 @@ func Test_export_failsFastOnMalformedChannelSource(t *testing.T) {
 	if err := cmd.Flags().Set("file", dest); err != nil {
 		t.Fatalf("failed to set --file: %v", err)
 	}
-	if got := export(cmd, []string{}); got != 1 {
+	p, _ := newTestPrinter()
+	if got := export(p, cmd, []string{}); got != 1 {
 		t.Fatalf("export() = %d, want 1 on malformed channel source", got)
 	}
 	if fileutil.IsFile(dest) {
@@ -364,7 +324,8 @@ func Test_export_failsFastOnUnsupportedSchema(t *testing.T) {
 	}
 	t.Setenv("GOBIN", filepath.Join("testdata", "check_success"))
 
-	if got := export(newExportCmd(), []string{}); got != 1 {
+	p, _ := newTestPrinter()
+	if got := export(p, newExportCmd(), []string{}); got != 1 {
 		t.Fatalf("export() = %d, want 1 on unsupported schema_version", got)
 	}
 }
@@ -383,7 +344,8 @@ func Test_export_emptyEnv_writesEmptyConfig(t *testing.T) {
 
 	t.Setenv("GOBIN", t.TempDir()) // existing but empty directory
 
-	if got := export(newExportCmd(), []string{}); got != 0 {
+	p, _ := newTestPrinter()
+	if got := export(p, newExportCmd(), []string{}); got != 0 {
 		t.Fatalf("export() on empty env = %d, want 0", got)
 	}
 

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -1,12 +1,10 @@
 package cmd
 
 import (
-	"io"
 	"testing"
 	"time"
 
 	"github.com/fatih/color"
-	"github.com/nao1215/gup/internal/print"
 	"github.com/spf13/cobra"
 )
 
@@ -52,13 +50,9 @@ func Test_rootCmd_noColorFlag_disablesColorViaExecute(t *testing.T) {
 	t.Setenv("NO_COLOR", "") // ensure the env var does not interfere
 	t.Cleanup(func() { color.NoColor = oldNoColor })
 
-	orgStdout := print.Stdout
-	print.Stdout = io.Discard // `gup version` prints via print.Info
-	t.Cleanup(func() { print.Stdout = orgStdout })
-
-	cmd := newRootCmd()
-	cmd.SetArgs([]string{"version", "--no-color"})
-	if err := cmd.Execute(); err != nil {
+	// `gup version` prints via the production Printer (os.Stdout); helper_runGup
+	// redirects and drains the real OS streams so the output is suppressed.
+	if _, err := helper_runGup(t, []string{testCmdGup, "version", "--no-color"}); err != nil {
 		t.Fatalf("Execute() error: %v", err)
 	}
 	if !color.NoColor {

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -33,7 +33,7 @@ versions recorded in that gup.json.`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
 		Run: func(cmd *cobra.Command, args []string) {
-			OsExit(runImport(cmd, args))
+			OsExit(runImport(print.NewColorable(), cmd, args))
 		},
 	}
 
@@ -48,81 +48,81 @@ versions recorded in that gup.json.`,
 	return cmd
 }
 
-func runImport(cmd *cobra.Command, _ []string) int {
+func runImport(p *print.Printer, cmd *cobra.Command, _ []string) int {
 	if err := ensureGoCommandAvailable(); err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
 	dryRun, err := getFlagBool(cmd, "dry-run")
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
 	confFile, err := getFlagString(cmd, "file")
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 	confFile, err = config.ResolveImportFilePath(confFile)
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
 	notify, err := getFlagBool(cmd, "notify")
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
 	cpus, err := getFlagInt(cmd, "jobs")
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 	cpus = clampJobs(cpus)
 
 	timeout, err := getTimeoutFlag(cmd)
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
 	if !fileutil.IsFile(confFile) {
-		print.Err(fmt.Errorf("%s is not found", confFile))
+		p.Err(fmt.Errorf("%s is not found", confFile))
 		return 1
 	}
 
 	pkgs, err := config.ReadConfFile(confFile)
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
 	if len(pkgs) == 0 {
-		print.Err("unable to import package: no package information")
+		p.Err("unable to import package: no package information")
 		return 1
 	}
 
-	print.Info("start import based on " + confFile)
-	return installFromConfig(pkgs, dryRun, notify, cpus, timeout)
+	p.Info("start import based on " + confFile)
+	return installFromConfig(p, pkgs, dryRun, notify, cpus, timeout)
 }
 
-func installFromConfig(pkgs []goutil.Package, dryRun, notification bool, cpus int, timeout time.Duration) (exitCode int) {
+func installFromConfig(pr *print.Printer, pkgs []goutil.Package, dryRun, notification bool, cpus int, timeout time.Duration) (exitCode int) {
 	dryRunManager := goutil.NewGoPaths()
 
 	if dryRun {
 		if err := dryRunManager.StartDryRunMode(); err != nil {
-			print.Err(fmt.Errorf("can not change to dry run mode: %w", err))
+			pr.Err(fmt.Errorf("can not change to dry run mode: %w", err))
 			return 1
 		}
 		// Restore the environment and remove the temp dir via defer so it runs
 		// even if a package install panics (see issue #297).
 		defer func() {
 			if err := dryRunManager.EndDryRunMode(); err != nil {
-				print.Err(fmt.Errorf("can not change dry run mode to normal mode: %w", err))
+				pr.Err(fmt.Errorf("can not change dry run mode to normal mode: %w", err))
 				exitCode = 1
 			}
 		}()
@@ -166,11 +166,11 @@ func installFromConfig(pkgs []goutil.Package, dryRun, notification bool, cpus in
 		}
 	}
 
-	result, _ := executePackages(pkgs, cpus, timeout, installer, func(prefix string, v updateResult) {
-		print.Info(fmt.Sprintf("%s %s@%s", prefix, v.pkg.ImportPath, v.pkg.Version.Current))
+	result, _ := executePackages(pr, pkgs, cpus, timeout, installer, func(prefix string, v updateResult) {
+		pr.Info(fmt.Sprintf("%s %s@%s", prefix, v.pkg.ImportPath, v.pkg.Version.Current))
 	})
 
-	desktopNotifyIfNeeded(result, notification)
+	desktopNotifyIfNeeded(pr, result, notification)
 	return result
 }
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -33,7 +33,7 @@ versions recorded in that gup.json.`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
 		Run: func(cmd *cobra.Command, args []string) {
-			OsExit(runImport(print.NewColorable(), cmd, args))
+			OsExit(runImport(printerFor(cmd), cmd, args))
 		},
 	}
 

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -1,11 +1,9 @@
-//nolint:paralleltest,errcheck,gosec
+//nolint:paralleltest
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,7 +12,6 @@ import (
 
 	"github.com/nao1215/gup/internal/config"
 	"github.com/nao1215/gup/internal/goutil"
-	"github.com/nao1215/gup/internal/print"
 	"github.com/spf13/cobra"
 )
 
@@ -77,20 +74,9 @@ func Test_runImport_flagErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			orgStdout := print.Stdout
-			orgStderr := print.Stderr
-			pr, pw, err := os.Pipe()
-			if err != nil {
-				t.Fatal(err)
-			}
-			print.Stdout = pw
-			print.Stderr = pw
+			p, _ := newTestPrinter()
 
-			got := runImport(tt.cmd, nil)
-			pw.Close()
-			print.Stdout = orgStdout
-			print.Stderr = orgStderr
-			pr.Close()
+			got := runImport(p, tt.cmd, nil)
 
 			if got != tt.want {
 				t.Errorf("runImport() = %v, want %v", got, tt.want)
@@ -104,27 +90,14 @@ func Test_runImport_notUseGoCmd(t *testing.T) {
 
 	cmd := newImportCmd()
 
-	orgStdout := print.Stdout
-	orgStderr := print.Stderr
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	print.Stdout = pw
-	print.Stderr = pw
+	p, buf := newTestPrinter()
 
-	got := runImport(cmd, nil)
-	pw.Close()
-	print.Stdout = orgStdout
-	print.Stderr = orgStderr
+	got := runImport(p, cmd, nil)
 
 	if got != 1 {
 		t.Errorf("runImport() = %v, want 1", got)
 	}
 
-	buf := bytes.Buffer{}
-	_, _ = io.Copy(&buf, pr)
-	pr.Close()
 	if !strings.Contains(buf.String(), "you didn't install golang") {
 		t.Errorf("expected go command error, got: %s", buf.String())
 	}
@@ -136,27 +109,13 @@ func Test_runImport_fileNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	orgStdout := print.Stdout
-	orgStderr := print.Stderr
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	print.Stdout = pw
-	print.Stderr = pw
+	p, buf := newTestPrinter()
 
-	got := runImport(cmd, nil)
-	pw.Close()
-	print.Stdout = orgStdout
-	print.Stderr = orgStderr
+	got := runImport(p, cmd, nil)
 
 	if got != 1 {
 		t.Errorf("runImport() = %v, want 1", got)
 	}
-
-	buf := bytes.Buffer{}
-	_, _ = io.Copy(&buf, pr)
-	pr.Close()
 
 	if !strings.Contains(buf.String(), "is not found") {
 		t.Errorf("expected 'is not found' error, got: %s", buf.String())
@@ -176,27 +135,13 @@ func Test_runImport_emptyConf(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	orgStdout := print.Stdout
-	orgStderr := print.Stderr
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	print.Stdout = pw
-	print.Stderr = pw
+	p, buf := newTestPrinter()
 
-	got := runImport(cmd, nil)
-	pw.Close()
-	print.Stdout = orgStdout
-	print.Stderr = orgStderr
+	got := runImport(p, cmd, nil)
 
 	if got != 1 {
 		t.Errorf("runImport() = %v, want 1", got)
 	}
-
-	buf := bytes.Buffer{}
-	_, _ = io.Copy(&buf, pr)
-	pr.Close()
 
 	if !strings.Contains(buf.String(), "unable to import package") {
 		t.Errorf("expected 'unable to import package' error, got: %s", buf.String())
@@ -219,21 +164,10 @@ func Test_runImport_jobsClamp(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	orgStdout := print.Stdout
-	orgStderr := print.Stderr
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	print.Stdout = pw
-	print.Stderr = pw
+	p, _ := newTestPrinter()
 
 	// Should not panic with jobs=0 (clamped to 1)
-	got := runImport(cmd, nil)
-	pw.Close()
-	print.Stdout = orgStdout
-	print.Stderr = orgStderr
-	pr.Close()
+	got := runImport(p, cmd, nil)
 
 	// Expect exit code 1 because the conf file has no packages
 	if got != 1 {
@@ -263,7 +197,8 @@ func Test_installFromConfig_UseVersion(t *testing.T) {
 		},
 	}
 
-	if got := installFromConfig(pkgs, false, false, 1, 0); got != 0 {
+	p, _ := newTestPrinter()
+	if got := installFromConfig(p, pkgs, false, false, 1, 0); got != 0 {
 		t.Fatalf("installFromConfig() = %d, want 0", got)
 	}
 
@@ -376,7 +311,8 @@ func Test_installFromConfig_installError(t *testing.T) {
 		},
 	}
 
-	if got := installFromConfig(pkgs, false, false, 1, 0); got != 1 {
+	p, _ := newTestPrinter()
+	if got := installFromConfig(p, pkgs, false, false, 1, 0); got != 1 {
 		t.Fatalf("installFromConfig() = %d, want 1", got)
 	}
 }
@@ -390,7 +326,8 @@ func Test_installFromConfig_emptyImportPath(t *testing.T) {
 		},
 	}
 
-	if got := installFromConfig(pkgs, false, false, 1, 0); got != 1 {
+	p, _ := newTestPrinter()
+	if got := installFromConfig(p, pkgs, false, false, 1, 0); got != 1 {
 		t.Fatalf("installFromConfig() = %d, want 1", got)
 	}
 }
@@ -413,7 +350,8 @@ func Test_installFromConfig_dryRun(t *testing.T) {
 		},
 	}
 
-	if got := installFromConfig(pkgs, true, false, 1, 0); got != 0 {
+	p, _ := newTestPrinter()
+	if got := installFromConfig(p, pkgs, true, false, 1, 0); got != 0 {
 		t.Fatalf("installFromConfig() dry-run = %d, want 0", got)
 	}
 }
@@ -436,27 +374,13 @@ func Test_runImport_ambiguousConfig(t *testing.T) {
 
 	cmd := newImportCmd()
 
-	orgStdout := print.Stdout
-	orgStderr := print.Stderr
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	print.Stdout = pw
-	print.Stderr = pw
+	p, buf := newTestPrinter()
 
-	got := runImport(cmd, nil)
-	pw.Close()
-	print.Stdout = orgStdout
-	print.Stderr = orgStderr
+	got := runImport(p, cmd, nil)
 
 	if got != 1 {
 		t.Errorf("runImport() = %v, want 1", got)
 	}
-
-	buf := bytes.Buffer{}
-	_, _ = io.Copy(&buf, pr)
-	pr.Close()
 
 	out := buf.String()
 	if !strings.Contains(out, "multiple gup.json") {
@@ -485,23 +409,9 @@ func Test_runImport_autoDetectSingleCandidate(t *testing.T) {
 
 	cmd := newImportCmd()
 
-	orgStdout := print.Stdout
-	orgStderr := print.Stderr
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	print.Stdout = pw
-	print.Stderr = pw
+	p, buf := newTestPrinter()
 
-	got := runImport(cmd, nil)
-	pw.Close()
-	print.Stdout = orgStdout
-	print.Stderr = orgStderr
-
-	buf := bytes.Buffer{}
-	_, _ = io.Copy(&buf, pr)
-	pr.Close()
+	got := runImport(p, cmd, nil)
 
 	out := buf.String()
 	if got != 0 {
@@ -542,7 +452,8 @@ func Test_runImport_timeoutPropagation(t *testing.T) {
 	if err := cmd.Flags().Set("timeout", "30s"); err != nil {
 		t.Fatal(err)
 	}
-	if got := runImport(cmd, nil); got != 0 {
+	p, _ := newTestPrinter()
+	if got := runImport(p, cmd, nil); got != 0 {
 		t.Fatalf("runImport() = %d, want 0", got)
 	}
 
@@ -581,7 +492,8 @@ func Test_runImport_timeoutZeroDisablesDeadline(t *testing.T) {
 	if err := cmd.Flags().Set("timeout", "0"); err != nil {
 		t.Fatal(err)
 	}
-	if got := runImport(cmd, nil); got != 0 {
+	p, _ := newTestPrinter()
+	if got := runImport(p, cmd, nil); got != 0 {
 		t.Fatalf("runImport() = %d, want 0", got)
 	}
 

--- a/cmd/jsonout.go
+++ b/cmd/jsonout.go
@@ -104,11 +104,11 @@ func resultsToJSONPackages(results []updateResult) []jsonPackage {
 // encodeJSONPackages writes records to stdout as an indented JSON array. A nil
 // or empty slice is emitted as "[]" (never "null") so consumers always receive
 // a valid JSON array.
-func encodeJSONPackages(recs []jsonPackage) error {
+func encodeJSONPackages(p *print.Printer, recs []jsonPackage) error {
 	if recs == nil {
 		recs = []jsonPackage{}
 	}
-	enc := json.NewEncoder(print.Stdout)
+	enc := json.NewEncoder(p.Out())
 	enc.SetIndent("", "  ")
 	return enc.Encode(recs)
 }

--- a/cmd/jsonout_test.go
+++ b/cmd/jsonout_test.go
@@ -156,16 +156,11 @@ func readJSON(t *testing.T, fn func() int) []jsonPackage {
 }
 
 func Test_doCheck_jsonOutput(t *testing.T) {
-	origLatest := getLatestVerCtx
-	origRef := getVerByRefCtx
-	t.Cleanup(func() {
-		getLatestVerCtx = origLatest
-		getVerByRefCtx = origRef
-	})
-	getLatestVerCtx = func(_ context.Context, _ string) (string, error) {
+	deps := testDeps()
+	deps.getLatestVer = func(_ context.Context, _ string) (string, error) {
 		return testVersionTwo, nil
 	}
-	getVerByRefCtx = func(_ context.Context, _ string, _ string) (string, error) {
+	deps.getVerByRef = func(_ context.Context, _ string, _ string) (string, error) {
 		return testVersionNine, nil
 	}
 
@@ -175,7 +170,7 @@ func Test_doCheck_jsonOutput(t *testing.T) {
 	}
 
 	recs := readJSON(t, func() int {
-		return doCheckJSON(pkgs, 1, 0, true)
+		return doCheckJSON(deps, pkgs, 1, 0, true)
 	})
 
 	got := map[string]string{}
@@ -195,9 +190,6 @@ func Test_doCheck_jsonOutput(t *testing.T) {
 // last (inverting completion order), the emitted JSON array stays in input
 // order.
 func Test_doCheckJSON_stableInputOrder(t *testing.T) {
-	origLatest := getLatestVerCtx
-	t.Cleanup(func() { getLatestVerCtx = origLatest })
-
 	const total = 6
 	pkgs := make([]goutil.Package, total)
 	sleepByModule := make(map[string]time.Duration, total)
@@ -208,13 +200,14 @@ func Test_doCheckJSON_stableInputOrder(t *testing.T) {
 		sleepByModule[p.ModulePath] = time.Duration(total-i) * 3 * time.Millisecond
 	}
 
-	getLatestVerCtx = func(_ context.Context, modulePath string) (string, error) {
+	deps := testDeps()
+	deps.getLatestVer = func(_ context.Context, modulePath string) (string, error) {
 		time.Sleep(sleepByModule[modulePath])
 		return testVersionTwo, nil
 	}
 
 	recs := readJSON(t, func() int {
-		return doCheckJSON(pkgs, total, 0, true)
+		return doCheckJSON(deps, pkgs, total, 0, true)
 	})
 
 	if len(recs) != total {
@@ -259,15 +252,10 @@ func Test_listJSONRecords(t *testing.T) {
 }
 
 func Test_updateWithChannels_jsonOutput(t *testing.T) {
-	origGetLatest := getLatestVer
-	origInstallLatest := installLatest
-	t.Cleanup(func() {
-		getLatestVer = origGetLatest
-		installLatest = origInstallLatest
-	})
+	deps := testDeps()
 	// tool: outdated -> will be updated; uptodate: already current -> up-to-date
-	getLatestVer = func(string) (string, error) { return testVersionTwo, nil }
-	installLatest = func(string) error { return nil }
+	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionTwo, nil }
+	deps.installLatest = func(context.Context, string) error { return nil }
 
 	pkgs := []goutil.Package{
 		{
@@ -293,7 +281,7 @@ func Test_updateWithChannels_jsonOutput(t *testing.T) {
 	var recs []jsonPackage
 	var result int
 	out := captureCheckOutput(t, func() int {
-		result, _, _ = updateWithChannels(pkgs, false, false, 1, true, channelMap, nil, 0, true, false)
+		result, _, _ = updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, true, false)
 		return result
 	})
 
@@ -316,9 +304,8 @@ func Test_updateWithChannels_jsonOutput(t *testing.T) {
 }
 
 func Test_doCheck_jsonOutput_errorRecord(t *testing.T) {
-	origLatest := getLatestVerCtx
-	t.Cleanup(func() { getLatestVerCtx = origLatest })
-	getLatestVerCtx = func(_ context.Context, _ string) (string, error) {
+	deps := testDeps()
+	deps.getLatestVer = func(_ context.Context, _ string) (string, error) {
 		return "", errors.New("module not found")
 	}
 
@@ -327,7 +314,7 @@ func Test_doCheck_jsonOutput_errorRecord(t *testing.T) {
 	}
 
 	recs := readJSON(t, func() int {
-		return doCheckJSON(pkgs, 1, 0, true)
+		return doCheckJSON(deps, pkgs, 1, 0, true)
 	})
 	if len(recs) != 1 {
 		t.Fatalf("got %d records, want 1", len(recs))
@@ -345,9 +332,8 @@ func Test_doCheck_jsonOutput_errorRecord(t *testing.T) {
 func Test_check_jsonFlag(t *testing.T) {
 	t.Setenv("GOBIN", filepath.Join("testdata", "check_success"))
 
-	origGetLatest := getLatestVer
-	t.Cleanup(func() { getLatestVer = origGetLatest })
-	getLatestVer = func(string) (string, error) { return testVersionNine, nil }
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionNine, nil }
 
 	cmd := newCheckCmd()
 	if err := cmd.Flags().Set("json", "true"); err != nil {
@@ -355,7 +341,7 @@ func Test_check_jsonFlag(t *testing.T) {
 	}
 
 	recs := readJSON(t, func() int {
-		return check(cmd, []string{})
+		return check(deps, cmd, []string{})
 	})
 	if len(recs) == 0 {
 		t.Fatal("expected at least one JSON record from check --json")
@@ -492,7 +478,7 @@ func Test_emptyEnv_jsonEmitsEmptyArray(t *testing.T) {
 			t.Fatal(err)
 		}
 		var got int
-		recs := readJSON(t, func() int { got = check(cmd, nil); return got })
+		recs := readJSON(t, func() int { got = check(defaultDependencies(), cmd, nil); return got })
 		if got != 0 {
 			t.Fatalf("check --json on empty env = %d, want 0", got)
 		}
@@ -508,7 +494,7 @@ func Test_emptyEnv_jsonEmitsEmptyArray(t *testing.T) {
 			t.Fatal(err)
 		}
 		var got int
-		recs := readJSON(t, func() int { got = gup(cmd, nil); return got })
+		recs := readJSON(t, func() int { got = gup(defaultDependencies(), cmd, nil); return got })
 		if got != 0 {
 			t.Fatalf("update --json on empty env = %d, want 0", got)
 		}
@@ -522,13 +508,13 @@ func Test_emptyEnv_jsonEmitsEmptyArray(t *testing.T) {
 // flag-parsing and JSON-dispatch branches in gup()/updateWithChannels are
 // covered without performing real installs.
 func Test_gup_jsonFlag(t *testing.T) {
-	helper_stubUpdateForJSON(t, func(string) error { return nil })
+	deps := helper_stubUpdateForJSON(t, func(context.Context, string) error { return nil })
 
 	cmd := helper_newJSONDryRunUpdateCmd(t)
 
 	var got int
 	recs := readJSON(t, func() int {
-		got = gup(cmd, []string{})
+		got = gup(deps, cmd, []string{})
 		return got
 	})
 	if got != 0 {
@@ -539,22 +525,20 @@ func Test_gup_jsonFlag(t *testing.T) {
 	}
 }
 
-// helper_stubUpdateForJSON stubs the update operations and points $GOBIN at the
+// helper_stubUpdateForJSON returns dependencies whose update operations are
+// stubbed (latest == v9.9.9, the given install func) and points $GOBIN at the
 // check_success fixtures so gup() can run --json end-to-end without real
-// installs. The returned readJSON helper fails the test if STDOUT is not valid
-// JSON, which is exactly the contamination this issue (#291) guards against.
-func helper_stubUpdateForJSON(t *testing.T, install func(string) error) {
+// installs. The caller passes the returned deps to gup(), and readJSON fails the
+// test if STDOUT is not valid JSON, which is exactly the contamination this
+// issue (#291) guards against.
+func helper_stubUpdateForJSON(t *testing.T, install func(context.Context, string) error) dependencies {
 	t.Helper()
 	t.Setenv("GOBIN", filepath.Join("testdata", "check_success"))
 
-	origGetLatest := getLatestVer
-	origInstallLatest := installLatest
-	t.Cleanup(func() {
-		getLatestVer = origGetLatest
-		installLatest = origInstallLatest
-	})
-	getLatestVer = func(string) (string, error) { return testVersionNine, nil }
-	installLatest = install
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionNine, nil }
+	deps.installLatest = install
+	return deps
 }
 
 // helper_newJSONDryRunUpdateCmd returns an update command with --json and
@@ -577,7 +561,7 @@ func helper_newJSONDryRunUpdateCmd(t *testing.T) *cobra.Command {
 // in normal mode. This is the core regression for issue #291: before the fix,
 // excludePkgs wrote that line to STDOUT (print.Info) and broke JSON parsing.
 func Test_gup_jsonFlag_excludeKeepsStdoutPure(t *testing.T) {
-	helper_stubUpdateForJSON(t, func(string) error { return nil })
+	deps := helper_stubUpdateForJSON(t, func(context.Context, string) error { return nil })
 
 	cmd := helper_newJSONDryRunUpdateCmd(t)
 	if err := cmd.Flags().Set("exclude", testBinPosixer); err != nil {
@@ -586,7 +570,7 @@ func Test_gup_jsonFlag_excludeKeepsStdoutPure(t *testing.T) {
 
 	var got int
 	recs := readJSON(t, func() int {
-		got = gup(cmd, []string{})
+		got = gup(deps, cmd, []string{})
 		return got
 	})
 	if got != 0 {
@@ -607,7 +591,7 @@ func Test_gup_jsonFlag_excludeKeepsStdoutPure(t *testing.T) {
 // not contaminate the JSON written to STDOUT, while the valid packages are still
 // reported. This pins STDOUT purity for the missing-targets edge case.
 func Test_gup_jsonFlag_missingFlagTargetKeepsStdoutPure(t *testing.T) {
-	helper_stubUpdateForJSON(t, func(string) error { return nil })
+	deps := helper_stubUpdateForJSON(t, func(context.Context, string) error { return nil })
 
 	cmd := helper_newJSONDryRunUpdateCmd(t)
 	if err := cmd.Flags().Set("main", "doesnotexist"); err != nil {
@@ -616,7 +600,7 @@ func Test_gup_jsonFlag_missingFlagTargetKeepsStdoutPure(t *testing.T) {
 
 	var got int
 	recs := readJSON(t, func() int {
-		got = gup(cmd, []string{})
+		got = gup(deps, cmd, []string{})
 		return got
 	})
 	if got != 0 {
@@ -631,7 +615,7 @@ func Test_gup_jsonFlag_missingFlagTargetKeepsStdoutPure(t *testing.T) {
 // fails to install, its error (emitted via print.Err to STDERR) does not
 // contaminate STDOUT and the JSON still reports a per-package error status.
 func Test_gup_jsonFlag_partialFailureKeepsStdoutPure(t *testing.T) {
-	helper_stubUpdateForJSON(t, func(importPath string) error {
+	deps := helper_stubUpdateForJSON(t, func(_ context.Context, importPath string) error {
 		if strings.Contains(importPath, testBinPosixer) {
 			return errors.New("install failed")
 		}
@@ -642,7 +626,7 @@ func Test_gup_jsonFlag_partialFailureKeepsStdoutPure(t *testing.T) {
 
 	var got int
 	recs := readJSON(t, func() int {
-		got = gup(cmd, []string{})
+		got = gup(deps, cmd, []string{})
 		return got
 	})
 	if got != 1 {

--- a/cmd/jsonout_test.go
+++ b/cmd/jsonout_test.go
@@ -1,4 +1,4 @@
-//nolint:paralleltest // tests mutate global state (print.Stdout)
+//nolint:paralleltest // tests mutate process-global state (GOBIN/XDG env, cwd)
 package cmd
 
 import (
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -77,8 +76,8 @@ func Test_newJSONPackage_nilVersionsAndError(t *testing.T) {
 }
 
 func Test_encodeJSONPackages_empty(t *testing.T) {
-	out := captureCheckOutput(t, func() int {
-		if err := encodeJSONPackages(nil); err != nil {
+	out := captureCheckOutput(t, func(p *print.Printer) int {
+		if err := encodeJSONPackages(p, nil); err != nil {
 			t.Fatalf("encodeJSONPackages() error = %v", err)
 		}
 		return 0
@@ -104,8 +103,8 @@ func Test_encodeJSONPackages_validJSON(t *testing.T) {
 		}, statusError, errors.New("network down")),
 	}
 
-	out := captureCheckOutput(t, func() int {
-		if err := encodeJSONPackages(recs); err != nil {
+	out := captureCheckOutput(t, func(p *print.Printer) int {
+		if err := encodeJSONPackages(p, recs); err != nil {
 			t.Fatalf("encodeJSONPackages() error = %v", err)
 		}
 		return 0
@@ -126,31 +125,19 @@ func Test_encodeJSONPackages_validJSON(t *testing.T) {
 	}
 }
 
-// readJSON runs fn (capturing stdout) and decodes the captured output as a
-// slice of jsonPackage records, failing the test if it is not valid JSON.
-func readJSON(t *testing.T, fn func() int) []jsonPackage {
+// readJSON runs fn with a Printer whose stdout and stderr are SEPARATE buffers,
+// then decodes only the stdout buffer as a slice of jsonPackage records. Keeping
+// the streams separate is the point: it verifies the #291 contract that warnings
+// and errors (written to stderr) never contaminate the machine-readable JSON on
+// stdout.
+func readJSON(t *testing.T, fn func(p *print.Printer) int) []jsonPackage {
 	t.Helper()
-	orgStdout := print.Stdout
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	print.Stdout = pw
-
-	fn()
-
-	_ = pw.Close()
-	print.Stdout = orgStdout
-
-	buf := bytes.Buffer{}
-	if _, err := io.Copy(&buf, pr); err != nil {
-		t.Fatal(err)
-	}
-	_ = pr.Close()
+	var out, errBuf bytes.Buffer
+	fn(print.New(&out, &errBuf))
 
 	var recs []jsonPackage
-	if err := json.Unmarshal(buf.Bytes(), &recs); err != nil {
-		t.Fatalf("stdout is not valid JSON: %v\n%s", err, buf.String())
+	if err := json.Unmarshal(out.Bytes(), &recs); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\nSTDOUT:\n%s\nSTDERR:\n%s", err, out.String(), errBuf.String())
 	}
 	return recs
 }
@@ -169,8 +156,8 @@ func Test_doCheck_jsonOutput(t *testing.T) {
 		newCheckPkg("outdated", testVersionOne, goutil.UpdateChannelLatest), // < latest -> update-available
 	}
 
-	recs := readJSON(t, func() int {
-		return doCheckJSON(deps, pkgs, 1, 0, true)
+	recs := readJSON(t, func(p *print.Printer) int {
+		return doCheckJSON(deps, p, pkgs, 1, 0, true)
 	})
 
 	got := map[string]string{}
@@ -206,8 +193,8 @@ func Test_doCheckJSON_stableInputOrder(t *testing.T) {
 		return testVersionTwo, nil
 	}
 
-	recs := readJSON(t, func() int {
-		return doCheckJSON(deps, pkgs, total, 0, true)
+	recs := readJSON(t, func(p *print.Printer) int {
+		return doCheckJSON(deps, p, pkgs, total, 0, true)
 	})
 
 	if len(recs) != total {
@@ -280,8 +267,8 @@ func Test_updateWithChannels_jsonOutput(t *testing.T) {
 
 	var recs []jsonPackage
 	var result int
-	out := captureCheckOutput(t, func() int {
-		result, _, _ = updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, true, false)
+	out := captureCheckOutput(t, func(p *print.Printer) int {
+		result, _, _ = updateWithChannels(deps, p, pkgs, false, false, 1, true, channelMap, nil, 0, true, false)
 		return result
 	})
 
@@ -313,8 +300,8 @@ func Test_doCheck_jsonOutput_errorRecord(t *testing.T) {
 		newCheckPkg("brokentool", testVersionOne, goutil.UpdateChannelLatest),
 	}
 
-	recs := readJSON(t, func() int {
-		return doCheckJSON(deps, pkgs, 1, 0, true)
+	recs := readJSON(t, func(p *print.Printer) int {
+		return doCheckJSON(deps, p, pkgs, 1, 0, true)
 	})
 	if len(recs) != 1 {
 		t.Fatalf("got %d records, want 1", len(recs))
@@ -340,8 +327,8 @@ func Test_check_jsonFlag(t *testing.T) {
 		t.Fatalf("failed to set json flag: %v", err)
 	}
 
-	recs := readJSON(t, func() int {
-		return check(deps, cmd, []string{})
+	recs := readJSON(t, func(p *print.Printer) int {
+		return check(deps, p, cmd, []string{})
 	})
 	if len(recs) == 0 {
 		t.Fatal("expected at least one JSON record from check --json")
@@ -362,8 +349,8 @@ func Test_list_jsonFlag(t *testing.T) {
 		t.Fatalf("failed to set json flag: %v", err)
 	}
 
-	recs := readJSON(t, func() int {
-		return list(cmd, []string{})
+	recs := readJSON(t, func(p *print.Printer) int {
+		return list(p, cmd, []string{})
 	})
 	if len(recs) == 0 {
 		t.Fatal("expected at least one JSON record from list --json")
@@ -407,8 +394,8 @@ func Test_list_jsonFlag_ambiguousConfigFailsFast(t *testing.T) {
 		t.Fatalf("failed to set json flag: %v", err)
 	}
 	var ambiguousGot int
-	out := captureCheckOutput(t, func() int {
-		ambiguousGot = list(ambiguousCmd, []string{})
+	out := captureCheckOutput(t, func(p *print.Printer) int {
+		ambiguousGot = list(p, ambiguousCmd, []string{})
 		return ambiguousGot
 	})
 	if ambiguousGot != 1 {
@@ -428,8 +415,8 @@ func Test_list_jsonFlag_ambiguousConfigFailsFast(t *testing.T) {
 	}
 
 	var got int
-	recs := readJSON(t, func() int {
-		got = list(cmd, []string{})
+	recs := readJSON(t, func(p *print.Printer) int {
+		got = list(p, cmd, []string{})
 		return got
 	})
 	if got != 0 {
@@ -462,7 +449,7 @@ func Test_emptyEnv_jsonEmitsEmptyArray(t *testing.T) {
 			t.Fatal(err)
 		}
 		var got int
-		recs := readJSON(t, func() int { got = list(cmd, nil); return got })
+		recs := readJSON(t, func(p *print.Printer) int { got = list(p, cmd, nil); return got })
 		if got != 0 {
 			t.Fatalf("list --json on empty env = %d, want 0", got)
 		}
@@ -478,7 +465,7 @@ func Test_emptyEnv_jsonEmitsEmptyArray(t *testing.T) {
 			t.Fatal(err)
 		}
 		var got int
-		recs := readJSON(t, func() int { got = check(defaultDependencies(), cmd, nil); return got })
+		recs := readJSON(t, func(p *print.Printer) int { got = check(defaultDependencies(), p, cmd, nil); return got })
 		if got != 0 {
 			t.Fatalf("check --json on empty env = %d, want 0", got)
 		}
@@ -494,7 +481,7 @@ func Test_emptyEnv_jsonEmitsEmptyArray(t *testing.T) {
 			t.Fatal(err)
 		}
 		var got int
-		recs := readJSON(t, func() int { got = gup(defaultDependencies(), cmd, nil); return got })
+		recs := readJSON(t, func(p *print.Printer) int { got = gup(defaultDependencies(), p, cmd, nil); return got })
 		if got != 0 {
 			t.Fatalf("update --json on empty env = %d, want 0", got)
 		}
@@ -513,8 +500,8 @@ func Test_gup_jsonFlag(t *testing.T) {
 	cmd := helper_newJSONDryRunUpdateCmd(t)
 
 	var got int
-	recs := readJSON(t, func() int {
-		got = gup(deps, cmd, []string{})
+	recs := readJSON(t, func(p *print.Printer) int {
+		got = gup(deps, p, cmd, []string{})
 		return got
 	})
 	if got != 0 {
@@ -569,8 +556,8 @@ func Test_gup_jsonFlag_excludeKeepsStdoutPure(t *testing.T) {
 	}
 
 	var got int
-	recs := readJSON(t, func() int {
-		got = gup(deps, cmd, []string{})
+	recs := readJSON(t, func(p *print.Printer) int {
+		got = gup(deps, p, cmd, []string{})
 		return got
 	})
 	if got != 0 {
@@ -599,8 +586,8 @@ func Test_gup_jsonFlag_missingFlagTargetKeepsStdoutPure(t *testing.T) {
 	}
 
 	var got int
-	recs := readJSON(t, func() int {
-		got = gup(deps, cmd, []string{})
+	recs := readJSON(t, func(p *print.Printer) int {
+		got = gup(deps, p, cmd, []string{})
 		return got
 	})
 	if got != 0 {
@@ -625,8 +612,8 @@ func Test_gup_jsonFlag_partialFailureKeepsStdoutPure(t *testing.T) {
 	cmd := helper_newJSONDryRunUpdateCmd(t)
 
 	var got int
-	recs := readJSON(t, func() int {
-		got = gup(deps, cmd, []string{})
+	recs := readJSON(t, func(p *print.Printer) int {
+		got = gup(deps, p, cmd, []string{})
 		return got
 	})
 	if got != 1 {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -22,7 +22,7 @@ func newListCmd() *cobra.Command {
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
 		Run: func(cmd *cobra.Command, args []string) {
-			OsExit(list(cmd, args))
+			OsExit(list(print.NewColorable(), cmd, args))
 		},
 	}
 	cmd.Flags().Bool("json", false, "output result as machine-readable JSON")
@@ -31,27 +31,27 @@ func newListCmd() *cobra.Command {
 	return cmd
 }
 
-func list(cmd *cobra.Command, _ []string) int {
+func list(p *print.Printer, cmd *cobra.Command, _ []string) int {
 	if err := ensureGoCommandAvailable(); err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
-	pkgs, err := pkgselect.PackageInfo()
+	pkgs, err := pkgselect.PackageInfo(p)
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
 	jsonOut, err := getFlagBool(cmd, "json")
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
 	confFile, err := getFlagString(cmd, "file")
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
@@ -62,11 +62,11 @@ func list(cmd *cobra.Command, _ []string) int {
 		// check/update (#368).
 		if len(pkgs) == 0 {
 			if err := configstate.ValidateExplicitFile(confFile); err != nil {
-				print.Err(err)
+				p.Err(err)
 				return 1
 			}
-			if err := encodeJSONPackages(listJSONRecords(nil)); err != nil {
-				print.Err(err)
+			if err := encodeJSONPackages(p, listJSONRecords(nil)); err != nil {
+				p.Err(err)
 				return 1
 			}
 			return 0
@@ -77,11 +77,11 @@ func list(cmd *cobra.Command, _ []string) int {
 		// picking the user-level one (#364).
 		annotated, cerr := configstate.ResolveAndApplyChannels(pkgs, confFile)
 		if cerr != nil {
-			print.Err(cerr)
+			p.Err(cerr)
 			return 1
 		}
-		if err := encodeJSONPackages(listJSONRecords(annotated)); err != nil {
-			print.Err(err)
+		if err := encodeJSONPackages(p, listJSONRecords(annotated)); err != nil {
+			p.Err(err)
 			return 1
 		}
 		return 0
@@ -90,11 +90,11 @@ func list(cmd *cobra.Command, _ []string) int {
 	// An empty-but-valid environment is a normal first-run condition, not an
 	// error (#350).
 	if len(pkgs) == 0 {
-		print.Info(emptyEnvMessage)
+		p.Info(emptyEnvMessage)
 		return 0
 	}
 
-	printPackageList(pkgs)
+	printPackageList(p, pkgs)
 	return 0
 }
 
@@ -110,7 +110,7 @@ func listJSONRecords(pkgs []goutil.Package) []jsonPackage {
 }
 
 // PackageList list up command package in $GOPATH/bin or $GOBIN.
-func printPackageList(pkgs []goutil.Package) {
+func printPackageList(p *print.Printer, pkgs []goutil.Package) {
 	max := 0
 	for _, v := range pkgs {
 		if len(v.Name) > max {
@@ -119,7 +119,7 @@ func printPackageList(pkgs []goutil.Package) {
 	}
 
 	for _, v := range pkgs {
-		_, _ = fmt.Fprintf(print.Stdout, "%"+strconv.Itoa(max)+"s: %s%s\n",
+		_, _ = fmt.Fprintf(p.Out(), "%"+strconv.Itoa(max)+"s: %s%s\n",
 			v.Name,
 			v.ImportPath,
 			color.GreenString("@"+v.Version.Current))

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -22,7 +22,7 @@ func newListCmd() *cobra.Command {
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
 		Run: func(cmd *cobra.Command, args []string) {
-			OsExit(list(print.NewColorable(), cmd, args))
+			OsExit(list(printerFor(cmd), cmd, args))
 		},
 	}
 	cmd.Flags().Bool("json", false, "output result as machine-readable JSON")

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"bytes"
-	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -10,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/nao1215/gup/internal/print"
 	"github.com/spf13/cobra"
 )
 
@@ -18,32 +15,11 @@ func Test_list_not_found_go_command(t *testing.T) {
 	t.Run("Not found go command", func(t *testing.T) {
 		t.Setenv("PATH", "")
 
-		orgStdout := print.Stdout
-		orgStderr := print.Stderr
-		pr, pw, err := os.Pipe()
-		if err != nil {
-			t.Fatal(err)
-		}
-		print.Stdout = pw
-		print.Stderr = pw
+		p, buf := newTestPrinter()
 
-		if got := list(&cobra.Command{}, []string{}); got != 1 {
+		if got := list(p, &cobra.Command{}, []string{}); got != 1 {
 			t.Errorf("list() = %v, want %v", got, 1)
 		}
-		if err := pw.Close(); err != nil {
-			t.Fatal(err)
-		}
-		print.Stdout = orgStdout
-		print.Stderr = orgStderr
-
-		buf := bytes.Buffer{}
-		_, err = io.Copy(&buf, pr)
-		if err != nil {
-			t.Error(err)
-		}
-		defer func() {
-			_ = pr.Close()
-		}()
 		got := strings.Split(buf.String(), "\n")
 
 		want := []string{}
@@ -128,32 +104,11 @@ func Test_list_gobin_is_empty(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("GOBIN", tt.gobin)
 
-			orgStdout := print.Stdout
-			orgStderr := print.Stderr
-			pr, pw, err := os.Pipe()
-			if err != nil {
-				t.Fatal(err)
-			}
-			print.Stdout = pw
-			print.Stderr = pw
+			p, buf := newTestPrinter()
 
-			if got := list(newListCmd(), tt.args.args); got != tt.want {
+			if got := list(p, newListCmd(), tt.args.args); got != tt.want {
 				t.Errorf("list() = %v, want %v", got, tt.want)
 			}
-			if err := pw.Close(); err != nil {
-				t.Fatal(err)
-			}
-			print.Stdout = orgStdout
-			print.Stderr = orgStderr
-
-			buf := bytes.Buffer{}
-			_, err = io.Copy(&buf, pr)
-			if err != nil {
-				t.Error(err)
-			}
-			defer func() {
-				_ = pr.Close()
-			}()
 			got := strings.Split(buf.String(), "\n")
 
 			if diff := cmp.Diff(tt.stderr, got); diff != "" {

--- a/cmd/man.go
+++ b/cmd/man.go
@@ -25,16 +25,16 @@ func newManCmd() *cobra.Command {
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
 		Run: func(cmd *cobra.Command, args []string) {
-			OsExit(man(cmd, args))
+			OsExit(man(print.NewColorable(), cmd, args))
 		},
 	}
 	return cmd
 }
 
-func man(_ *cobra.Command, _ []string) int {
+func man(p *print.Printer, _ *cobra.Command, _ []string) int {
 	for _, dst := range manPaths(os.Getenv("MANPATH")) {
-		if err := generateManpages(dst); err != nil {
-			print.Err(fmt.Errorf("can not generate man-pages in %s: %w", dst, err))
+		if err := generateManpages(p, dst); err != nil {
+			p.Err(fmt.Errorf("can not generate man-pages in %s: %w", dst, err))
 			return 1
 		}
 	}
@@ -69,7 +69,7 @@ func manPaths(manpathEnv string) []string {
 	return paths
 }
 
-func generateManpages(dst string) error {
+func generateManpages(p *print.Printer, dst string) error {
 	now := time.Now()
 	header := &doc.GenManHeader{
 		Title:   `gup - Update binaries installed by 'go install'`,
@@ -97,10 +97,10 @@ func generateManpages(dst string) error {
 		return err
 	}
 
-	return copyManpages(manFiles, dst)
+	return copyManpages(p, manFiles, dst)
 }
 
-func copyManpages(manFiles []string, dst string) error {
+func copyManpages(p *print.Printer, manFiles []string, dst string) error {
 	dst = filepath.Clean(dst)
 
 	// Ensure the target man1 directory exists before writing. A valid custom
@@ -111,18 +111,18 @@ func copyManpages(manFiles []string, dst string) error {
 	}
 
 	for _, file := range manFiles {
-		if err := copyOneManpage(filepath.Clean(file), dst); err != nil {
+		if err := copyOneManpage(p, filepath.Clean(file), dst); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func copyOneManpage(file, dst string) (err error) {
+func copyOneManpage(p *print.Printer, file, dst string) (err error) {
 	outputPath := filepath.Clean(filepath.Join(dst, filepath.Base(file)+".gz"))
 	defer func() {
 		if err == nil {
-			print.Info("Generate " + outputPath)
+			p.Info("Generate " + outputPath)
 		}
 	}()
 

--- a/cmd/man.go
+++ b/cmd/man.go
@@ -25,7 +25,7 @@ func newManCmd() *cobra.Command {
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
 		Run: func(cmd *cobra.Command, args []string) {
-			OsExit(man(print.NewColorable(), cmd, args))
+			OsExit(man(printerFor(cmd), cmd, args))
 		},
 	}
 	return cmd

--- a/cmd/man_test.go
+++ b/cmd/man_test.go
@@ -23,7 +23,8 @@ func TestGenerateManpages(t *testing.T) {
 			}
 		}()
 
-		if err := generateManpages(dst); err != nil {
+		p, _ := newTestPrinter()
+		if err := generateManpages(p, dst); err != nil {
 			t.Fatalf("generateManpages() failed: %v", err)
 		}
 
@@ -91,7 +92,7 @@ func TestMan(t *testing.T) {
 		}
 		t.Setenv("MANPATH", dst)
 
-		if got := man(nil, nil); got != 0 {
+		if got := man(discardPrinter(), nil, nil); got != 0 {
 			t.Fatalf("man() = %d, want 0", got)
 		}
 
@@ -111,7 +112,7 @@ func TestMan(t *testing.T) {
 		manpath := filepath.Join(base, "shareman")
 		t.Setenv("MANPATH", manpath)
 
-		if got := man(nil, nil); got != 0 {
+		if got := man(discardPrinter(), nil, nil); got != 0 {
 			t.Fatalf("man() = %d, want 0", got)
 		}
 
@@ -136,7 +137,7 @@ func TestMan(t *testing.T) {
 		}
 		t.Setenv("MANPATH", filepath.Join(readonly, "shareman"))
 
-		if got := man(nil, nil); got != 1 {
+		if got := man(discardPrinter(), nil, nil); got != 1 {
 			t.Fatalf("man() = %d, want 1", got)
 		}
 	})

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -63,7 +63,7 @@ If BINARY arguments are given, only those binaries are migrated.`,
 			"gup migrate /old/gobin /new/gobin"),
 		ValidArgsFunction: cobra.NoFileCompletions,
 		Run: func(cmd *cobra.Command, args []string) {
-			OsExit(runMigrate(cmd, args))
+			OsExit(runMigrate(print.NewColorable(), cmd, args))
 		},
 	}
 
@@ -77,36 +77,36 @@ If BINARY arguments are given, only those binaries are migrated.`,
 	return cmd
 }
 
-func runMigrate(cmd *cobra.Command, args []string) int {
+func runMigrate(p *print.Printer, cmd *cobra.Command, args []string) int {
 	if err := ensureGoCommandAvailable(); err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
 	dryRun, err := getFlagBool(cmd, "dry-run")
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 	notify, err := getFlagBool(cmd, "notify")
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 	cpus, err := getFlagInt(cmd, "jobs")
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 	cpus = clampJobs(cpus)
 	force, err := getFlagBool(cmd, "force")
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 	timeout, err := getTimeoutFlag(cmd)
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
@@ -115,27 +115,27 @@ func runMigrate(cmd *cobra.Command, args []string) int {
 	binaries := args[2:]
 
 	if err := validateMigratePaths(beforePath, afterPath, dryRun); err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
 	binList, err := goutil.BinaryPathList(beforePath)
 	if err != nil {
-		print.Err(fmt.Errorf("can't read binaries under %s: %w", beforePath, err))
+		p.Err(fmt.Errorf("can't read binaries under %s: %w", beforePath, err))
 		return 1
 	}
 	binList = pkgselect.FilterBinaryPaths(binList, binaries)
 	// migrate never reads GoVersion, so skip the "go version" subprocess.
-	pkgs := goutil.GetPackageInformationWithoutGoVersion(binList)
-	warnMissingMigrateTargets(binaries, pkgs, beforePath)
+	pkgs := goutil.GetPackageInformationWithoutGoVersion(p, binList)
+	warnMissingMigrateTargets(p, binaries, pkgs, beforePath)
 
 	if len(pkgs) == 0 {
-		print.Err(fmt.Errorf("no go-install binary to migrate under %s", beforePath))
+		p.Err(fmt.Errorf("no go-install binary to migrate under %s", beforePath))
 		return 1
 	}
 
-	print.Info(fmt.Sprintf("start migration from %s to %s", beforePath, afterPath))
-	return migratePackages(pkgs, afterPath, dryRun, notify, cpus, force, timeout)
+	p.Info(fmt.Sprintf("start migration from %s to %s", beforePath, afterPath))
+	return migratePackages(p, pkgs, afterPath, dryRun, notify, cpus, force, timeout)
 }
 
 // validateMigratePaths validates BEFORE_PATH and AFTER_PATH.
@@ -206,14 +206,14 @@ func sameDirPath(a, b string) (bool, error) {
 	return false, nil
 }
 
-func migratePackages(pkgs []goutil.Package, afterPath string, dryRun, notification bool, cpus int, force bool, timeout time.Duration) int {
+func migratePackages(pr *print.Printer, pkgs []goutil.Package, afterPath string, dryRun, notification bool, cpus int, force bool, timeout time.Duration) int {
 	// Point GOBIN at AFTER_PATH so the existing 'go install' path reinstalls
 	// into the target directory. Restore the environment afterward. Dry-run
 	// never installs, so the environment is left untouched.
 	if !dryRun {
 		restore, err := withGoBin(afterPath)
 		if err != nil {
-			print.Err(fmt.Errorf("can't set GOBIN to %s: %w", afterPath, err))
+			pr.Err(fmt.Errorf("can't set GOBIN to %s: %w", afterPath, err))
 			return 1
 		}
 		defer restore()
@@ -256,22 +256,22 @@ func migratePackages(pkgs []goutil.Package, afterPath string, dryRun, notificati
 		return updateResult{updated: true, pkg: p}
 	}
 
-	result, _ := executePackages(pkgs, cpus, timeout, migrator, func(prefix string, v updateResult) {
+	result, _ := executePackages(pr, pkgs, cpus, timeout, migrator, func(prefix string, v updateResult) {
 		if v.skipped {
-			print.Info(fmt.Sprintf("%s skip %s: %s", prefix, v.pkg.Name, v.skipReason))
+			pr.Info(fmt.Sprintf("%s skip %s: %s", prefix, v.pkg.Name, v.skipReason))
 			return
 		}
-		print.Info(fmt.Sprintf("%s %s@%s", prefix, v.pkg.ImportPath, v.pkg.Version.Current))
+		pr.Info(fmt.Sprintf("%s %s@%s", prefix, v.pkg.ImportPath, v.pkg.Version.Current))
 	})
 
-	desktopNotifyIfNeeded(result, notification)
+	desktopNotifyIfNeeded(pr, result, notification)
 	return result
 }
 
 // warnMissingMigrateTargets warns about each requested binary name that was not
 // found among the migration targets, mirroring the target-selection UX of
 // 'gup update'. It is a no-op when no binaries were explicitly requested.
-func warnMissingMigrateTargets(targets []string, pkgs []goutil.Package, beforePath string) {
+func warnMissingMigrateTargets(pr *print.Printer, targets []string, pkgs []goutil.Package, beforePath string) {
 	if len(targets) == 0 {
 		return
 	}
@@ -292,7 +292,7 @@ func warnMissingMigrateTargets(targets []string, pkgs []goutil.Package, beforePa
 		}
 		seen[normalized] = struct{}{}
 		if _, ok := present[normalized]; !ok {
-			print.Warn("not found '" + strings.TrimSpace(raw) + "' package in " + beforePath)
+			pr.Warn("not found '" + strings.TrimSpace(raw) + "' package in " + beforePath)
 		}
 	}
 }

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -63,7 +63,7 @@ If BINARY arguments are given, only those binaries are migrated.`,
 			"gup migrate /old/gobin /new/gobin"),
 		ValidArgsFunction: cobra.NoFileCompletions,
 		Run: func(cmd *cobra.Command, args []string) {
-			OsExit(runMigrate(print.NewColorable(), cmd, args))
+			OsExit(runMigrate(printerFor(cmd), cmd, args))
 		},
 	}
 

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -2,7 +2,6 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -86,19 +85,12 @@ const (
 	testUnknown           = "unknown"
 )
 
-// captureMigrateOutput redirects print output into a buffer for the duration of fn.
-func captureMigrateOutput(t *testing.T, fn func()) string {
+// captureMigrateOutput runs fn with a buffer-backed printer and returns the
+// captured output.
+func captureMigrateOutput(t *testing.T, fn func(p *print.Printer)) string {
 	t.Helper()
-	orgStdout := print.Stdout
-	orgStderr := print.Stderr
-	buf := &bytes.Buffer{}
-	print.Stdout = buf
-	print.Stderr = buf
-	defer func() {
-		print.Stdout = orgStdout
-		print.Stderr = orgStderr
-	}()
-	fn()
+	p, buf := newTestPrinter()
+	fn(p)
 	return buf.String()
 }
 
@@ -274,8 +266,8 @@ func Test_migratePackages_install(t *testing.T) {
 		{Name: testBinTool, ImportPath: testImportPathTool, Version: &goutil.Version{Current: testVersion123}},
 	}
 
-	out := captureMigrateOutput(t, func() {
-		if got := migratePackages(pkgs, after, false, false, 1, false, 0); got != 0 {
+	out := captureMigrateOutput(t, func(p *print.Printer) {
+		if got := migratePackages(p, pkgs, after, false, false, 1, false, 0); got != 0 {
 			t.Fatalf("migratePackages() = %d, want 0", got)
 		}
 	})
@@ -311,8 +303,8 @@ func Test_migratePackages_addOnlySkip(t *testing.T) {
 		{Name: testBinTool, ImportPath: testImportPathTool, Version: &goutil.Version{Current: testVersion123}},
 	}
 
-	out := captureMigrateOutput(t, func() {
-		if got := migratePackages(pkgs, after, false, false, 1, false, 0); got != 0 {
+	out := captureMigrateOutput(t, func(p *print.Printer) {
+		if got := migratePackages(p, pkgs, after, false, false, 1, false, 0); got != 0 {
 			t.Fatalf("migratePackages() = %d, want 0", got)
 		}
 	})
@@ -346,8 +338,8 @@ func Test_migratePackages_force(t *testing.T) {
 		{Name: testBinTool, ImportPath: testImportPathTool, Version: &goutil.Version{Current: testVersion123}},
 	}
 
-	captureMigrateOutput(t, func() {
-		if got := migratePackages(pkgs, after, false, false, 1, true, 0); got != 0 {
+	captureMigrateOutput(t, func(p *print.Printer) {
+		if got := migratePackages(p, pkgs, after, false, false, 1, true, 0); got != 0 {
 			t.Fatalf("migratePackages() = %d, want 0", got)
 		}
 	})
@@ -373,8 +365,8 @@ func Test_migratePackages_dryRun(t *testing.T) {
 		{Name: testBinTool, ImportPath: testImportPathTool, Version: &goutil.Version{Current: testVersion123}},
 	}
 
-	captureMigrateOutput(t, func() {
-		if got := migratePackages(pkgs, after, true, false, 1, false, 0); got != 0 {
+	captureMigrateOutput(t, func(p *print.Printer) {
+		if got := migratePackages(p, pkgs, after, true, false, 1, false, 0); got != 0 {
 			t.Fatalf("migratePackages() dry-run = %d, want 0", got)
 		}
 	})
@@ -403,8 +395,8 @@ func Test_migratePackages_skipDevelAndUnknown(t *testing.T) {
 		{Name: "good", ImportPath: "github.com/example/good", Version: &goutil.Version{Current: testVersionOne}},
 	}
 
-	captureMigrateOutput(t, func() {
-		if got := migratePackages(pkgs, after, false, false, 2, false, 0); got != 0 {
+	captureMigrateOutput(t, func(p *print.Printer) {
+		if got := migratePackages(p, pkgs, after, false, false, 2, false, 0); got != 0 {
 			t.Fatalf("migratePackages() = %d, want 0", got)
 		}
 	})
@@ -439,8 +431,8 @@ func Test_migratePackages_modulePathMismatchRetry(t *testing.T) {
 		},
 	}
 
-	captureMigrateOutput(t, func() {
-		if got := migratePackages(pkgs, after, false, false, 1, false, 0); got != 0 {
+	captureMigrateOutput(t, func(p *print.Printer) {
+		if got := migratePackages(p, pkgs, after, false, false, 1, false, 0); got != 0 {
 			t.Fatalf("migratePackages() = %d, want 0", got)
 		}
 	})
@@ -468,8 +460,8 @@ func Test_migratePackages_installError(t *testing.T) {
 		{Name: testBinTool, ImportPath: testImportPathTool, Version: &goutil.Version{Current: testVersionOne}},
 	}
 
-	captureMigrateOutput(t, func() {
-		if got := migratePackages(pkgs, after, false, false, 1, false, 0); got != 1 {
+	captureMigrateOutput(t, func(p *print.Printer) {
+		if got := migratePackages(p, pkgs, after, false, false, 1, false, 0); got != 1 {
 			t.Fatalf("migratePackages() = %d, want 1 on install error", got)
 		}
 	})
@@ -490,8 +482,8 @@ func Test_migratePackages_jobsBoundary(t *testing.T) {
 	}
 
 	for _, jobs := range []int{-1, 0, 1, 100} {
-		captureMigrateOutput(t, func() {
-			if got := migratePackages(pkgs, after, false, false, jobs, false, 0); got != 0 {
+		captureMigrateOutput(t, func(p *print.Printer) {
+			if got := migratePackages(p, pkgs, after, false, false, jobs, false, 0); got != 0 {
 				t.Fatalf("migratePackages(jobs=%d) = %d, want 0", jobs, got)
 			}
 		})
@@ -513,8 +505,8 @@ func Test_runMigrate_filterByBinary(t *testing.T) {
 	}
 
 	cmd := newMigrateCmd()
-	captureMigrateOutput(t, func() {
-		if got := runMigrate(cmd, []string{before, after, testBinPosixer}); got != 0 {
+	captureMigrateOutput(t, func(p *print.Printer) {
+		if got := runMigrate(p, cmd, []string{before, after, testBinPosixer}); got != 0 {
 			t.Fatalf("runMigrate() = %d, want 0", got)
 		}
 	})
@@ -542,9 +534,9 @@ func Test_runMigrate_missingTargetWarning(t *testing.T) {
 	}
 
 	cmd := newMigrateCmd()
-	out := captureMigrateOutput(t, func() {
+	out := captureMigrateOutput(t, func(p *print.Printer) {
 		// "posixer" exists in testdata; "doesnotexist" does not.
-		if got := runMigrate(cmd, []string{before, after, testBinPosixer, "doesnotexist"}); got != 0 {
+		if got := runMigrate(p, cmd, []string{before, after, testBinPosixer, "doesnotexist"}); got != 0 {
 			t.Fatalf("runMigrate() = %d, want 0", got)
 		}
 	})
@@ -563,8 +555,8 @@ func Test_runMigrate_allTargetsMissingWarns(t *testing.T) {
 	t.Setenv("GOBIN", t.TempDir())
 
 	cmd := newMigrateCmd()
-	out := captureMigrateOutput(t, func() {
-		if got := runMigrate(cmd, []string{before, after, "nope1", "nope2"}); got != 1 {
+	out := captureMigrateOutput(t, func(p *print.Printer) {
+		if got := runMigrate(p, cmd, []string{before, after, "nope1", "nope2"}); got != 1 {
 			t.Fatalf("runMigrate() = %d, want 1 when no requested binary exists", got)
 		}
 	})
@@ -577,8 +569,8 @@ func Test_runMigrate_allTargetsMissingWarns(t *testing.T) {
 func Test_runMigrate_sameDirError(t *testing.T) {
 	dir := t.TempDir()
 	cmd := newMigrateCmd()
-	out := captureMigrateOutput(t, func() {
-		if got := runMigrate(cmd, []string{dir, dir}); got != 1 {
+	out := captureMigrateOutput(t, func(p *print.Printer) {
+		if got := runMigrate(p, cmd, []string{dir, dir}); got != 1 {
 			t.Fatalf("runMigrate() = %d, want 1 for same directory", got)
 		}
 	})
@@ -589,8 +581,8 @@ func Test_runMigrate_sameDirError(t *testing.T) {
 
 func Test_runMigrate_beforeNotFound(t *testing.T) {
 	cmd := newMigrateCmd()
-	captureMigrateOutput(t, func() {
-		if got := runMigrate(cmd, []string{filepath.Join(t.TempDir(), "missing"), t.TempDir()}); got != 1 {
+	captureMigrateOutput(t, func(p *print.Printer) {
+		if got := runMigrate(p, cmd, []string{filepath.Join(t.TempDir(), "missing"), t.TempDir()}); got != 1 {
 			t.Fatalf("runMigrate() = %d, want 1 for missing BEFORE_PATH", got)
 		}
 	})

--- a/cmd/parallel.go
+++ b/cmd/parallel.go
@@ -60,15 +60,15 @@ func summarizeResults(results []updateResult, isCheck bool) string {
 // showInQuiet are printed, without the "[i/n]" counter (which would be sparse);
 // otherwise every line is printed with the counter. The returned callback is
 // passed to executePackages as onResult.
-func resultLineRenderer(quiet bool, showInQuiet func(updateResult) bool, resultStr func(goutil.Package) string) func(string, updateResult) {
+func resultLineRenderer(p *print.Printer, quiet bool, showInQuiet func(updateResult) bool, resultStr func(goutil.Package) string) func(string, updateResult) {
 	return func(prefix string, v updateResult) {
 		if quiet {
 			if showInQuiet(v) {
-				print.Info(fmt.Sprintf("%s (%s)", v.pkg.ImportPath, resultStr(v.pkg)))
+				p.Info(fmt.Sprintf("%s (%s)", v.pkg.ImportPath, resultStr(v.pkg)))
 			}
 			return
 		}
-		print.Info(fmt.Sprintf("%s %s (%s)", prefix, v.pkg.ImportPath, resultStr(v.pkg)))
+		p.Info(fmt.Sprintf("%s %s (%s)", prefix, v.pkg.ImportPath, resultStr(v.pkg)))
 	}
 }
 
@@ -84,7 +84,7 @@ func resultLineRenderer(quiet bool, showInQuiet func(updateResult) bool, resultS
 // slice is in input order, so machine-readable (--json) output is deterministic
 // across runs regardless of worker scheduling (#365). onResult may be nil
 // (used by --json callers that render from the returned results instead).
-func executePackages(pkgs []goutil.Package, cpus int, timeout time.Duration,
+func executePackages(p *print.Printer, pkgs []goutil.Package, cpus int, timeout time.Duration,
 	worker func(context.Context, goutil.Package) updateResult,
 	onResult func(prefix string, v updateResult)) (int, []updateResult) {
 	ctx, cancel, signals := newSignalCancelContext()
@@ -100,9 +100,9 @@ func executePackages(pkgs []goutil.Package, cpus int, timeout time.Duration,
 			prefix := fmt.Sprintf(countFmt, done, total)
 			if v.err != nil {
 				exitCode = 1
-				print.Err(fmt.Errorf("%s %s", prefix, v.err.Error()))
+				p.Err(fmt.Errorf("%s %s", prefix, v.err.Error()))
 				if hint := diagnose.Hint(v.err); hint != "" {
-					print.Hint(hint)
+					p.Hint(hint)
 				}
 			} else if onResult != nil {
 				onResult(prefix, v)

--- a/cmd/parallel_test.go
+++ b/cmd/parallel_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"strconv"
@@ -11,7 +10,6 @@ import (
 	"time"
 
 	"github.com/nao1215/gup/internal/goutil"
-	"github.com/nao1215/gup/internal/print"
 )
 
 // Package names reused across the parallel tests, extracted to constants to
@@ -65,8 +63,9 @@ func TestExecutePackages_TimeoutIsolation(t *testing.T) {
 		{Name: pkgSlow},
 	}
 
+	p, _ := newTestPrinter()
 	var succeeded int64
-	code, results := executePackages(pkgs, 2, 20*time.Millisecond,
+	code, results := executePackages(p, pkgs, 2, 20*time.Millisecond,
 		func(ctx context.Context, p goutil.Package) updateResult {
 			if p.Name == pkgSlow {
 				<-ctx.Done()
@@ -116,7 +115,8 @@ func TestExecutePackages_StableInputOrder(t *testing.T) {
 		sleepByName[p.Name] = time.Duration(total-i) * 3 * time.Millisecond
 	}
 
-	code, results := executePackages(pkgs, total, 0,
+	p, _ := newTestPrinter()
+	code, results := executePackages(p, pkgs, total, 0,
 		func(_ context.Context, p goutil.Package) updateResult {
 			time.Sleep(sleepByName[p.Name])
 			return updateResult{pkg: p, status: statusUpdated}
@@ -165,7 +165,8 @@ func TestExecutePackages_StableInputOrderWithFailures(t *testing.T) {
 		failByName[p.Name] = i%2 == 0
 	}
 
-	code, results := executePackages(pkgs, total, 0,
+	p, _ := newTestPrinter()
+	code, results := executePackages(p, pkgs, total, 0,
 		func(_ context.Context, p goutil.Package) updateResult {
 			time.Sleep(sleepByName[p.Name])
 			if failByName[p.Name] {
@@ -197,18 +198,15 @@ func TestExecutePackages_StableInputOrderWithFailures(t *testing.T) {
 // deterministic), a failed package prints the shared "[i/n] <error>" line to
 // STDERR and is NOT passed to onResult, while successful packages reach onResult
 // with their "[i/n]" prefix and the exit code becomes 1.
-//
-//nolint:paralleltest // captures the global print.Stderr
 func TestExecutePackages_streamsPrefixesAndReportsErrors(t *testing.T) {
-	orgStderr := print.Stderr
-	var buf bytes.Buffer
-	print.Stderr = &buf
-	t.Cleanup(func() { print.Stderr = orgStderr })
+	t.Parallel()
+
+	p, buf := newTestPrinter()
 
 	pkgs := []goutil.Package{{Name: "a"}, {Name: pkgFail}, {Name: "c"}}
 
 	var prefixes []string
-	code, results := executePackages(pkgs, 1, 0,
+	code, results := executePackages(p, pkgs, 1, 0,
 		func(_ context.Context, p goutil.Package) updateResult {
 			if p.Name == pkgFail {
 				return updateResult{pkg: p, err: errors.New("boom")}

--- a/cmd/pin.go
+++ b/cmd/pin.go
@@ -41,7 +41,7 @@ development environment). Run 'gup unpin' to allow the tool to update again.`,
 		Args:              cobra.RangeArgs(pinMinArgs, pinMaxArgs),
 		ValidArgsFunction: completePathBinaries,
 		Run: func(cmd *cobra.Command, args []string) {
-			OsExit(runPin(print.NewColorable(), cmd, args))
+			OsExit(runPin(printerFor(cmd), cmd, args))
 		},
 	}
 	cmd.Flags().StringP("file", "f", "", "specify gup.json file path to read/write")
@@ -62,7 +62,7 @@ nothing and succeeds.`,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completePathBinaries,
 		Run: func(cmd *cobra.Command, args []string) {
-			OsExit(runUnpin(print.NewColorable(), cmd, args))
+			OsExit(runUnpin(printerFor(cmd), cmd, args))
 		},
 	}
 	cmd.Flags().StringP("file", "f", "", "specify gup.json file path to read/write")

--- a/cmd/pin.go
+++ b/cmd/pin.go
@@ -41,7 +41,7 @@ development environment). Run 'gup unpin' to allow the tool to update again.`,
 		Args:              cobra.RangeArgs(pinMinArgs, pinMaxArgs),
 		ValidArgsFunction: completePathBinaries,
 		Run: func(cmd *cobra.Command, args []string) {
-			OsExit(runPin(cmd, args))
+			OsExit(runPin(print.NewColorable(), cmd, args))
 		},
 	}
 	cmd.Flags().StringP("file", "f", "", "specify gup.json file path to read/write")
@@ -62,7 +62,7 @@ nothing and succeeds.`,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completePathBinaries,
 		Run: func(cmd *cobra.Command, args []string) {
-			OsExit(runUnpin(cmd, args))
+			OsExit(runUnpin(print.NewColorable(), cmd, args))
 		},
 	}
 	cmd.Flags().StringP("file", "f", "", "specify gup.json file path to read/write")
@@ -102,63 +102,63 @@ func parsePinArgs(args []string) (target, version string, err error) {
 	return target, version, nil
 }
 
-func runPin(cmd *cobra.Command, args []string) int {
+func runPin(p *print.Printer, cmd *cobra.Command, args []string) int {
 	if err := ensureGoCommandAvailable(); err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
 	target, version, err := parsePinArgs(args)
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
 	confFile, err := getFlagString(cmd, "file")
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
-	installed, err := pinPackageInfo()
+	installed, err := pinPackageInfo(p)
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 	pkg, err := resolvePinTarget(installed, target)
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
 	confReadPath, err := config.ResolveImportFilePath(confFile)
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 	confPkgs, err := configstate.ReadFileIfExists(confReadPath)
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
 	merged, err := configstate.SetPin(confPkgs, pkg, version)
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
 	writePath := configstate.ResolveWritePath(confFile, confReadPath)
 	if err := writeConfigFile(writePath, merged); err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
-	print.Info(fmt.Sprintf("Pinned %s to %s (run 'gup update' to apply)", pkg.Name, version))
+	p.Info(fmt.Sprintf("Pinned %s to %s (run 'gup update' to apply)", pkg.Name, version))
 	return 0
 }
 
-func runUnpin(cmd *cobra.Command, args []string) int {
+func runUnpin(p *print.Printer, cmd *cobra.Command, args []string) int {
 	// unpin only edits gup.json (channel back to @latest); it never runs the Go
 	// toolchain, so it must not fail when 'go' is absent.
 	target := strings.TrimSpace(args[0])
@@ -166,40 +166,40 @@ func runUnpin(cmd *cobra.Command, args []string) int {
 		target = strings.TrimSpace(target[:i])
 	}
 	if target == "" {
-		print.Err(errors.New("missing tool name"))
+		p.Err(errors.New("missing tool name"))
 		return 1
 	}
 
 	confFile, err := getFlagString(cmd, "file")
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
 	confReadPath, err := config.ResolveImportFilePath(confFile)
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 	confPkgs, err := configstate.ReadFileIfExists(confReadPath)
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
 	merged, changed := configstate.RemovePin(confPkgs, targetPackage(target))
 	if !changed {
-		print.Info(target + " is not pinned; nothing to do")
+		p.Info(target + " is not pinned; nothing to do")
 		return 0
 	}
 
 	writePath := configstate.ResolveWritePath(confFile, confReadPath)
 	if err := writeConfigFile(writePath, merged); err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
-	print.Info("Unpinned " + target)
+	p.Info("Unpinned " + target)
 	return 0
 }
 

--- a/cmd/pin_run_test.go
+++ b/cmd/pin_run_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nao1215/gup/internal/config"
 	"github.com/nao1215/gup/internal/goutil"
+	"github.com/nao1215/gup/internal/print"
 )
 
 // stubPinPackageInfo swaps the installed-package lister for the duration of a
@@ -15,7 +16,7 @@ import (
 func stubPinPackageInfo(t *testing.T, pkgs []goutil.Package) {
 	t.Helper()
 	orig := pinPackageInfo
-	pinPackageInfo = func() ([]goutil.Package, error) { return pkgs, nil }
+	pinPackageInfo = func(*print.Printer) ([]goutil.Package, error) { return pkgs, nil }
 	t.Cleanup(func() { pinPackageInfo = orig })
 }
 
@@ -39,7 +40,8 @@ func TestRunPin_writesPinnedConfig(t *testing.T) {
 		{Name: testBinTool, ImportPath: pinnedTestImport, Version: &goutil.Version{Current: "v0.9.0"}},
 	})
 
-	if code := runPin(newPinCmd(), []string{testBinTool, testVersionOne}); code != 0 {
+	p, _ := newTestPrinter()
+	if code := runPin(p, newPinCmd(), []string{testBinTool, testVersionOne}); code != 0 {
 		t.Fatalf("runPin() = %d, want 0", code)
 	}
 
@@ -62,7 +64,8 @@ func TestRunPin_unmanagedToolFails(t *testing.T) {
 		{Name: "other", ImportPath: "example.com/other", Version: &goutil.Version{Current: testVersionOne}},
 	})
 
-	if code := runPin(newPinCmd(), []string{testBinTool, testVersionOne}); code != 1 {
+	p, _ := newTestPrinter()
+	if code := runPin(p, newPinCmd(), []string{testBinTool, testVersionOne}); code != 1 {
 		t.Fatalf("runPin() for an unmanaged tool = %d, want 1", code)
 	}
 	// Nothing must be written when the pin target can't be resolved.
@@ -79,7 +82,8 @@ func TestRunPin_invalidVersionFails(t *testing.T) {
 	})
 
 	// "latest" is a channel keyword, not a concrete version: pin must reject it.
-	if code := runPin(newPinCmd(), []string{testBinTool, string(goutil.UpdateChannelLatest)}); code != 1 {
+	p, _ := newTestPrinter()
+	if code := runPin(p, newPinCmd(), []string{testBinTool, string(goutil.UpdateChannelLatest)}); code != 1 {
 		t.Fatalf("runPin() with a channel keyword as version = %d, want 1", code)
 	}
 }
@@ -91,7 +95,8 @@ func TestRunUnpin_clearsPin(t *testing.T) {
 		{"name":"tool","import_path":"example.com/tool","version":"v1.0.0","channel":"pinned"}
 	]}`)
 
-	if code := runUnpin(newUnpinCmd(), []string{testBinTool}); code != 0 {
+	p, _ := newTestPrinter()
+	if code := runUnpin(p, newUnpinCmd(), []string{testBinTool}); code != 0 {
 		t.Fatalf("runUnpin() = %d, want 0", code)
 	}
 
@@ -119,7 +124,8 @@ func TestRunUnpin_notPinnedIsIdempotent(t *testing.T) {
 		{"name":"tool","import_path":"example.com/tool","version":"v1.0.0","channel":"latest"}
 	]}`)
 
-	if code := runUnpin(newUnpinCmd(), []string{testBinTool}); code != 0 {
+	p, _ := newTestPrinter()
+	if code := runUnpin(p, newUnpinCmd(), []string{testBinTool}); code != 0 {
 		t.Fatalf("runUnpin() on a non-pinned tool = %d, want 0 (idempotent)", code)
 	}
 }
@@ -128,7 +134,8 @@ func TestRunUnpin_notPinnedIsIdempotent(t *testing.T) {
 func TestRunUnpin_missingToolName(t *testing.T) {
 	setupXDGBase(t)
 	// "@" strips to an empty target, which must be rejected.
-	if code := runUnpin(newUnpinCmd(), []string{"@"}); code != 1 {
+	p, _ := newTestPrinter()
+	if code := runUnpin(p, newUnpinCmd(), []string{"@"}); code != 1 {
 		t.Fatalf("runUnpin() with an empty tool name = %d, want 1", code)
 	}
 }
@@ -138,7 +145,8 @@ func TestRunUnpin_malformedConfigFails(t *testing.T) {
 	setupXDGBase(t)
 	writeUserConfig(t, `{"schema_version":1,"packages":[`) // truncated JSON
 
-	if code := runUnpin(newUnpinCmd(), []string{testBinTool}); code != 1 {
+	p, _ := newTestPrinter()
+	if code := runUnpin(p, newUnpinCmd(), []string{testBinTool}); code != 1 {
 		t.Fatalf("runUnpin() with a malformed config = %d, want 1", code)
 	}
 }
@@ -151,7 +159,8 @@ func TestRunPin_malformedConfigFails(t *testing.T) {
 	})
 	writeUserConfig(t, `{"schema_version":1,"packages":[`) // truncated JSON
 
-	if code := runPin(newPinCmd(), []string{testBinTool, testVersionOne}); code != 1 {
+	p, _ := newTestPrinter()
+	if code := runPin(p, newPinCmd(), []string{testBinTool, testVersionOne}); code != 1 {
 		t.Fatalf("runPin() with a malformed config = %d, want 1", code)
 	}
 }

--- a/cmd/pinned_update_test.go
+++ b/cmd/pinned_update_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -28,28 +29,27 @@ func pinnedTestPkg(installed, pinned string) goutil.Package {
 	}
 }
 
-//nolint:paralleltest // swaps package-level install stubs; must not run in parallel
 func TestUpdatePinned_reinstallsAtPinWhenDifferent(t *testing.T) {
+	t.Parallel()
 	var gotImport, gotVersion string
 	called := false
-	installByVersionUpd = func(importPath, version string) error {
+	deps := testDeps()
+	deps.installByVersion = func(_ context.Context, importPath, version string) error {
 		called = true
 		gotImport, gotVersion = importPath, version
 		return nil
 	}
-	getLatestVer = func(string) (string, error) {
+	deps.getLatestVer = func(context.Context, string) (string, error) {
 		t.Fatal("pinned update must not resolve @latest")
 		return "", nil
 	}
-	installLatest = func(string) error { t.Fatal("pinned update must not install @latest"); return nil }
-	defer func() {
-		installByVersionUpd = goutil.Install
-		getLatestVer = goutil.GetLatestVer
-		installLatest = goutil.InstallLatest
-	}()
+	deps.installLatest = func(context.Context, string) error {
+		t.Fatal("pinned update must not install @latest")
+		return nil
+	}
 
 	p := pinnedTestPkg("v1.1.0", testVersionOne)
-	res := updatePinned(defaultDependencies(), t.Context(), p, false)
+	res := updatePinned(deps, t.Context(), p, false)
 	if !called {
 		t.Fatal("expected go install <path>@<pinned> to be called")
 	}
@@ -61,16 +61,16 @@ func TestUpdatePinned_reinstallsAtPinWhenDifferent(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // swaps package-level install stubs; must not run in parallel
 func TestUpdatePinned_skipsWhenAlreadyAtPin(t *testing.T) {
-	installByVersionUpd = func(string, string) error {
+	t.Parallel()
+	deps := testDeps()
+	deps.installByVersion = func(context.Context, string, string) error {
 		t.Fatal("must not reinstall when already at the pinned version")
 		return nil
 	}
-	defer func() { installByVersionUpd = goutil.Install }()
 
 	p := pinnedTestPkg(testVersionOne, testVersionOne)
-	res := updatePinned(defaultDependencies(), t.Context(), p, false)
+	res := updatePinned(deps, t.Context(), p, false)
 	if res.updated {
 		t.Error("updated = true, want false when already at the pin")
 	}
@@ -82,16 +82,16 @@ func TestUpdatePinned_skipsWhenAlreadyAtPin(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // swaps package-level install stubs; must not run in parallel
 func TestUpdatePinned_emptyPinIsError(t *testing.T) {
-	installByVersionUpd = func(string, string) error {
+	t.Parallel()
+	deps := testDeps()
+	deps.installByVersion = func(context.Context, string, string) error {
 		t.Fatal("must not install when the pin target is missing")
 		return nil
 	}
-	defer func() { installByVersionUpd = goutil.Install }()
 
 	p := pinnedTestPkg("v1.0.0", "")
-	res := updatePinned(defaultDependencies(), t.Context(), p, false)
+	res := updatePinned(deps, t.Context(), p, false)
 	if res.err == nil {
 		t.Fatal("expected an error for a pin with no recorded version, never a silent @latest")
 	}
@@ -133,19 +133,19 @@ func TestCheckPinned_goToolchainOutdated(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // swaps package-level install stubs; must not run in parallel
 func TestUpdatePinned_reinstallsWhenGoOutdated(t *testing.T) {
+	t.Parallel()
 	var gotVersion string
 	called := false
-	installByVersionUpd = func(_ string, version string) error {
+	deps := testDeps()
+	deps.installByVersion = func(_ context.Context, _ string, version string) error {
 		called = true
 		gotVersion = version
 		return nil
 	}
-	defer func() { installByVersionUpd = goutil.Install }()
 
 	// Version already matches the pin, only the Go toolchain is newer.
-	res := updatePinned(defaultDependencies(), t.Context(), pinnedStaleGo(), false)
+	res := updatePinned(deps, t.Context(), pinnedStaleGo(), false)
 	if !called {
 		t.Fatal("expected a reinstall at the pinned version when the Go toolchain is newer")
 	}
@@ -157,15 +157,15 @@ func TestUpdatePinned_reinstallsWhenGoOutdated(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // swaps package-level install stubs; must not run in parallel
 func TestUpdatePinned_ignoreGoUpdateKeepsPin(t *testing.T) {
-	installByVersionUpd = func(string, string) error {
+	t.Parallel()
+	deps := testDeps()
+	deps.installByVersion = func(context.Context, string, string) error {
 		t.Fatal("must not reinstall a satisfied pin when Go updates are ignored")
 		return nil
 	}
-	defer func() { installByVersionUpd = goutil.Install }()
 
-	res := updatePinned(defaultDependencies(), t.Context(), pinnedStaleGo(), true)
+	res := updatePinned(deps, t.Context(), pinnedStaleGo(), true)
 	if res.updated || res.status != statusPinned {
 		t.Errorf("result updated=%v status=%q, want kept/pinned", res.updated, res.status)
 	}

--- a/cmd/quiet_test.go
+++ b/cmd/quiet_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/nao1215/gup/internal/goutil"
+	"github.com/nao1215/gup/internal/print"
 )
 
 const (
@@ -50,8 +51,8 @@ func Test_updateWithChannels_quiet(t *testing.T) {
 	}
 
 	var got int
-	out := captureCheckOutput(t, func() int {
-		got, _, _ = updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, true)
+	out := captureCheckOutput(t, func(p *print.Printer) int {
+		got, _, _ = updateWithChannels(deps, p, pkgs, false, false, 1, true, channelMap, nil, 0, false, true)
 		return got
 	})
 	if got != 0 {
@@ -89,8 +90,8 @@ func Test_updateWithChannels_quiet_failed(t *testing.T) {
 	channelMap := map[string]goutil.UpdateChannel{quietNameUpdated: goutil.UpdateChannelLatest}
 
 	var got int
-	out := captureCheckOutput(t, func() int {
-		got, _, _ = updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, true)
+	out := captureCheckOutput(t, func(p *print.Printer) int {
+		got, _, _ = updateWithChannels(deps, p, pkgs, false, false, 1, true, channelMap, nil, 0, false, true)
 		return got
 	})
 	if got != 1 {
@@ -113,8 +114,8 @@ func Test_doCheck_quiet(t *testing.T) {
 	pkgs := quietMixedPkgs()
 
 	var got int
-	out := captureCheckOutput(t, func() int {
-		got = doCheck(deps, pkgs, 1, 0, true, true)
+	out := captureCheckOutput(t, func(p *print.Printer) int {
+		got = doCheck(deps, p, pkgs, 1, 0, true, true)
 		return got
 	})
 	if got != 0 {
@@ -152,8 +153,8 @@ func Test_updateWithChannels_jsonQuiet(t *testing.T) {
 		quietNameUpToDate: goutil.UpdateChannelLatest,
 	}
 
-	recs := readJSON(t, func() int {
-		got, _, _ := updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, true, true)
+	recs := readJSON(t, func(p *print.Printer) int {
+		got, _, _ := updateWithChannels(deps, p, pkgs, false, false, 1, true, channelMap, nil, 0, true, true)
 		return got
 	})
 	if len(recs) != 2 {

--- a/cmd/quiet_test.go
+++ b/cmd/quiet_test.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -38,14 +39,9 @@ func quietMixedPkgs() []goutil.Package {
 }
 
 func Test_updateWithChannels_quiet(t *testing.T) {
-	origGetLatest := getLatestVer
-	origInstallLatest := installLatest
-	defer func() {
-		getLatestVer = origGetLatest
-		installLatest = origInstallLatest
-	}()
-	getLatestVer = func(string) (string, error) { return testVersionNine, nil }
-	installLatest = func(string) error { return nil }
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionNine, nil }
+	deps.installLatest = func(context.Context, string) error { return nil }
 
 	pkgs := quietMixedPkgs()
 	channelMap := map[string]goutil.UpdateChannel{
@@ -55,7 +51,7 @@ func Test_updateWithChannels_quiet(t *testing.T) {
 
 	var got int
 	out := captureCheckOutput(t, func() int {
-		got, _, _ = updateWithChannels(pkgs, false, false, 1, true, channelMap, nil, 0, false, true)
+		got, _, _ = updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, true)
 		return got
 	})
 	if got != 0 {
@@ -77,14 +73,9 @@ func Test_updateWithChannels_quiet(t *testing.T) {
 }
 
 func Test_updateWithChannels_quiet_failed(t *testing.T) {
-	origGetLatest := getLatestVer
-	origInstallLatest := installLatest
-	defer func() {
-		getLatestVer = origGetLatest
-		installLatest = origInstallLatest
-	}()
-	getLatestVer = func(string) (string, error) { return testVersionNine, nil }
-	installLatest = func(string) error { return errors.New("install failed") }
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionNine, nil }
+	deps.installLatest = func(context.Context, string) error { return errors.New("install failed") }
 
 	pkgs := []goutil.Package{
 		{
@@ -99,7 +90,7 @@ func Test_updateWithChannels_quiet_failed(t *testing.T) {
 
 	var got int
 	out := captureCheckOutput(t, func() int {
-		got, _, _ = updateWithChannels(pkgs, false, false, 1, true, channelMap, nil, 0, false, true)
+		got, _, _ = updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, true)
 		return got
 	})
 	if got != 1 {
@@ -116,15 +107,14 @@ func Test_updateWithChannels_quiet_failed(t *testing.T) {
 }
 
 func Test_doCheck_quiet(t *testing.T) {
-	origGetLatest := getLatestVer
-	defer func() { getLatestVer = origGetLatest }()
-	getLatestVer = func(string) (string, error) { return testVersionNine, nil }
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionNine, nil }
 
 	pkgs := quietMixedPkgs()
 
 	var got int
 	out := captureCheckOutput(t, func() int {
-		got = doCheck(pkgs, 1, 0, true, true)
+		got = doCheck(deps, pkgs, 1, 0, true, true)
 		return got
 	})
 	if got != 0 {
@@ -152,14 +142,9 @@ func Test_doCheck_quiet(t *testing.T) {
 // Test_updateWithChannels_jsonQuiet verifies that --json takes precedence over
 // --quiet: STDOUT stays a valid JSON array with no summary line mixed in.
 func Test_updateWithChannels_jsonQuiet(t *testing.T) {
-	origGetLatest := getLatestVer
-	origInstallLatest := installLatest
-	defer func() {
-		getLatestVer = origGetLatest
-		installLatest = origInstallLatest
-	}()
-	getLatestVer = func(string) (string, error) { return testVersionNine, nil }
-	installLatest = func(string) error { return nil }
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionNine, nil }
+	deps.installLatest = func(context.Context, string) error { return nil }
 
 	pkgs := quietMixedPkgs()
 	channelMap := map[string]goutil.UpdateChannel{
@@ -168,7 +153,7 @@ func Test_updateWithChannels_jsonQuiet(t *testing.T) {
 	}
 
 	recs := readJSON(t, func() int {
-		got, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, nil, 0, true, true)
+		got, _, _ := updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, true, true)
 		return got
 	})
 	if len(recs) != 2 {

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -30,7 +30,7 @@ If you want to specify multiple binaries at once, separate them with space.
 			"gup remove --force air"),
 		ValidArgsFunction: completePathBinaries,
 		Run: func(cmd *cobra.Command, args []string) {
-			OsExit(remove(cmd, args))
+			OsExit(remove(print.NewColorable(), cmd, args))
 		},
 	}
 	cmd.Flags().BoolP("force", "f", false, "forcibly remove the file")
@@ -38,20 +38,20 @@ If you want to specify multiple binaries at once, separate them with space.
 	return cmd
 }
 
-func remove(cmd *cobra.Command, args []string) int {
+func remove(p *print.Printer, cmd *cobra.Command, args []string) int {
 	force, err := getFlagBool(cmd, "force")
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
 	gobin, err := goutil.GoBin()
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
-	return removeLoop(gobin, force, args)
+	return removeLoop(p, gobin, force, args)
 }
 
 const goosWindows = "windows"
@@ -72,7 +72,7 @@ var stdinIsTerminal = func() bool { //nolint:gochecknoglobals
 	return (info.Mode() & os.ModeCharDevice) != 0
 }
 
-func removeLoop(gobin string, force bool, target []string) int {
+func removeLoop(p *print.Printer, gobin string, force bool, target []string) int {
 	result := 0
 	for _, v := range target {
 		orig := v
@@ -84,36 +84,36 @@ func removeLoop(gobin string, force bool, target []string) int {
 			v += execSuffix
 		}
 		if !isSafeBinaryName(v) {
-			print.Err(fmt.Errorf("invalid command name: %s", orig))
+			p.Err(fmt.Errorf("invalid command name: %s", orig))
 			result = 1
 			continue
 		}
 
 		target := filepath.Join(gobin, v)
 		if !fileutil.IsFile(target) {
-			print.Err(fmt.Errorf("no such file or directory: %s", target))
+			p.Err(fmt.Errorf("no such file or directory: %s", target))
 			result = 1
 			continue
 		}
 		if !force {
 			if !stdinIsTerminal() {
-				print.Err(errors.New("gup remove requires confirmation, but stdin is not a TTY.\nUse --force to skip confirmation"))
+				p.Err(errors.New("gup remove requires confirmation, but stdin is not a TTY.\nUse --force to skip confirmation"))
 				result = 1
 				continue
 			}
-			if !print.Question(fmt.Sprintf("remove %s?", target)) {
-				print.Info("cancel removal " + target)
+			if !p.Question(fmt.Sprintf("remove %s?", target)) {
+				p.Info("cancel removal " + target)
 				continue
 			}
 		}
 
 		//nolint:gosec // target is constrained to a file name under gobin by isSafeBinaryName.
 		if err := os.Remove(target); err != nil {
-			print.Err(err)
+			p.Err(err)
 			result = 1
 			continue
 		}
-		print.Info("removed " + target)
+		p.Info("removed " + target)
 	}
 	return result
 }

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -30,7 +30,7 @@ If you want to specify multiple binaries at once, separate them with space.
 			"gup remove --force air"),
 		ValidArgsFunction: completePathBinaries,
 		Run: func(cmd *cobra.Command, args []string) {
-			OsExit(remove(print.NewColorable(), cmd, args))
+			OsExit(remove(printerFor(cmd), cmd, args))
 		},
 	}
 	cmd.Flags().BoolP("force", "f", false, "forcibly remove the file")

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -147,7 +147,8 @@ func Test_removeLoop(t *testing.T) {
 				t.Setenv("GOEXE", dotExe)
 			}
 
-			if got := removeLoop(tt.args.gobin, tt.args.force, tt.args.target); got != tt.want {
+			p, _ := newTestPrinter()
+			if got := removeLoop(p, tt.args.gobin, tt.args.force, tt.args.target); got != tt.want {
 				t.Errorf("removeLoop() = %v, want %v", got, tt.want)
 			}
 
@@ -171,7 +172,8 @@ func Test_removeLoop_rejectPathTraversal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got := removeLoop(gobin, true, []string{"../victim"}); got != 1 {
+	p, _ := newTestPrinter()
+	if got := removeLoop(p, gobin, true, []string{"../victim"}); got != 1 {
 		t.Fatalf("removeLoop() = %v, want %v", got, 1)
 	}
 
@@ -184,7 +186,8 @@ func Test_remove_flagError(t *testing.T) {
 	t.Parallel()
 	cmd := &cobra.Command{}
 	// missing "force" flag
-	got := remove(cmd, []string{testBinTool})
+	p, _ := newTestPrinter()
+	got := remove(p, cmd, []string{testBinTool})
 	if got != 1 {
 		t.Errorf("remove() = %v, want 1", got)
 	}
@@ -215,7 +218,8 @@ func Test_remove_noArgs(t *testing.T) {
 func Test_removeLoop_forceNonExist(t *testing.T) {
 	t.Parallel()
 	gobin := t.TempDir()
-	got := removeLoop(gobin, true, []string{"nonexistent"})
+	p, _ := newTestPrinter()
+	got := removeLoop(p, gobin, true, []string{"nonexistent"})
 	if got != 1 {
 		t.Errorf("removeLoop() = %v, want 1 for non-existent binary", got)
 	}
@@ -233,7 +237,8 @@ func Test_removeLoop_windowsFallbackGoexe(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got := removeLoop(gobin, true, []string{testBinPosixer}); got != 0 {
+	p, _ := newTestPrinter()
+	if got := removeLoop(p, gobin, true, []string{testBinPosixer}); got != 0 {
 		t.Fatalf("removeLoop() = %v, want 0", got)
 	}
 	if fileutil.IsFile(binaryPath) {
@@ -253,7 +258,8 @@ func Test_removeLoop_windowsSuffixCaseInsensitive(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got := removeLoop(gobin, true, []string{"gopls.EXE"}); got != 0 {
+	p, _ := newTestPrinter()
+	if got := removeLoop(p, gobin, true, []string{"gopls.EXE"}); got != 0 {
 		t.Fatalf("removeLoop() = %v, want 0", got)
 	}
 	if fileutil.IsFile(binaryPath) {
@@ -274,7 +280,8 @@ func Test_removeLoop_forceTrimmedName(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got := removeLoop(gobin, true, []string{"  posixer  "}); got != 0 {
+	p, _ := newTestPrinter()
+	if got := removeLoop(p, gobin, true, []string{"  posixer  "}); got != 0 {
 		t.Fatalf("removeLoop() = %v, want 0", got)
 	}
 	if fileutil.IsFile(binaryPath) {
@@ -338,7 +345,8 @@ func Test_removeLoop_nonTTYWithoutForceFailsFast(t *testing.T) {
 
 	// Without --force and without a TTY, removeLoop must fail fast (exit 1)
 	// and must NOT attempt interactive confirmation nor remove the file.
-	if got := removeLoop(gobin, false, []string{target}); got != 1 {
+	p, _ := newTestPrinter()
+	if got := removeLoop(p, gobin, false, []string{target}); got != 1 {
 		t.Fatalf("removeLoop() = %v, want 1 for non-TTY without --force", got)
 	}
 	if !fileutil.IsFile(binaryPath) {
@@ -365,7 +373,8 @@ func Test_removeLoop_nonTTYWithForceStillRemoves(t *testing.T) {
 	t.Cleanup(func() { stdinIsTerminal = origStdinIsTerminal })
 
 	// --force must skip confirmation regardless of TTY state.
-	if got := removeLoop(gobin, true, []string{target}); got != 0 {
+	p, _ := newTestPrinter()
+	if got := removeLoop(p, gobin, true, []string{target}); got != 0 {
 		t.Fatalf("removeLoop() = %v, want 0 for non-TTY with --force", got)
 	}
 	if fileutil.IsFile(binaryPath) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,11 +8,21 @@ import (
 
 	"github.com/nao1215/gup/internal/cmdinfo"
 	"github.com/nao1215/gup/internal/completion"
+	"github.com/nao1215/gup/internal/print"
 	"github.com/spf13/cobra"
 )
 
 // OsExit is wrapper for  os.Exit(). It's for unit test.
 var OsExit = os.Exit //nolint:gochecknoglobals
+
+// printerFor builds a Printer from a command's output streams. It uses
+// cmd.OutOrStdout()/ErrOrStderr() so output flows through cobra's configurable
+// writers: production wires the colorable process streams onto the root command
+// in Execute, while a test can capture output by calling SetOut/SetErr with a
+// buffer instead of redirecting the process-wide os.Stdout/os.Stderr.
+func printerFor(cmd *cobra.Command) *print.Printer {
+	return print.New(cmd.OutOrStdout(), cmd.ErrOrStderr())
+}
 
 func newRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -79,6 +89,12 @@ If you find gup useful, please consider sponsoring the project:
 // Execute run gup process.
 func Execute() error {
 	rootCmd := newRootCmd()
+	// Wire the colorable process streams onto the root command. cobra propagates
+	// these to every subcommand (OutOrStdout/ErrOrStderr walk up to the parent),
+	// so printerFor builds production Printers over them while tests can override
+	// with SetOut/SetErr.
+	rootCmd.SetOut(print.ColorableStdout())
+	rootCmd.SetErr(print.ColorableStderr())
 	return rootCmd.Execute()
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -76,8 +76,8 @@ func helper_runUpdateWithDeps(t *testing.T, deps dependencies, flagArgs ...strin
 	if err := cmd.ParseFlags(flagArgs); err != nil {
 		t.Fatalf("failed to parse update flags %v: %v", flagArgs, err)
 	}
-	out := captureCheckOutput(t, func() int {
-		return gup(deps, cmd, cmd.Flags().Args())
+	out := captureCheckOutput(t, func(p *print.Printer) int {
+		return gup(deps, p, cmd, cmd.Flags().Args())
 	})
 	return strings.Split(out, "\n")
 }
@@ -94,60 +94,65 @@ func helper_stubImportInstaller(t *testing.T) {
 	})
 }
 
-// Runs a gup command, and return its output split by \n.
+// Runs a gup command, and return its output split by \n. The command's cobra
+// Run closures build their own colorable Printer over the process os.Stdout/
+// os.Stderr, so this captures by redirecting those real streams (not the print
+// package, which no longer has mutable globals).
 func helper_runGup(t *testing.T, args []string) ([]string, error) {
 	t.Helper()
 
-	// Redirect output
-	orgStdout := print.Stdout
-	orgStderr := print.Stderr
+	orgOSStdout := os.Stdout
+	orgOSStderr := os.Stderr
 	defer func() {
-		print.Stdout = orgStdout
-		print.Stderr = orgStderr
+		os.Stdout = orgOSStdout
+		os.Stderr = orgOSStderr
 	}()
 	pr, pw, err := os.Pipe()
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer pr.Close() //nolint:errcheck // ignore close error in test
-	print.Stdout = pw
-	print.Stderr = pw
+	os.Stdout = pw
+	os.Stderr = pw
 
 	OsExit = func(code int) {}
 	defer func() {
 		OsExit = os.Exit
 	}()
 
-	// Run command
+	// Drain the pipe concurrently so a command that writes more than the pipe
+	// buffer does not deadlock.
+	buf := bytes.Buffer{}
+	copyDone := make(chan error, 1)
+	go func() {
+		_, copyErr := io.Copy(&buf, pr)
+		copyDone <- copyErr
+	}()
+
 	os.Args = args
 	err = Execute()
 	pw.Close() //nolint:errcheck,gosec // ignore close error in test
+	if copyErr := <-copyDone; copyErr != nil {
+		t.Fatal(copyErr)
+	}
 	if err != nil {
 		return nil, err
 	}
 
-	// Get output
-	buf := bytes.Buffer{}
-	_, err = io.Copy(&buf, pr)
-	if err != nil {
-		t.Fatal(err)
-	}
 	got := strings.Split(buf.String(), "\n")
-
 	return got, nil
 }
 
-// Runs a gup command and captures both print package output and os.Stdout.
+// Runs a gup command and captures os.Stdout/os.Stderr (which the per-command
+// Printer wraps).
 func helper_runGupCaptureAllOutput(t *testing.T, args []string) (string, error) {
 	t.Helper()
 
-	orgStdout := print.Stdout
-	orgStderr := print.Stderr
 	orgOSStdout := os.Stdout
+	orgOSStderr := os.Stderr
 	defer func() {
-		print.Stdout = orgStdout
-		print.Stderr = orgStderr
 		os.Stdout = orgOSStdout
+		os.Stderr = orgOSStderr
 	}()
 
 	pr, pw, err := os.Pipe()
@@ -156,9 +161,8 @@ func helper_runGupCaptureAllOutput(t *testing.T, args []string) (string, error) 
 	}
 	defer pr.Close() //nolint:errcheck // ignore close error in test
 
-	print.Stdout = pw
-	print.Stderr = pw
 	os.Stdout = pw
+	os.Stderr = pw
 
 	OsExit = func(code int) {}
 	defer func() {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -82,6 +82,22 @@ func helper_runUpdateWithDeps(t *testing.T, deps dependencies, flagArgs ...strin
 	return strings.Split(out, "\n")
 }
 
+// helper_runCheckWithDeps is the check counterpart of helper_runUpdateWithDeps:
+// it runs check() with injected dependencies (so version lookups never hit the
+// network) while capturing output, instead of dispatching through Execute() and
+// depending on live module resolution.
+func helper_runCheckWithDeps(t *testing.T, deps dependencies, flagArgs ...string) []string {
+	t.Helper()
+	cmd := newCheckCmd()
+	if err := cmd.ParseFlags(flagArgs); err != nil {
+		t.Fatalf("failed to parse check flags %v: %v", flagArgs, err)
+	}
+	out := captureCheckOutput(t, func(p *print.Printer) int {
+		return check(deps, p, cmd, cmd.Flags().Args())
+	})
+	return strings.Split(out, "\n")
+}
+
 func helper_stubImportInstaller(t *testing.T) {
 	t.Helper()
 
@@ -242,10 +258,10 @@ func TestExecute_Check(t *testing.T) {
 		t.Setenv("GOBIN", gobinDir)
 	}
 
-	got, err := helper_runGup(t, []string{testCmdGup, "check"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	// Inject stubbed version lookups (latest == v9.9.9) so every installed binary
+	// is reported as needing an update, deterministically and without resolving
+	// modules over the network.
+	got := helper_runCheckWithDeps(t, stubUpdateDeps())
 
 	if !strings.Contains(got[len(got)-2], "posixer") {
 		t.Errorf("posixer package is not included in the update target: %s", got[len(got)-2])

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -65,40 +65,21 @@ func helper_setupFakeGoBin(t *testing.T) {
 	}
 }
 
-func helper_stubUpdateOps(t *testing.T) {
+// helper_runUpdateWithDeps builds the update command, applies the given flag
+// args (e.g. "--dry-run", "--notify"), runs gup() with injected dependencies
+// while capturing print output, and returns the output split by newline. It
+// replaces dispatching update through Execute() with globally-stubbed operations
+// so integration-style update tests inject their fakes explicitly.
+func helper_runUpdateWithDeps(t *testing.T, deps dependencies, flagArgs ...string) []string {
 	t.Helper()
-
-	orgGetLatestVer := getLatestVer
-	orgGetVerByRef := getVerByRefCtx
-	orgInstallLatest := installLatest
-	orgInstallMainOrMaster := installMainOrMaster
-	orgInstallByVersionUpd := installByVersionUpd
-
-	getLatestVer = func(string) (string, error) {
-		return testVersionNine, nil
+	cmd := newUpdateCmd()
+	if err := cmd.ParseFlags(flagArgs); err != nil {
+		t.Fatalf("failed to parse update flags %v: %v", flagArgs, err)
 	}
-	// The channel-aware skip/update decision resolves @main/@master versions
-	// through this ref lookup, so stub it alongside the @latest lookup.
-	getVerByRefCtx = func(context.Context, string, string) (string, error) {
-		return testVersionNine, nil
-	}
-	installLatest = func(string) error {
-		return nil
-	}
-	installMainOrMaster = func(string) error {
-		return nil
-	}
-	installByVersionUpd = func(string, string) error {
-		return nil
-	}
-
-	t.Cleanup(func() {
-		getLatestVer = orgGetLatestVer
-		getVerByRefCtx = orgGetVerByRef
-		installLatest = orgInstallLatest
-		installMainOrMaster = orgInstallMainOrMaster
-		installByVersionUpd = orgInstallByVersionUpd
+	out := captureCheckOutput(t, func() int {
+		return gup(deps, cmd, cmd.Flags().Args())
 	})
+	return strings.Split(out, "\n")
 }
 
 func helper_stubImportInstaller(t *testing.T) {
@@ -788,7 +769,7 @@ func TestExecute_Import_WithBadInputFile(t *testing.T) {
 
 func TestExecute_Update(t *testing.T) {
 	setupXDGBase(t)
-	helper_stubUpdateOps(t)
+	deps := stubUpdateDeps()
 	helper_setupFakeGoBin(t)
 	OsExit = func(code int) {}
 	defer func() {
@@ -823,10 +804,7 @@ func TestExecute_Update(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := helper_runGup(t, []string{testCmdGup, testCmdUpdate})
-	if err != nil {
-		t.Fatal(err)
-	}
+	got := helper_runUpdateWithDeps(t, deps)
 
 	contain := false
 	for _, v := range got {
@@ -841,7 +819,7 @@ func TestExecute_Update(t *testing.T) {
 
 func TestExecute_Update_DryRunAndNotify(t *testing.T) {
 	setupXDGBase(t)
-	helper_stubUpdateOps(t)
+	deps := stubUpdateDeps()
 	helper_setupFakeGoBin(t)
 	OsExit = func(code int) {}
 	defer func() {
@@ -876,10 +854,7 @@ func TestExecute_Update_DryRunAndNotify(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := helper_runGup(t, []string{testCmdGup, testCmdUpdate, testFlagDryRun, testFlagNotify})
-	if err != nil {
-		t.Fatal(err)
-	}
+	got := helper_runUpdateWithDeps(t, deps, testFlagDryRun, testFlagNotify)
 
 	contain := false
 	for _, v := range got {
@@ -923,7 +898,7 @@ func TestExecute_NoAssetsForReadOnlyCommands(t *testing.T) {
 
 func TestExecute_AssetsDeployedForNotifyCommand(t *testing.T) {
 	setupXDGBase(t)
-	helper_stubUpdateOps(t)
+	deps := stubUpdateDeps()
 	helper_setupFakeGoBin(t)
 	OsExit = func(code int) {}
 	defer func() {
@@ -956,9 +931,7 @@ func TestExecute_AssetsDeployedForNotifyCommand(t *testing.T) {
 		t.Fatalf("assets directory %s should not exist before notify command runs", assetsDirForTest())
 	}
 
-	if _, err := helper_runGup(t, []string{testCmdGup, testCmdUpdate, testFlagDryRun, testFlagNotify}); err != nil {
-		t.Fatal(err)
-	}
+	_ = helper_runUpdateWithDeps(t, deps, testFlagDryRun, testFlagNotify)
 
 	if !fileutil.IsDir(assetsDirForTest()) {
 		t.Errorf("notify command did not deploy assets directory %s", assetsDirForTest())

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -94,97 +94,50 @@ func helper_stubImportInstaller(t *testing.T) {
 	})
 }
 
-// Runs a gup command, and return its output split by \n. The command's cobra
-// Run closures build their own colorable Printer over the process os.Stdout/
-// os.Stderr, so this captures by redirecting those real streams (not the print
-// package, which no longer has mutable globals).
+// helper_runGup runs a gup command and returns its output split by \n. It builds
+// the root command and wires a buffer onto it via cobra's SetOut/SetErr (which
+// the per-command Printer reads through cmd.OutOrStdout/ErrOrStderr), so output
+// is captured without redirecting the process-wide os.Stdout/os.Stderr.
 func helper_runGup(t *testing.T, args []string) ([]string, error) {
 	t.Helper()
 
-	orgOSStdout := os.Stdout
-	orgOSStderr := os.Stderr
-	defer func() {
-		os.Stdout = orgOSStdout
-		os.Stderr = orgOSStderr
-	}()
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer pr.Close() //nolint:errcheck // ignore close error in test
-	os.Stdout = pw
-	os.Stderr = pw
-
 	OsExit = func(code int) {}
 	defer func() {
 		OsExit = os.Exit
 	}()
 
-	// Drain the pipe concurrently so a command that writes more than the pipe
-	// buffer does not deadlock.
-	buf := bytes.Buffer{}
-	copyDone := make(chan error, 1)
-	go func() {
-		_, copyErr := io.Copy(&buf, pr)
-		copyDone <- copyErr
-	}()
-
-	os.Args = args
-	err = Execute()
-	pw.Close() //nolint:errcheck,gosec // ignore close error in test
-	if copyErr := <-copyDone; copyErr != nil {
-		t.Fatal(copyErr)
-	}
+	buf, err := runRootWithBuffer(args)
 	if err != nil {
 		return nil, err
 	}
-
-	got := strings.Split(buf.String(), "\n")
-	return got, nil
+	return strings.Split(buf, "\n"), nil
 }
 
-// Runs a gup command and captures os.Stdout/os.Stderr (which the per-command
-// Printer wraps).
+// helper_runGupCaptureAllOutput runs a gup command and returns all of its output
+// (stdout and stderr merged), captured via the root command's SetOut/SetErr.
 func helper_runGupCaptureAllOutput(t *testing.T, args []string) (string, error) {
 	t.Helper()
-
-	orgOSStdout := os.Stdout
-	orgOSStderr := os.Stderr
-	defer func() {
-		os.Stdout = orgOSStdout
-		os.Stderr = orgOSStderr
-	}()
-
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer pr.Close() //nolint:errcheck // ignore close error in test
-
-	os.Stdout = pw
-	os.Stderr = pw
 
 	OsExit = func(code int) {}
 	defer func() {
 		OsExit = os.Exit
 	}()
 
-	buf := bytes.Buffer{}
-	copyDone := make(chan error, 1)
-	go func() {
-		_, copyErr := io.Copy(&buf, pr)
-		copyDone <- copyErr
-	}()
+	return runRootWithBuffer(args)
+}
 
-	os.Args = args
-	runErr := Execute()
-	pw.Close() //nolint:errcheck,gosec // ignore close error in test
-
-	if err := <-copyDone; err != nil {
-		t.Fatal(err)
-	}
-
-	return buf.String(), runErr
+// runRootWithBuffer executes the root command with args (the first element is the
+// "gup" program name, like os.Args), capturing stdout and stderr into one buffer
+// via cobra's configurable writers. Returning the buffer and the Execute error
+// keeps the helpers free of any process-global stream redirection.
+func runRootWithBuffer(args []string) (string, error) {
+	buf := &bytes.Buffer{}
+	rootCmd := newRootCmd()
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs(args[1:])
+	err := rootCmd.Execute()
+	return buf.String(), err
 }
 
 func setupXDGBase(t *testing.T) {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -19,14 +19,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	getLatestVerCtx        = goutil.GetLatestVerWithContext        //nolint:gochecknoglobals // swapped in tests
-	getVerByRefCtx         = goutil.GetVerWithContext              //nolint:gochecknoglobals // swapped in tests
-	installLatestCtx       = goutil.InstallLatestWithContext       //nolint:gochecknoglobals // swapped in tests
-	installMainOrMasterCtx = goutil.InstallMainOrMasterWithContext //nolint:gochecknoglobals // swapped in tests
-	installByVersionUpdCtx = goutil.InstallWithContext             //nolint:gochecknoglobals // swapped in tests
-)
-
 const latestKeyword = "latest"
 
 func newUpdateCmd() *cobra.Command {
@@ -42,7 +34,7 @@ If you execute '$ gup update', gup gets the package path of all commands
 under $GOPATH/bin and automatically updates commands to the latest version,
 using the current installed Go toolchain.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			OsExit(gup(cmd, args))
+			OsExit(gup(defaultDependencies(), cmd, args))
 		},
 		ValidArgsFunction: completePathBinaries,
 	}
@@ -133,7 +125,11 @@ func parseUpdateFlags(cmd *cobra.Command) (updateOpts, error) {
 
 // gup is main sequence.
 // All errors are handled in this function.
-func gup(cmd *cobra.Command, args []string) int {
+//
+// deps carries the go-toolchain operations (version lookups and per-channel
+// installs) so the update flow takes its collaborators explicitly. Production
+// passes defaultDependencies(); tests inject fakes.
+func gup(deps dependencies, cmd *cobra.Command, args []string) int {
 	if err := ensureGoCommandAvailable(); err != nil {
 		print.Err(err)
 		return 1
@@ -203,7 +199,7 @@ func gup(cmd *cobra.Command, args []string) int {
 		return 1
 	}
 
-	result, succeededPkgs, renamedPkgs := updateWithChannels(pkgs, opts.dryRun, opts.notify, opts.cpus, ignoreGoUpdate, channelMap, pinnedMap, opts.timeout, opts.jsonOut, opts.quiet)
+	result, succeededPkgs, renamedPkgs := updateWithChannels(deps, pkgs, opts.dryRun, opts.notify, opts.cpus, ignoreGoUpdate, channelMap, pinnedMap, opts.timeout, opts.jsonOut, opts.quiet)
 
 	if !opts.dryRun && (configstate.ShouldPersistChannels(opts.mainPkgNames, opts.masterPkgNames, opts.latestPkgNames) || len(renamedPkgs) > 0) {
 		merged := configstate.MergePackages(confPkgs, succeededPkgs, channelMap, renamedPkgs)
@@ -225,10 +221,9 @@ type updateResult struct {
 	status      string // machine-readable status for --json output (see jsonout.go)
 }
 
-func updateWithChannels(pkgs []goutil.Package, dryRun, notification bool, cpus int, ignoreGoUpdate bool, channelMap map[string]goutil.UpdateChannel, pinnedMap map[string]string, timeout time.Duration, jsonOut, quiet bool) (exitCode int, succeeded []goutil.Package, renamed map[string]string) {
+func updateWithChannels(deps dependencies, pkgs []goutil.Package, dryRun, notification bool, cpus int, ignoreGoUpdate bool, channelMap map[string]goutil.UpdateChannel, pinnedMap map[string]string, timeout time.Duration, jsonOut, quiet bool) (exitCode int, succeeded []goutil.Package, renamed map[string]string) {
 	dryRunManager := goutil.NewGoPaths()
 
-	deps := defaultDependencies()
 	verCache := deps.newVerCache()
 
 	if !jsonOut && !quiet {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -34,7 +34,7 @@ If you execute '$ gup update', gup gets the package path of all commands
 under $GOPATH/bin and automatically updates commands to the latest version,
 using the current installed Go toolchain.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			OsExit(gup(defaultDependencies(), print.NewColorable(), cmd, args))
+			OsExit(gup(defaultDependencies(), printerFor(cmd), cmd, args))
 		},
 		ValidArgsFunction: completePathBinaries,
 	}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -34,7 +34,7 @@ If you execute '$ gup update', gup gets the package path of all commands
 under $GOPATH/bin and automatically updates commands to the latest version,
 using the current installed Go toolchain.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			OsExit(gup(defaultDependencies(), cmd, args))
+			OsExit(gup(defaultDependencies(), print.NewColorable(), cmd, args))
 		},
 		ValidArgsFunction: completePathBinaries,
 	}
@@ -129,21 +129,21 @@ func parseUpdateFlags(cmd *cobra.Command) (updateOpts, error) {
 // deps carries the go-toolchain operations (version lookups and per-channel
 // installs) so the update flow takes its collaborators explicitly. Production
 // passes defaultDependencies(); tests inject fakes.
-func gup(deps dependencies, cmd *cobra.Command, args []string) int {
+func gup(deps dependencies, p *print.Printer, cmd *cobra.Command, args []string) int {
 	if err := ensureGoCommandAvailable(); err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
 	opts, err := parseUpdateFlags(cmd)
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
-	pkgs, missingTargets, goVersionAvailable, err := pkgselect.PackageInfoByTargets(args)
+	pkgs, missingTargets, goVersionAvailable, err := pkgselect.PackageInfoByTargets(p, args)
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 	// When the installed Go version can't be detected, behave as
@@ -151,13 +151,13 @@ func gup(deps dependencies, cmd *cobra.Command, args []string) int {
 	// every binary to reinstall (see issue #296).
 	ignoreGoUpdate := opts.ignoreGoUpdate || !goVersionAvailable
 
-	pkgselect.WarnMissing(missingTargets, func(msg string) { print.Warn(msg) })
+	pkgselect.WarnMissing(missingTargets, func(msg string) { p.Warn(msg) })
 	// In JSON mode the human-readable "Exclude ..." notice is suppressed so
-	// STDOUT stays valid JSON (the notice goes to STDOUT via print.Info, which
+	// STDOUT stays valid JSON (the notice goes to STDOUT via p.Info, which
 	// would otherwise break machine-readable output; see issue #291).
 	excludeNotify := func(string) {}
 	if !opts.jsonOut {
-		excludeNotify = func(msg string) { print.Info(msg) }
+		excludeNotify = func(msg string) { p.Info(msg) }
 	}
 	pkgs = pkgselect.Exclude(pkgs, opts.excludePkgList, excludeNotify)
 
@@ -165,7 +165,7 @@ func gup(deps dependencies, cmd *cobra.Command, args []string) int {
 		// With explicit targets or --exclude, an empty result means the user
 		// narrowed everything out: that is a usage error. Otherwise it is a normal
 		// first-run condition handled the same way as check.
-		return handleEmptyEnvironment(opts.confFile, opts.jsonOut,
+		return handleEmptyEnvironment(p, opts.confFile, opts.jsonOut,
 			len(args) != 0 || len(opts.excludePkgList) != 0,
 			"unable to update package: no package information or no package under $GOBIN")
 	}
@@ -175,7 +175,7 @@ func gup(deps dependencies, cmd *cobra.Command, args []string) int {
 	// import and check.
 	confReadPath, err := config.ResolveImportFilePath(opts.confFile)
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 	confWritePath := configstate.ResolveWritePath(opts.confFile, confReadPath)
@@ -185,7 +185,7 @@ func gup(deps dependencies, cmd *cobra.Command, args []string) int {
 	// then persist that downgrade back to gup.json (#369).
 	confPkgs, err := configstate.ReadFileIfExists(confReadPath)
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
@@ -193,18 +193,18 @@ func gup(deps dependencies, cmd *cobra.Command, args []string) int {
 	// pass them so ResolveChannels does not emit a second, redundant notice for a
 	// name listed both as a positional target and in --main/--master/--latest.
 	channelMap, pinnedMap, err := configstate.ResolveChannels(pkgs, confPkgs, opts.mainPkgNames, opts.masterPkgNames, opts.latestPkgNames,
-		missingTargets, func(msg string) { print.Warn(msg) })
+		missingTargets, func(msg string) { p.Warn(msg) })
 	if err != nil {
-		print.Err(err)
+		p.Err(err)
 		return 1
 	}
 
-	result, succeededPkgs, renamedPkgs := updateWithChannels(deps, pkgs, opts.dryRun, opts.notify, opts.cpus, ignoreGoUpdate, channelMap, pinnedMap, opts.timeout, opts.jsonOut, opts.quiet)
+	result, succeededPkgs, renamedPkgs := updateWithChannels(deps, p, pkgs, opts.dryRun, opts.notify, opts.cpus, ignoreGoUpdate, channelMap, pinnedMap, opts.timeout, opts.jsonOut, opts.quiet)
 
 	if !opts.dryRun && (configstate.ShouldPersistChannels(opts.mainPkgNames, opts.masterPkgNames, opts.latestPkgNames) || len(renamedPkgs) > 0) {
 		merged := configstate.MergePackages(confPkgs, succeededPkgs, channelMap, renamedPkgs)
 		if err := writeConfigFile(confWritePath, merged); err != nil {
-			print.Warn("failed to write " + confWritePath + ": " + err.Error())
+			p.Warn("failed to write " + confWritePath + ": " + err.Error())
 		}
 	}
 
@@ -221,25 +221,25 @@ type updateResult struct {
 	status      string // machine-readable status for --json output (see jsonout.go)
 }
 
-func updateWithChannels(deps dependencies, pkgs []goutil.Package, dryRun, notification bool, cpus int, ignoreGoUpdate bool, channelMap map[string]goutil.UpdateChannel, pinnedMap map[string]string, timeout time.Duration, jsonOut, quiet bool) (exitCode int, succeeded []goutil.Package, renamed map[string]string) {
+func updateWithChannels(deps dependencies, pr *print.Printer, pkgs []goutil.Package, dryRun, notification bool, cpus int, ignoreGoUpdate bool, channelMap map[string]goutil.UpdateChannel, pinnedMap map[string]string, timeout time.Duration, jsonOut, quiet bool) (exitCode int, succeeded []goutil.Package, renamed map[string]string) {
 	dryRunManager := goutil.NewGoPaths()
 
 	verCache := deps.newVerCache()
 
 	if !jsonOut && !quiet {
-		print.Info("update binary under $GOPATH/bin or $GOBIN")
+		pr.Info("update binary under $GOPATH/bin or $GOBIN")
 	}
 	if dryRun {
 		if err := dryRunManager.StartDryRunMode(); err != nil {
-			print.Err(fmt.Errorf("can not change to dry run mode: %w", err))
-			notify.Warn("gup", "Can not change to dry run mode")
+			pr.Err(fmt.Errorf("can not change to dry run mode: %w", err))
+			notify.Warn(pr, "gup", "Can not change to dry run mode")
 			return 1, nil, nil
 		}
 		// Restore the environment and remove the temp dir via defer so it runs
 		// even if a package update panics (see issue #297).
 		defer func() {
 			if err := dryRunManager.EndDryRunMode(); err != nil {
-				print.Err(fmt.Errorf("can not change dry run mode to normal mode: %w", err))
+				pr.Err(fmt.Errorf("can not change dry run mode to normal mode: %w", err))
 				exitCode = 1
 			}
 		}()
@@ -358,24 +358,24 @@ func updateWithChannels(deps dependencies, pkgs []goutil.Package, dryRun, notifi
 	var onResult func(prefix string, v updateResult)
 	if !jsonOut {
 		// In quiet mode show only binaries that were actually updated.
-		onResult = resultLineRenderer(quiet,
+		onResult = resultLineRenderer(pr, quiet,
 			func(v updateResult) bool { return v.updated },
 			updateResultStr)
 	}
 
 	// update all packages
-	result, results := executePackages(pkgs, cpus, timeout, updater, onResult)
+	result, results := executePackages(pr, pkgs, cpus, timeout, updater, onResult)
 
 	if jsonOut {
-		if err := encodeJSONPackages(resultsToJSONPackages(results)); err != nil {
-			print.Err(err)
+		if err := encodeJSONPackages(pr, resultsToJSONPackages(results)); err != nil {
+			pr.Err(err)
 			result = 1
 		}
 	} else if quiet {
-		print.Info(summarizeResults(results, false))
+		pr.Info(summarizeResults(results, false))
 	}
 
-	desktopNotifyIfNeeded(result, notification)
+	desktopNotifyIfNeeded(pr, result, notification)
 
 	succeededPkgs, renamedPkgs := succeededAndRenamed(results)
 	return result, succeededPkgs, renamedPkgs
@@ -399,12 +399,12 @@ func succeededAndRenamed(results []updateResult) ([]goutil.Package, map[string]s
 	return succeededPkgs, renamedPkgs
 }
 
-func desktopNotifyIfNeeded(result int, enable bool) {
+func desktopNotifyIfNeeded(p *print.Printer, result int, enable bool) {
 	if enable {
 		if result == 0 {
-			notify.Info("gup", "All update success")
+			notify.Info(p, "gup", "All update success")
 		} else {
-			notify.Warn("gup", "Some package can't update")
+			notify.Warn(p, "gup", "Some package can't update")
 		}
 	}
 }

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -28,32 +28,6 @@ const testVersionZero = "v0.0.0"
 const testVersionOne = "v1.0.0"
 const testVersionNine = "v9.9.9"
 
-//nolint:gochecknoglobals // legacy stubs used by tests via init bridge.
-var (
-	getLatestVer        = goutil.GetLatestVer
-	installLatest       = goutil.InstallLatest
-	installMainOrMaster = goutil.InstallMainOrMaster
-	installByVersionUpd = goutil.Install
-)
-
-//nolint:gochecknoinits
-func init() {
-	// Keep existing tests that stub legacy function variables working
-	// after adding context-aware update/lookup paths.
-	getLatestVerCtx = func(_ context.Context, modulePath string) (string, error) {
-		return getLatestVer(modulePath)
-	}
-	installLatestCtx = func(_ context.Context, importPath string) error {
-		return installLatest(importPath)
-	}
-	installMainOrMasterCtx = func(_ context.Context, importPath string) error {
-		return installMainOrMaster(importPath)
-	}
-	installByVersionUpdCtx = func(_ context.Context, importPath, version string) error {
-		return installByVersionUpd(importPath, version)
-	}
-}
-
 func Test_gup(t *testing.T) {
 	type args struct {
 		cmd  *cobra.Command
@@ -130,7 +104,7 @@ func Test_gup(t *testing.T) {
 			print.Stdout = pw
 			print.Stderr = pw
 
-			if got := gup(tt.args.cmd, tt.args.args); got != tt.want {
+			if got := gup(defaultDependencies(), tt.args.cmd, tt.args.args); got != tt.want {
 				t.Errorf("gup() = %v, want %v", got, tt.want)
 			}
 			if err := pw.Close(); err != nil {
@@ -197,20 +171,8 @@ func Test_gup_ignoreGoUpdateFlag(t *testing.T) {
 		t.Fatalf("failed to set ignore-go-update flag: %v", err)
 	}
 
-	origGetLatest := getLatestVer
-	origInstallLatest := installLatest
-	origInstallMain := installMainOrMaster
-	origInstallByVersionUpd := installByVersionUpd
-	getLatestVer = func(string) (string, error) { return testVersionZero, nil }
-	installLatest = func(string) error { return nil }
-	installMainOrMaster = func(string) error { return nil }
-	installByVersionUpd = func(string, string) error { return nil }
-	defer func() {
-		getLatestVer = origGetLatest
-		installLatest = origInstallLatest
-		installMainOrMaster = origInstallMain
-		installByVersionUpd = origInstallByVersionUpd
-	}()
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionZero, nil }
 
 	OsExit = func(code int) {}
 	defer func() {
@@ -226,7 +188,7 @@ func Test_gup_ignoreGoUpdateFlag(t *testing.T) {
 	print.Stdout = pw
 	print.Stderr = pw
 
-	if got := gup(cmd, []string{}); got != 0 {
+	if got := gup(deps, cmd, []string{}); got != 0 {
 		t.Fatalf("gup() = %v, want %v", got, 0)
 	}
 	if err := pw.Close(); err != nil {
@@ -268,7 +230,7 @@ func Test_gup_emptyEnv_validatesExplicitMalformedFile(t *testing.T) {
 
 	var got int
 	out := captureCheckOutput(t, func() int {
-		got = gup(cmd, []string{})
+		got = gup(defaultDependencies(), cmd, []string{})
 		return got
 	})
 	if got != 1 {
@@ -297,7 +259,7 @@ func Test_gup_emptyEnv_validatesExplicitDirectoryFile(t *testing.T) {
 
 	got := 0
 	_ = captureCheckOutput(t, func() int {
-		got = gup(cmd, []string{})
+		got = gup(defaultDependencies(), cmd, []string{})
 		return got
 	})
 	if got != 1 {
@@ -314,7 +276,7 @@ func Test_gup_emptyEnv_succeedsWithoutExplicitConfigProblem(t *testing.T) {
 
 	got := 0
 	_ = captureCheckOutput(t, func() int {
-		got = gup(newUpdateCmd(), []string{})
+		got = gup(defaultDependencies(), newUpdateCmd(), []string{})
 		return got
 	})
 	if got != 0 {
@@ -328,7 +290,7 @@ func Test_gup_emptyEnv_succeedsWithoutExplicitConfigProblem(t *testing.T) {
 func Test_gup_invalidConfigFile(t *testing.T) {
 	setupXDGBase(t)
 	t.Setenv("GOBIN", filepath.Join("testdata", "check_success"))
-	helper_stubUpdateOps(t)
+	deps := stubUpdateDeps()
 
 	confPath := config.FilePath()
 	if err := os.MkdirAll(filepath.Dir(confPath), 0o750); err != nil {
@@ -340,7 +302,7 @@ func Test_gup_invalidConfigFile(t *testing.T) {
 
 	var got int
 	out := captureCheckOutput(t, func() int {
-		got = gup(newUpdateCmd(), []string{})
+		got = gup(deps, newUpdateCmd(), []string{})
 		return got
 	})
 	if got != 1 {
@@ -360,36 +322,27 @@ func Test_gup_dryRun(t *testing.T) {
 	}
 
 	var installCalled atomic.Bool
-	origGetLatest := getLatestVer
-	origInstallLatest := installLatest
-	origInstallMain := installMainOrMaster
-	origInstallByVersionUpd := installByVersionUpd
-	getLatestVer = func(string) (string, error) { return testVersionNine, nil }
-	installLatest = func(string) error {
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionNine, nil }
+	deps.installLatest = func(context.Context, string) error {
 		installCalled.Store(true)
 		return nil
 	}
-	installMainOrMaster = func(string) error {
+	deps.installMainOrMaster = func(context.Context, string) error {
 		installCalled.Store(true)
 		return nil
 	}
-	installByVersionUpd = func(string, string) error {
+	deps.installByVersion = func(context.Context, string, string) error {
 		installCalled.Store(true)
 		return nil
 	}
-	defer func() {
-		getLatestVer = origGetLatest
-		installLatest = origInstallLatest
-		installMainOrMaster = origInstallMain
-		installByVersionUpd = origInstallByVersionUpd
-	}()
 
 	OsExit = func(code int) {}
 	defer func() {
 		OsExit = os.Exit
 	}()
 
-	if got := gup(cmd, []string{}); got != 0 {
+	if got := gup(deps, cmd, []string{}); got != 0 {
 		t.Fatalf("gup() = %v, want %v", got, 0)
 	}
 	if !installCalled.Load() {
@@ -413,7 +366,7 @@ func Test_update_not_use_go_cmd(t *testing.T) {
 		print.Stdout = pw
 		print.Stderr = pw
 
-		if got := gup(newUpdateCmd(), []string{}); got != 1 {
+		if got := gup(defaultDependencies(), newUpdateCmd(), []string{}); got != 1 {
 			t.Errorf("gup() = %v, want %v", got, 1)
 		}
 		if err := pw.Close(); err != nil {
@@ -485,20 +438,8 @@ func Test_gup_jobsClamp(t *testing.T) {
 		t.Fatalf("failed to set jobs flag: %v", err)
 	}
 
-	origGetLatest := getLatestVer
-	origInstallLatest := installLatest
-	origInstallMain := installMainOrMaster
-	origInstallByVersionUpd := installByVersionUpd
-	getLatestVer = func(string) (string, error) { return testVersionZero, nil }
-	installLatest = func(string) error { return nil }
-	installMainOrMaster = func(string) error { return nil }
-	installByVersionUpd = func(string, string) error { return nil }
-	defer func() {
-		getLatestVer = origGetLatest
-		installLatest = origInstallLatest
-		installMainOrMaster = origInstallMain
-		installByVersionUpd = origInstallByVersionUpd
-	}()
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionZero, nil }
 
 	OsExit = func(code int) {}
 	defer func() {
@@ -515,7 +456,7 @@ func Test_gup_jobsClamp(t *testing.T) {
 	print.Stderr = pw
 
 	// Should not hang with jobs=-1 (clamped to 1)
-	got := gup(cmd, []string{})
+	got := gup(deps, cmd, []string{})
 	pw.Close()
 	print.Stdout = orgStdout
 	print.Stderr = orgStderr
@@ -609,19 +550,9 @@ func Test_update_modulePathChangedOnGetLatest(t *testing.T) {
 		newImport = "github.com/air-verse/air/cmd/air"
 	)
 
-	origGetLatest := getLatestVer
-	origInstallLatest := installLatest
-	origInstallMain := installMainOrMaster
-	origInstallByVersionUpd := installByVersionUpd
-	defer func() {
-		getLatestVer = origGetLatest
-		installLatest = origInstallLatest
-		installMainOrMaster = origInstallMain
-		installByVersionUpd = origInstallByVersionUpd
-	}()
-
+	deps := testDeps()
 	var latestCalls []string
-	getLatestVer = func(modulePath string) (string, error) {
+	deps.getLatestVer = func(_ context.Context, modulePath string) (string, error) {
 		latestCalls = append(latestCalls, modulePath)
 		if modulePath == oldModule {
 			return "", modulePathMismatchErr(oldModule, newModule)
@@ -633,15 +564,15 @@ func Test_update_modulePathChangedOnGetLatest(t *testing.T) {
 	}
 
 	var installCalls []string
-	installLatest = func(importPath string) error {
+	deps.installLatest = func(_ context.Context, importPath string) error {
 		installCalls = append(installCalls, importPath)
 		return nil
 	}
-	installMainOrMaster = func(string) error {
+	deps.installMainOrMaster = func(context.Context, string) error {
 		t.Fatal("installMainOrMaster should not be called")
 		return nil
 	}
-	installByVersionUpd = func(string, string) error {
+	deps.installByVersion = func(context.Context, string, string) error {
 		t.Fatal("installByVersionUpd should not be called")
 		return nil
 	}
@@ -662,7 +593,7 @@ func Test_update_modulePathChangedOnGetLatest(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinAir: goutil.UpdateChannelLatest}
-	if got, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, nil, 0, false, false); got != 0 {
+	if got, _, _ := updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, false); got != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", got)
 	}
 	if diff := cmp.Diff([]string{oldModule, newModule}, latestCalls); diff != "" {
@@ -681,29 +612,19 @@ func Test_update_modulePathChangedOnInstall(t *testing.T) {
 		newImport = testNewModule
 	)
 
-	origGetLatest := getLatestVer
-	origInstallLatest := installLatest
-	origInstallMain := installMainOrMaster
-	origInstallByVersionUpd := installByVersionUpd
-	defer func() {
-		getLatestVer = origGetLatest
-		installLatest = origInstallLatest
-		installMainOrMaster = origInstallMain
-		installByVersionUpd = origInstallByVersionUpd
-	}()
-
-	getLatestVer = func(string) (string, error) { return testVersionNine, nil }
-	installMainOrMaster = func(string) error {
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionNine, nil }
+	deps.installMainOrMaster = func(context.Context, string) error {
 		t.Fatal("installMainOrMaster should not be called")
 		return nil
 	}
-	installByVersionUpd = func(string, string) error {
+	deps.installByVersion = func(context.Context, string, string) error {
 		t.Fatal("installByVersionUpd should not be called")
 		return nil
 	}
 
 	var installCalls []string
-	installLatest = func(importPath string) error {
+	deps.installLatest = func(_ context.Context, importPath string) error {
 		installCalls = append(installCalls, importPath)
 		switch len(installCalls) {
 		case 1:
@@ -731,7 +652,7 @@ func Test_update_modulePathChangedOnInstall(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinAir: goutil.UpdateChannelLatest}
-	if got, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, nil, 0, false, false); got != 0 {
+	if got, _, _ := updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, false); got != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", got)
 	}
 	if diff := cmp.Diff([]string{oldImport, newImport}, installCalls); diff != "" {
@@ -778,12 +699,9 @@ func Test_installWithSelectedVersion(t *testing.T) {
 }
 
 func Test_installWithSelectedVersion_contextCanceled(t *testing.T) {
-	origInstallLatestCtx := installLatestCtx
-	defer func() {
-		installLatestCtx = origInstallLatestCtx
-	}()
-
-	installLatestCtx = func(ctx context.Context, _ string) error {
+	t.Parallel()
+	deps := testDeps()
+	deps.installLatest = func(ctx context.Context, _ string) error {
 		<-ctx.Done()
 		return fmt.Errorf("can't install %s:\n%w", "example.com/tool", ctx.Err())
 	}
@@ -791,7 +709,7 @@ func Test_installWithSelectedVersion_contextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := installWithSelectedVersion(defaultDependencies(), ctx, "example.com/tool", goutil.UpdateChannelLatest)
+	err := installWithSelectedVersion(deps, ctx, "example.com/tool", goutil.UpdateChannelLatest)
 	if !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), context.Canceled.Error()) {
 		t.Fatalf("installWithSelectedVersion() error = %v, want cancellation to be surfaced", err)
 	}
@@ -878,9 +796,8 @@ func Test_removeOldBinaryIfRenamed_emptyNames(t *testing.T) {
 }
 
 func Test_updateWithChannels_emptyImportPath(t *testing.T) {
-	origGetLatest := getLatestVer
-	defer func() { getLatestVer = origGetLatest }()
-	getLatestVer = func(string) (string, error) { return testVersionNine, nil }
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionNine, nil }
 
 	pkgs := []goutil.Package{
 		{
@@ -893,16 +810,15 @@ func Test_updateWithChannels_emptyImportPath(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
+	result, _, _ := updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
 	if result != 1 {
 		t.Fatalf("updateWithChannels() = %d, want 1 (empty import path)", result)
 	}
 }
 
 func Test_updateWithChannels_alreadyUpToDate(t *testing.T) {
-	origGetLatest := getLatestVer
-	defer func() { getLatestVer = origGetLatest }()
-	getLatestVer = func(string) (string, error) { return testVersionOne, nil }
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionOne, nil }
 
 	pkgs := []goutil.Package{
 		{
@@ -915,7 +831,7 @@ func Test_updateWithChannels_alreadyUpToDate(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, succeeded, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
+	result, succeeded, _ := updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
@@ -926,28 +842,19 @@ func Test_updateWithChannels_alreadyUpToDate(t *testing.T) {
 }
 
 func Test_updateWithChannels_alreadyUpToDate_customGoBuildTag(t *testing.T) {
-	origGetLatest := getLatestVer
-	origInstallLatest := installLatest
-	origInstallMain := installMainOrMaster
-	origInstallByVersionUpd := installByVersionUpd
-	defer func() {
-		getLatestVer = origGetLatest
-		installLatest = origInstallLatest
-		installMainOrMaster = origInstallMain
-		installByVersionUpd = origInstallByVersionUpd
-	}()
-	getLatestVer = func(string) (string, error) { return testVersionOne, nil }
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionOne, nil }
 
 	var installCalled atomic.Bool
-	installLatest = func(string) error {
+	deps.installLatest = func(context.Context, string) error {
 		installCalled.Store(true)
 		return nil
 	}
-	installMainOrMaster = func(string) error {
+	deps.installMainOrMaster = func(context.Context, string) error {
 		t.Fatal("installMainOrMaster should not be called")
 		return nil
 	}
-	installByVersionUpd = func(string, string) error {
+	deps.installByVersion = func(context.Context, string, string) error {
 		t.Fatal("installByVersionUpd should not be called")
 		return nil
 	}
@@ -972,7 +879,7 @@ func Test_updateWithChannels_alreadyUpToDate_customGoBuildTag(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, succeeded, _ := updateWithChannels(pkgs, false, false, 1, false, channelMap, nil, 0, false, false)
+	result, succeeded, _ := updateWithChannels(deps, pkgs, false, false, 1, false, channelMap, nil, 0, false, false)
 
 	if err := pw.Close(); err != nil {
 		t.Fatal(err)
@@ -1008,23 +915,14 @@ func Test_updateWithChannels_customGoBuildTag_goVersionDiffColor(t *testing.T) {
 	color.NoColor = false
 	t.Cleanup(func() { color.NoColor = oldNoColor })
 
-	origGetLatest := getLatestVer
-	origInstallLatest := installLatest
-	origInstallMain := installMainOrMaster
-	origInstallByVersionUpd := installByVersionUpd
-	defer func() {
-		getLatestVer = origGetLatest
-		installLatest = origInstallLatest
-		installMainOrMaster = origInstallMain
-		installByVersionUpd = origInstallByVersionUpd
-	}()
-	getLatestVer = func(string) (string, error) { return testVersionOne, nil }
-	installLatest = func(string) error { return nil }
-	installMainOrMaster = func(string) error {
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionOne, nil }
+	deps.installLatest = func(context.Context, string) error { return nil }
+	deps.installMainOrMaster = func(context.Context, string) error {
 		t.Fatal("installMainOrMaster should not be called")
 		return nil
 	}
-	installByVersionUpd = func(string, string) error {
+	deps.installByVersion = func(context.Context, string, string) error {
 		t.Fatal("installByVersionUpd should not be called")
 		return nil
 	}
@@ -1049,7 +947,7 @@ func Test_updateWithChannels_customGoBuildTag_goVersionDiffColor(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, false, channelMap, nil, 0, false, false)
+	result, _, _ := updateWithChannels(deps, pkgs, false, false, 1, false, channelMap, nil, 0, false, false)
 	if err := pw.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -1074,9 +972,8 @@ func Test_updateWithChannels_customGoBuildTag_goVersionDiffColor(t *testing.T) {
 }
 
 func Test_updateWithChannels_emptyModulePath(t *testing.T) {
-	origInstallLatest := installLatest
-	defer func() { installLatest = origInstallLatest }()
-	installLatest = func(string) error { return nil }
+	deps := testDeps()
+	deps.installLatest = func(context.Context, string) error { return nil }
 
 	pkgs := []goutil.Package{
 		{
@@ -1089,16 +986,15 @@ func Test_updateWithChannels_emptyModulePath(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
+	result, _, _ := updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
 }
 
 func Test_updateWithChannels_getLatestVerError(t *testing.T) {
-	origGetLatest := getLatestVer
-	defer func() { getLatestVer = origGetLatest }()
-	getLatestVer = func(string) (string, error) {
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) {
 		return "", errors.New("network error")
 	}
 
@@ -1113,27 +1009,19 @@ func Test_updateWithChannels_getLatestVerError(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
+	result, _, _ := updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
 	if result != 1 {
 		t.Fatalf("updateWithChannels() = %d, want 1", result)
 	}
 }
 
 func Test_updateWithChannels_masterChannel(t *testing.T) {
-	origGetLatest := getLatestVer
-	origRef := getVerByRefCtx
-	origInstallByVersionUpd := installByVersionUpd
-	defer func() {
-		getLatestVer = origGetLatest
-		getVerByRefCtx = origRef
-		installByVersionUpd = origInstallByVersionUpd
-	}()
-
-	getLatestVer = func(string) (string, error) { return testVersionNine, nil }
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionNine, nil }
 	// The skip/update decision resolves the version via the @master ref.
-	getVerByRefCtx = func(_ context.Context, _ string, _ string) (string, error) { return testVersionNine, nil }
+	deps.getVerByRef = func(_ context.Context, _ string, _ string) (string, error) { return testVersionNine, nil }
 	var calledVersion string
-	installByVersionUpd = func(_, ver string) error { calledVersion = ver; return nil }
+	deps.installByVersion = func(_ context.Context, _, ver string) error { calledVersion = ver; return nil }
 
 	pkgs := []goutil.Package{
 		{
@@ -1146,7 +1034,7 @@ func Test_updateWithChannels_masterChannel(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelMaster}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
+	result, _, _ := updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
@@ -1161,17 +1049,9 @@ func Test_updateWithChannels_masterChannel(t *testing.T) {
 // version (so an @latest-based decision would wrongly skip the package), while
 // @master has moved forward and must trigger an update.
 func Test_updateWithChannels_masterChannel_skipDecisionUsesChannel(t *testing.T) {
-	origGetLatest := getLatestVer
-	origRef := getVerByRefCtx
-	origInstallByVersionUpd := installByVersionUpd
-	defer func() {
-		getLatestVer = origGetLatest
-		getVerByRefCtx = origRef
-		installByVersionUpd = origInstallByVersionUpd
-	}()
-
-	getLatestVer = func(string) (string, error) { return testVersionOne, nil }
-	getVerByRefCtx = func(_ context.Context, _ string, ref string) (string, error) {
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionOne, nil }
+	deps.getVerByRef = func(_ context.Context, _ string, ref string) (string, error) {
 		if ref == string(goutil.UpdateChannelMaster) {
 			return testVersionNine, nil
 		}
@@ -1180,7 +1060,7 @@ func Test_updateWithChannels_masterChannel_skipDecisionUsesChannel(t *testing.T)
 
 	var installCalled atomic.Bool
 	var calledVersion string
-	installByVersionUpd = func(_, ver string) error {
+	deps.installByVersion = func(_ context.Context, _, ver string) error {
 		installCalled.Store(true)
 		calledVersion = ver
 		return nil
@@ -1197,7 +1077,7 @@ func Test_updateWithChannels_masterChannel_skipDecisionUsesChannel(t *testing.T)
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelMaster}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
+	result, _, _ := updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
@@ -1214,24 +1094,16 @@ func Test_updateWithChannels_masterChannel_skipDecisionUsesChannel(t *testing.T)
 // an update) but the @master ref still matches the installed version, so the
 // package must be skipped.
 func Test_updateWithChannels_masterChannel_latestMovedButMasterSame(t *testing.T) {
-	origGetLatest := getLatestVer
-	origRef := getVerByRefCtx
-	origInstallByVersionUpd := installByVersionUpd
-	defer func() {
-		getLatestVer = origGetLatest
-		getVerByRefCtx = origRef
-		installByVersionUpd = origInstallByVersionUpd
-	}()
-
-	getLatestVer = func(string) (string, error) { return testVersionNine, nil }
-	getVerByRefCtx = func(_ context.Context, _ string, ref string) (string, error) {
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionNine, nil }
+	deps.getVerByRef = func(_ context.Context, _ string, ref string) (string, error) {
 		if ref == string(goutil.UpdateChannelMaster) {
 			return testVersionOne, nil
 		}
 		return "", fmt.Errorf("unexpected ref %q", ref)
 	}
 
-	installByVersionUpd = func(_, _ string) error {
+	deps.installByVersion = func(context.Context, string, string) error {
 		t.Fatal("install must not run: @master is unchanged")
 		return nil
 	}
@@ -1247,7 +1119,7 @@ func Test_updateWithChannels_masterChannel_latestMovedButMasterSame(t *testing.T
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelMaster}
-	result, succeeded, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
+	result, succeeded, _ := updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
@@ -1260,17 +1132,9 @@ func Test_updateWithChannels_masterChannel_latestMovedButMasterSame(t *testing.T
 // channel-aware skip decision for the @main channel: @latest equals the
 // installed version, but @main has moved and must trigger an update.
 func Test_updateWithChannels_mainChannel_skipDecisionUsesChannel(t *testing.T) {
-	origGetLatest := getLatestVer
-	origRef := getVerByRefCtx
-	origInstallMain := installMainOrMaster
-	defer func() {
-		getLatestVer = origGetLatest
-		getVerByRefCtx = origRef
-		installMainOrMaster = origInstallMain
-	}()
-
-	getLatestVer = func(string) (string, error) { return testVersionOne, nil }
-	getVerByRefCtx = func(_ context.Context, _ string, ref string) (string, error) {
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionOne, nil }
+	deps.getVerByRef = func(_ context.Context, _ string, ref string) (string, error) {
 		if ref == string(goutil.UpdateChannelMain) {
 			return testVersionNine, nil
 		}
@@ -1278,7 +1142,7 @@ func Test_updateWithChannels_mainChannel_skipDecisionUsesChannel(t *testing.T) {
 	}
 
 	var installCalled atomic.Bool
-	installMainOrMaster = func(string) error {
+	deps.installMainOrMaster = func(context.Context, string) error {
 		installCalled.Store(true)
 		return nil
 	}
@@ -1294,7 +1158,7 @@ func Test_updateWithChannels_mainChannel_skipDecisionUsesChannel(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelMain}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
+	result, _, _ := updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
@@ -1311,7 +1175,7 @@ func Test_gup_excludeFlag(t *testing.T) {
 		t.Fatalf("failed to set exclude flag: %v", err)
 	}
 
-	helper_stubUpdateOps(t)
+	deps := stubUpdateDeps()
 
 	OsExit = func(code int) {}
 	defer func() { OsExit = os.Exit }()
@@ -1325,7 +1189,7 @@ func Test_gup_excludeFlag(t *testing.T) {
 	print.Stdout = pw
 	print.Stderr = pw
 
-	got := gup(cmd, []string{})
+	got := gup(deps, cmd, []string{})
 	pw.Close()
 	print.Stdout = orgStdout
 	print.Stderr = orgStderr
@@ -1346,15 +1210,9 @@ func Test_removeOldBinaryIfRenamed_notExist(t *testing.T) {
 }
 
 func Test_updateWithChannels_notify(t *testing.T) {
-	origGetLatest := getLatestVer
-	origInstallLatest := installLatest
-	defer func() {
-		getLatestVer = origGetLatest
-		installLatest = origInstallLatest
-	}()
-
-	getLatestVer = func(string) (string, error) { return testVersionNine, nil }
-	installLatest = func(string) error { return nil }
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionNine, nil }
+	deps.installLatest = func(context.Context, string) error { return nil }
 
 	pkgs := []goutil.Package{
 		{
@@ -1367,22 +1225,16 @@ func Test_updateWithChannels_notify(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(pkgs, false, true, 1, true, channelMap, nil, 0, false, false)
+	result, _, _ := updateWithChannels(deps, pkgs, false, true, 1, true, channelMap, nil, 0, false, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() with notify = %d, want 0", result)
 	}
 }
 
 func Test_updateWithChannels_installError(t *testing.T) {
-	origGetLatest := getLatestVer
-	origInstallLatest := installLatest
-	defer func() {
-		getLatestVer = origGetLatest
-		installLatest = origInstallLatest
-	}()
-
-	getLatestVer = func(string) (string, error) { return testVersionNine, nil }
-	installLatest = func(string) error { return errors.New("install failed") }
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionNine, nil }
+	deps.installLatest = func(context.Context, string) error { return errors.New("install failed") }
 
 	pkgs := []goutil.Package{
 		{
@@ -1395,35 +1247,23 @@ func Test_updateWithChannels_installError(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
+	result, _, _ := updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
 	if result != 1 {
 		t.Fatalf("updateWithChannels() = %d, want 1", result)
 	}
 }
 
 func Test_updateWithChannels_mainChannel(t *testing.T) {
-	origGetLatest := getLatestVer
-	origRef := getVerByRefCtx
-	origInstallLatest := installLatest
-	origInstallMain := installMainOrMaster
-	origInstallByVersionUpd := installByVersionUpd
-	defer func() {
-		getLatestVer = origGetLatest
-		getVerByRefCtx = origRef
-		installLatest = origInstallLatest
-		installMainOrMaster = origInstallMain
-		installByVersionUpd = origInstallByVersionUpd
-	}()
-
-	getLatestVer = func(string) (string, error) { return testVersionNine, nil }
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionNine, nil }
 	// The skip/update decision resolves the version via the @main ref.
-	getVerByRefCtx = func(_ context.Context, _ string, _ string) (string, error) { return testVersionNine, nil }
-	installLatest = func(string) error {
+	deps.getVerByRef = func(_ context.Context, _ string, _ string) (string, error) { return testVersionNine, nil }
+	deps.installLatest = func(context.Context, string) error {
 		t.Fatal("installLatest should not be called for main channel")
 		return nil
 	}
-	installMainOrMaster = func(string) error { return nil }
-	installByVersionUpd = func(string, string) error { return nil }
+	deps.installMainOrMaster = func(context.Context, string) error { return nil }
+	deps.installByVersion = func(context.Context, string, string) error { return nil }
 
 	pkgs := []goutil.Package{
 		{
@@ -1436,7 +1276,7 @@ func Test_updateWithChannels_mainChannel(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelMain}
-	result, _, _ := updateWithChannels(pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
+	result, _, _ := updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
@@ -1474,7 +1314,7 @@ func Test_update_ambiguousConfigFailsFast(t *testing.T) {
 	print.Stdout = pw
 	print.Stderr = pw
 
-	got := gup(newUpdateCmd(), []string{})
+	got := gup(defaultDependencies(), newUpdateCmd(), []string{})
 
 	pw.Close()
 	print.Stdout = orgStdout

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -1,12 +1,10 @@
-//nolint:paralleltest,errcheck,gosec
+//nolint:paralleltest
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -95,30 +93,11 @@ func Test_gup(t *testing.T) {
 				OsExit = os.Exit
 			}()
 
-			orgStdout := print.Stdout
-			orgStderr := print.Stderr
-			pr, pw, err := os.Pipe()
-			if err != nil {
-				t.Fatal(err)
-			}
-			print.Stdout = pw
-			print.Stderr = pw
+			p, buf := newTestPrinter()
 
-			if got := gup(defaultDependencies(), tt.args.cmd, tt.args.args); got != tt.want {
+			if got := gup(defaultDependencies(), p, tt.args.cmd, tt.args.args); got != tt.want {
 				t.Errorf("gup() = %v, want %v", got, tt.want)
 			}
-			if err := pw.Close(); err != nil {
-				t.Fatal(err)
-			}
-			print.Stdout = orgStdout
-			print.Stderr = orgStderr
-
-			buf := bytes.Buffer{}
-			_, err = io.Copy(&buf, pr)
-			if err != nil {
-				t.Error(err)
-			}
-			defer pr.Close()
 			got := strings.Split(buf.String(), "\n")
 
 			if diff := cmp.Diff(tt.stderr, got); diff != "" {
@@ -179,31 +158,11 @@ func Test_gup_ignoreGoUpdateFlag(t *testing.T) {
 		OsExit = os.Exit
 	}()
 
-	orgStdout := print.Stdout
-	orgStderr := print.Stderr
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	print.Stdout = pw
-	print.Stderr = pw
+	p, buf := newTestPrinter()
 
-	if got := gup(deps, cmd, []string{}); got != 0 {
+	if got := gup(deps, p, cmd, []string{}); got != 0 {
 		t.Fatalf("gup() = %v, want %v", got, 0)
 	}
-	if err := pw.Close(); err != nil {
-		t.Fatal(err)
-	}
-	print.Stdout = orgStdout
-	print.Stderr = orgStderr
-
-	var buf bytes.Buffer
-	if _, err = io.Copy(&buf, pr); err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		_ = pr.Close()
-	}()
 
 	output := strings.Split(buf.String(), "\n")
 	if len(output) == 0 || !strings.Contains(output[0], "update binary under") {
@@ -229,8 +188,8 @@ func Test_gup_emptyEnv_validatesExplicitMalformedFile(t *testing.T) {
 	}
 
 	var got int
-	out := captureCheckOutput(t, func() int {
-		got = gup(defaultDependencies(), cmd, []string{})
+	out := captureCheckOutput(t, func(p *print.Printer) int {
+		got = gup(defaultDependencies(), p, cmd, []string{})
 		return got
 	})
 	if got != 1 {
@@ -258,8 +217,8 @@ func Test_gup_emptyEnv_validatesExplicitDirectoryFile(t *testing.T) {
 	}
 
 	got := 0
-	_ = captureCheckOutput(t, func() int {
-		got = gup(defaultDependencies(), cmd, []string{})
+	_ = captureCheckOutput(t, func(p *print.Printer) int {
+		got = gup(defaultDependencies(), p, cmd, []string{})
 		return got
 	})
 	if got != 1 {
@@ -275,8 +234,8 @@ func Test_gup_emptyEnv_succeedsWithoutExplicitConfigProblem(t *testing.T) {
 	t.Setenv("GOBIN", t.TempDir()) // empty environment
 
 	got := 0
-	_ = captureCheckOutput(t, func() int {
-		got = gup(defaultDependencies(), newUpdateCmd(), []string{})
+	_ = captureCheckOutput(t, func(p *print.Printer) int {
+		got = gup(defaultDependencies(), p, newUpdateCmd(), []string{})
 		return got
 	})
 	if got != 0 {
@@ -301,8 +260,8 @@ func Test_gup_invalidConfigFile(t *testing.T) {
 	}
 
 	var got int
-	out := captureCheckOutput(t, func() int {
-		got = gup(deps, newUpdateCmd(), []string{})
+	out := captureCheckOutput(t, func(p *print.Printer) int {
+		got = gup(deps, p, newUpdateCmd(), []string{})
 		return got
 	})
 	if got != 1 {
@@ -342,7 +301,8 @@ func Test_gup_dryRun(t *testing.T) {
 		OsExit = os.Exit
 	}()
 
-	if got := gup(deps, cmd, []string{}); got != 0 {
+	p, _ := newTestPrinter()
+	if got := gup(deps, p, cmd, []string{}); got != 0 {
 		t.Fatalf("gup() = %v, want %v", got, 0)
 	}
 	if !installCalled.Load() {
@@ -357,30 +317,11 @@ func Test_update_not_use_go_cmd(t *testing.T) {
 	t.Run("Not found go command", func(t *testing.T) {
 		t.Setenv("PATH", "")
 
-		orgStdout := print.Stdout
-		orgStderr := print.Stderr
-		pr, pw, err := os.Pipe()
-		if err != nil {
-			t.Fatal(err)
-		}
-		print.Stdout = pw
-		print.Stderr = pw
+		p, buf := newTestPrinter()
 
-		if got := gup(defaultDependencies(), newUpdateCmd(), []string{}); got != 1 {
+		if got := gup(defaultDependencies(), p, newUpdateCmd(), []string{}); got != 1 {
 			t.Errorf("gup() = %v, want %v", got, 1)
 		}
-		if err := pw.Close(); err != nil {
-			t.Fatal(err)
-		}
-		print.Stdout = orgStdout
-		print.Stderr = orgStderr
-
-		buf := bytes.Buffer{}
-		_, err = io.Copy(&buf, pr)
-		if err != nil {
-			t.Error(err)
-		}
-		defer pr.Close()
 		got := strings.Split(buf.String(), "\n")
 
 		want := []string{}
@@ -425,7 +366,8 @@ func Test_desktopNotifyIfNeeded(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			desktopNotifyIfNeeded(tt.args.result, tt.args.enable)
+			p, _ := newTestPrinter()
+			desktopNotifyIfNeeded(p, tt.args.result, tt.args.enable)
 		})
 	}
 }
@@ -446,20 +388,10 @@ func Test_gup_jobsClamp(t *testing.T) {
 		OsExit = os.Exit
 	}()
 
-	orgStdout := print.Stdout
-	orgStderr := print.Stderr
-	_, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	print.Stdout = pw
-	print.Stderr = pw
+	p, _ := newTestPrinter()
 
 	// Should not hang with jobs=-1 (clamped to 1)
-	got := gup(deps, cmd, []string{})
-	pw.Close()
-	print.Stdout = orgStdout
-	print.Stderr = orgStderr
+	got := gup(deps, p, cmd, []string{})
 
 	if got != 0 {
 		t.Errorf("gup() = %v, want 0", got)
@@ -593,7 +525,8 @@ func Test_update_modulePathChangedOnGetLatest(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinAir: goutil.UpdateChannelLatest}
-	if got, _, _ := updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, false); got != 0 {
+	p, _ := newTestPrinter()
+	if got, _, _ := updateWithChannels(deps, p, pkgs, false, false, 1, true, channelMap, nil, 0, false, false); got != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", got)
 	}
 	if diff := cmp.Diff([]string{oldModule, newModule}, latestCalls); diff != "" {
@@ -652,7 +585,8 @@ func Test_update_modulePathChangedOnInstall(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinAir: goutil.UpdateChannelLatest}
-	if got, _, _ := updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, false); got != 0 {
+	p, _ := newTestPrinter()
+	if got, _, _ := updateWithChannels(deps, p, pkgs, false, false, 1, true, channelMap, nil, 0, false, false); got != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", got)
 	}
 	if diff := cmp.Diff([]string{oldImport, newImport}, installCalls); diff != "" {
@@ -810,7 +744,8 @@ func Test_updateWithChannels_emptyImportPath(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
+	p, _ := newTestPrinter()
+	result, _, _ := updateWithChannels(deps, p, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
 	if result != 1 {
 		t.Fatalf("updateWithChannels() = %d, want 1 (empty import path)", result)
 	}
@@ -831,7 +766,8 @@ func Test_updateWithChannels_alreadyUpToDate(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, succeeded, _ := updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
+	p, _ := newTestPrinter()
+	result, succeeded, _ := updateWithChannels(deps, p, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
@@ -859,14 +795,7 @@ func Test_updateWithChannels_alreadyUpToDate_customGoBuildTag(t *testing.T) {
 		return nil
 	}
 
-	orgStdout := print.Stdout
-	orgStderr := print.Stderr
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	print.Stdout = pw
-	print.Stderr = pw
+	p, buf := newTestPrinter()
 
 	pkgs := []goutil.Package{
 		{
@@ -879,19 +808,7 @@ func Test_updateWithChannels_alreadyUpToDate_customGoBuildTag(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, succeeded, _ := updateWithChannels(deps, pkgs, false, false, 1, false, channelMap, nil, 0, false, false)
-
-	if err := pw.Close(); err != nil {
-		t.Fatal(err)
-	}
-	print.Stdout = orgStdout
-	print.Stderr = orgStderr
-
-	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, pr); err != nil {
-		t.Fatal(err)
-	}
-	_ = pr.Close()
+	result, succeeded, _ := updateWithChannels(deps, p, pkgs, false, false, 1, false, channelMap, nil, 0, false, false)
 
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
@@ -927,14 +844,7 @@ func Test_updateWithChannels_customGoBuildTag_goVersionDiffColor(t *testing.T) {
 		return nil
 	}
 
-	orgStdout := print.Stdout
-	orgStderr := print.Stderr
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	print.Stdout = pw
-	print.Stderr = pw
+	p, buf := newTestPrinter()
 
 	pkgs := []goutil.Package{
 		{
@@ -947,18 +857,7 @@ func Test_updateWithChannels_customGoBuildTag_goVersionDiffColor(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(deps, pkgs, false, false, 1, false, channelMap, nil, 0, false, false)
-	if err := pw.Close(); err != nil {
-		t.Fatal(err)
-	}
-	print.Stdout = orgStdout
-	print.Stderr = orgStderr
-
-	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, pr); err != nil {
-		t.Fatal(err)
-	}
-	_ = pr.Close()
+	result, _, _ := updateWithChannels(deps, p, pkgs, false, false, 1, false, channelMap, nil, 0, false, false)
 
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
@@ -986,7 +885,8 @@ func Test_updateWithChannels_emptyModulePath(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
+	p, _ := newTestPrinter()
+	result, _, _ := updateWithChannels(deps, p, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
@@ -1009,7 +909,8 @@ func Test_updateWithChannels_getLatestVerError(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
+	p, _ := newTestPrinter()
+	result, _, _ := updateWithChannels(deps, p, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
 	if result != 1 {
 		t.Fatalf("updateWithChannels() = %d, want 1", result)
 	}
@@ -1034,7 +935,8 @@ func Test_updateWithChannels_masterChannel(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelMaster}
-	result, _, _ := updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
+	p, _ := newTestPrinter()
+	result, _, _ := updateWithChannels(deps, p, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
@@ -1077,7 +979,8 @@ func Test_updateWithChannels_masterChannel_skipDecisionUsesChannel(t *testing.T)
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelMaster}
-	result, _, _ := updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
+	p, _ := newTestPrinter()
+	result, _, _ := updateWithChannels(deps, p, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
@@ -1119,7 +1022,8 @@ func Test_updateWithChannels_masterChannel_latestMovedButMasterSame(t *testing.T
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelMaster}
-	result, succeeded, _ := updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
+	p, _ := newTestPrinter()
+	result, succeeded, _ := updateWithChannels(deps, p, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
@@ -1158,7 +1062,8 @@ func Test_updateWithChannels_mainChannel_skipDecisionUsesChannel(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelMain}
-	result, _, _ := updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
+	p, _ := newTestPrinter()
+	result, _, _ := updateWithChannels(deps, p, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
@@ -1180,19 +1085,9 @@ func Test_gup_excludeFlag(t *testing.T) {
 	OsExit = func(code int) {}
 	defer func() { OsExit = os.Exit }()
 
-	orgStdout := print.Stdout
-	orgStderr := print.Stderr
-	_, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	print.Stdout = pw
-	print.Stderr = pw
+	p, _ := newTestPrinter()
 
-	got := gup(deps, cmd, []string{})
-	pw.Close()
-	print.Stdout = orgStdout
-	print.Stderr = orgStderr
+	got := gup(deps, p, cmd, []string{})
 
 	if got != 1 {
 		t.Errorf("gup() with all excluded = %v, want 1", got)
@@ -1225,7 +1120,8 @@ func Test_updateWithChannels_notify(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(deps, pkgs, false, true, 1, true, channelMap, nil, 0, false, false)
+	p, _ := newTestPrinter()
+	result, _, _ := updateWithChannels(deps, p, pkgs, false, true, 1, true, channelMap, nil, 0, false, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() with notify = %d, want 0", result)
 	}
@@ -1247,7 +1143,8 @@ func Test_updateWithChannels_installError(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
-	result, _, _ := updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
+	p, _ := newTestPrinter()
+	result, _, _ := updateWithChannels(deps, p, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
 	if result != 1 {
 		t.Fatalf("updateWithChannels() = %d, want 1", result)
 	}
@@ -1276,7 +1173,8 @@ func Test_updateWithChannels_mainChannel(t *testing.T) {
 	}
 
 	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelMain}
-	result, _, _ := updateWithChannels(deps, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
+	p, _ := newTestPrinter()
+	result, _, _ := updateWithChannels(deps, p, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
 	if result != 0 {
 		t.Fatalf("updateWithChannels() = %d, want 0", result)
 	}
@@ -1305,24 +1203,9 @@ func Test_update_ambiguousConfigFailsFast(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	orgStdout := print.Stdout
-	orgStderr := print.Stderr
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	print.Stdout = pw
-	print.Stderr = pw
+	p, buf := newTestPrinter()
 
-	got := gup(defaultDependencies(), newUpdateCmd(), []string{})
-
-	pw.Close()
-	print.Stdout = orgStdout
-	print.Stderr = orgStderr
-
-	buf := bytes.Buffer{}
-	io.Copy(&buf, pr)
-	pr.Close()
+	got := gup(defaultDependencies(), p, newUpdateCmd(), []string{})
 
 	if got != 1 {
 		t.Errorf("update() = %d, want 1", got)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -14,7 +14,7 @@ func newVersionCmd() *cobra.Command {
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
 		Run: func(cmd *cobra.Command, args []string) {
-			print.Info(cmdinfo.GetVersion())
+			print.NewColorable().Info(cmdinfo.GetVersion())
 		},
 	}
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"github.com/nao1215/gup/internal/cmdinfo"
-	"github.com/nao1215/gup/internal/print"
 	"github.com/spf13/cobra"
 )
 
@@ -14,7 +13,7 @@ func newVersionCmd() *cobra.Command {
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
 		Run: func(cmd *cobra.Command, args []string) {
-			print.NewColorable().Info(cmdinfo.GetVersion())
+			printerFor(cmd).Info(cmdinfo.GetVersion())
 		},
 	}
 }

--- a/internal/assets/asset.go
+++ b/internal/assets/asset.go
@@ -17,11 +17,12 @@ var inforIcon []byte
 //go:embed warning.png
 var warningIcon []byte
 
-// DeployIconIfNeeded make icon file for notification.
-func DeployIconIfNeeded() {
+// DeployIconIfNeeded make icon file for notification. Diagnostics are written
+// through the provided Printer.
+func DeployIconIfNeeded(p *print.Printer) {
 	if !fileutil.IsDir(assetsDirPath()) {
 		if err := os.MkdirAll(assetsDirPath(), fileutil.FileModeCreatingDir); err != nil {
-			print.Err(fmt.Errorf("%s: %w", "can not make assets directory", err))
+			p.Err(fmt.Errorf("%s: %w", "can not make assets directory", err))
 			return
 		}
 	}
@@ -29,13 +30,13 @@ func DeployIconIfNeeded() {
 	if !fileutil.IsFile(InfoIconPath()) {
 		err := os.WriteFile(InfoIconPath(), inforIcon, fileutil.FileModeCreatingFile)
 		if err != nil {
-			print.Warn(err)
+			p.Warn(err)
 		}
 	}
 	if !fileutil.IsFile(WarningIconPath()) {
 		err := os.WriteFile(WarningIconPath(), warningIcon, fileutil.FileModeCreatingFile)
 		if err != nil {
-			print.Warn(err)
+			p.Warn(err)
 		}
 	}
 }

--- a/internal/assets/asset_test.go
+++ b/internal/assets/asset_test.go
@@ -1,8 +1,9 @@
-//nolint:paralleltest // tests mutate the global xdg.ConfigHome and print.Stderr
+//nolint:paralleltest // tests mutate the global xdg.ConfigHome
 package assets
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -37,7 +38,9 @@ func TestIconPaths(t *testing.T) {
 func TestDeployIconIfNeeded(t *testing.T) {
 	useTempConfigHome(t)
 
-	DeployIconIfNeeded()
+	p := print.New(io.Discard, io.Discard)
+
+	DeployIconIfNeeded(p)
 
 	if !fileutil.IsFile(InfoIconPath()) {
 		t.Fatalf("info icon was not deployed at %s", InfoIconPath())
@@ -55,7 +58,7 @@ func TestDeployIconIfNeeded(t *testing.T) {
 	}
 
 	// Calling again must be a no-op and must not error or change the files.
-	DeployIconIfNeeded()
+	DeployIconIfNeeded(p)
 	if !fileutil.IsFile(InfoIconPath()) || !fileutil.IsFile(WarningIconPath()) {
 		t.Error("icons should still exist after a second DeployIconIfNeeded call")
 	}
@@ -70,12 +73,10 @@ func TestDeployIconIfNeeded_MkdirError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	orig := print.Stderr
-	var buf bytes.Buffer
-	print.Stderr = &buf
-	t.Cleanup(func() { print.Stderr = orig })
+	buf := &bytes.Buffer{}
+	p := print.New(buf, buf)
 
-	DeployIconIfNeeded()
+	DeployIconIfNeeded(p)
 
 	if !strings.Contains(buf.String(), "can not make assets directory") {
 		t.Errorf("expected assets directory error, got: %s", buf.String())

--- a/internal/goutil/examples_test.go
+++ b/internal/goutil/examples_test.go
@@ -2,6 +2,7 @@ package goutil_test
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/nao1215/gup/internal/goutil"
+	"github.com/nao1215/gup/internal/print"
 )
 
 // ============================================================================
@@ -76,7 +78,7 @@ func ExampleGetPackageInformation() {
 
 	pathFileBin := filepath.Join("..", "..", "cmd", "testdata", nameDirCheckSuccess, nameFileBin)
 
-	pkgInfo, _ := goutil.GetPackageInformation([]string{pathFileBin})
+	pkgInfo, _ := goutil.GetPackageInformation(print.New(io.Discard, io.Discard), []string{pathFileBin})
 	if pkgInfo == nil {
 		log.Fatal("example GetPackageInformation failed. The returned package information is nil")
 	}
@@ -262,7 +264,7 @@ func ExampleGoPaths_StartDryRunMode() {
 // ----------------------------------------------------------------------------
 
 func ExamplePackage_SetLatestVer() {
-	packages, _ := goutil.GetPackageInformation([]string{"../../cmd/testdata/check_success/gal"})
+	packages, _ := goutil.GetPackageInformation(print.New(io.Discard, io.Discard), []string{"../../cmd/testdata/check_success/gal"})
 	if len(packages) == 0 {
 		log.Fatal("example GetPackageInformation failed. The returned package information is nil")
 	}

--- a/internal/goutil/goutil.go
+++ b/internal/goutil/goutil.go
@@ -16,10 +16,11 @@ const (
 	develVersionParen = "(devel)"
 )
 
+// goExe is the executable name for the go command.
+const goExe = "go"
+
 // Internal variables to mock/monkey-patch behaviors in tests.
 var (
-	// goExe is the executable name for the go command.
-	goExe = "go" //nolint:gochecknoglobals
 	// keyGoBin is the key name of the env variable for "GOBIN".
 	keyGoBin = "GOBIN" //nolint:gochecknoglobals
 	// keyGoPath is the key name of the env variable for "GOPATH".
@@ -27,10 +28,11 @@ var (
 	// osMkdirTemp is a copy of os.MkdirTemp to ease testing.
 	osMkdirTemp = os.MkdirTemp //nolint:gochecknoglobals
 	// goCommandContext builds the *exec.Cmd used to run the go toolchain. It is a
-	// variable so tests can swap in the standard "helper process" pattern
-	// (re-executing the test binary) and exercise the subprocess-driven helpers
-	// deterministically without network access. Production code always uses the
-	// default, which simply runs goExe with the given arguments.
+	// variable so tests can swap in either a stand-in executable (e.g. "echo") or
+	// the standard "helper process" pattern (re-executing the test binary) and
+	// exercise the subprocess-driven helpers deterministically without network
+	// access. Production code always uses the default, which runs the go command
+	// with the given arguments.
 	goCommandContext = func(ctx context.Context, args ...string) *exec.Cmd { //nolint:gochecknoglobals
 		return exec.CommandContext(ctx, goExe, args...) //#nosec G204 -- args are built internally, not from untrusted input
 	}

--- a/internal/goutil/goutil_test.go
+++ b/internal/goutil/goutil_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -160,18 +161,11 @@ but was required as: github.com/example/tool`),
 }
 
 func TestGetPackageInformation_unknown_module(t *testing.T) {
-	// Backup and defer restore STDERR via print package
-	oldPrintStderr := print.Stderr
-	defer func() {
-		print.Stderr = oldPrintStderr
-	}()
-
-	// Capture stderr
+	// Capture output via a buffer-backed Printer.
 	var tmpBuff bytes.Buffer
+	p := print.New(&tmpBuff, &tmpBuff)
 
-	print.Stderr = &tmpBuff
-
-	result, _ := GetPackageInformation([]string{"unknown-module"})
+	result, _ := GetPackageInformation(p, []string{"unknown-module"})
 
 	// Require to be empty
 	if len(result) != 0 {
@@ -191,16 +185,12 @@ func TestGetPackageInformation_unknown_module(t *testing.T) {
 // version is unavailable (second return value false) and warns exactly once,
 // instead of silently stamping "unknown" and forcing every binary to reinstall.
 func TestGetPackageInformation_goVersionFailure(t *testing.T) {
-	oldPrintStderr := print.Stderr
-	defer func() {
-		print.Stderr = oldPrintStderr
-	}()
 	// Point the go command at a binary that does not exist so "go version"
 	// fails on every OS (unlike "false", which is absent on Windows).
 	withGoExecutable(t, "gup-nonexistent-go-command-for-test")
 
-	var stderr bytes.Buffer
-	print.Stderr = &stderr
+	buf := &bytes.Buffer{}
+	printer := print.New(buf, buf)
 
 	nameDir := "check_success"
 	nameBin := "gal"
@@ -210,7 +200,7 @@ func TestGetPackageInformation_goVersionFailure(t *testing.T) {
 	}
 	pathBin := filepath.Join("..", "..", "cmd", "testdata", nameDir, nameBin)
 
-	pkgs, goVersionAvailable := GetPackageInformation([]string{pathBin})
+	pkgs, goVersionAvailable := GetPackageInformation(printer, []string{pathBin})
 
 	// The Go-version detection failure is reported, not swallowed.
 	if goVersionAvailable {
@@ -221,8 +211,8 @@ func TestGetPackageInformation_goVersionFailure(t *testing.T) {
 		t.Fatalf("GetPackageInformation() returned %d packages, want 1", len(pkgs))
 	}
 	// Exactly one warning explains why the Go-version comparison was skipped.
-	if c := strings.Count(stderr.String(), "skipping Go-version comparison"); c != 1 {
-		t.Errorf("want exactly one Go-version warning, got %d: %q", c, stderr.String())
+	if c := strings.Count(buf.String(), "skipping Go-version comparison"); c != 1 {
+		t.Errorf("want exactly one Go-version warning, got %d: %q", c, buf.String())
 	}
 
 	// Acceptance criterion (1): an otherwise up-to-date binary must not be
@@ -648,7 +638,7 @@ func TestGetPackageInformation_std_cmd_filtered(t *testing.T) {
 		t.Skipf("gofmt not found at %s: %v", gofmt, err)
 	}
 
-	result, _ := GetPackageInformation([]string{gofmt})
+	result, _ := GetPackageInformation(print.New(io.Discard, io.Discard), []string{gofmt})
 	if len(result) != 0 {
 		t.Errorf("GetPackageInformation() should filter standard library commands, got: %v", result)
 	}
@@ -1066,7 +1056,7 @@ func TestVersionUpToDate_invalidVersion(t *testing.T) {
 }
 
 func TestGetPackageInformation_emptyList(t *testing.T) {
-	result, _ := GetPackageInformation([]string{})
+	result, _ := GetPackageInformation(print.New(io.Discard, io.Discard), []string{})
 	if result != nil {
 		t.Errorf("expected nil for empty list, got %v", result)
 	}
@@ -1244,9 +1234,10 @@ func BenchmarkGetPackageInformation(b *testing.B) {
 			if err != nil {
 				b.Fatal(err)
 			}
+			p := print.New(io.Discard, io.Discard)
 			b.ResetTimer()
 			for range b.N {
-				_, _ = GetPackageInformation(list)
+				_, _ = GetPackageInformation(p, list)
 			}
 		})
 	}
@@ -1292,9 +1283,10 @@ func BenchmarkGetPackageInformationWithoutGoVersion(b *testing.B) {
 			if err != nil {
 				b.Fatal(err)
 			}
+			p := print.New(io.Discard, io.Discard)
 			b.ResetTimer()
 			for range b.N {
-				_ = GetPackageInformationWithoutGoVersion(list)
+				_ = GetPackageInformationWithoutGoVersion(p, list)
 			}
 		})
 	}

--- a/internal/goutil/goutil_test.go
+++ b/internal/goutil/goutil_test.go
@@ -88,15 +88,9 @@ func TestGetVerWithContext_unknown_module(t *testing.T) {
 }
 
 func TestGetVerWithContext_golden(t *testing.T) {
-	// Backup and defer restore
-	oldGoExe := goExe
-	defer func() {
-		goExe = oldGoExe
-	}()
-
 	// Mock the `go` to `echo` command so that the command succeeds and the
 	// requested ref is echoed back as the resolved version.
-	goExe = "echo"
+	withGoExecutable(t, "echo")
 
 	out, err := GetVerWithContext(context.Background(), "github.com/nao1215/gup", "master")
 	if err != nil {
@@ -197,15 +191,13 @@ func TestGetPackageInformation_unknown_module(t *testing.T) {
 // version is unavailable (second return value false) and warns exactly once,
 // instead of silently stamping "unknown" and forcing every binary to reinstall.
 func TestGetPackageInformation_goVersionFailure(t *testing.T) {
-	oldGoExe := goExe
 	oldPrintStderr := print.Stderr
 	defer func() {
-		goExe = oldGoExe
 		print.Stderr = oldPrintStderr
 	}()
 	// Point the go command at a binary that does not exist so "go version"
 	// fails on every OS (unlike "false", which is absent on Windows).
-	goExe = "gup-nonexistent-go-command-for-test"
+	withGoExecutable(t, "gup-nonexistent-go-command-for-test")
 
 	var stderr bytes.Buffer
 	print.Stderr = &stderr
@@ -310,17 +302,11 @@ func TestGetPackageVersion_package_has_no_version_info(t *testing.T) {
 	t.Setenv(keyGoBin, filepath.Join(t.TempDir(), "bin"))
 	t.Setenv(keyGoPath, "")
 
-	// Backup and defer restore
-	OldGoExe := goExe
-	defer func() {
-		goExe = OldGoExe
-	}()
-
 	// Mock the `go` to `echo` command to print instead of executing.
 	// This will succeed executing via `exec.Command` but the output will not
 	// contain package version as expected. Thus, it will return "unknown" as
 	// a result.
-	goExe = "echo"
+	withGoExecutable(t, "echo")
 
 	want := "unknown"
 	got := GetPackageVersion("go")
@@ -397,17 +383,11 @@ func TestInstall_arg_is_command_line_arguments(t *testing.T) {
 }
 
 func TestInstallLatest_golden(t *testing.T) {
-	// Backup and defer restore
-	OldGoExe := goExe
-	defer func() {
-		goExe = OldGoExe
-	}()
-
 	// Mock the `go` to `echo` command to print instead of executing go.
 	//
 	// This will succeed executing via `exec.Command` and will not execute the
 	// actual `go install <package>` command but `echo install <package>`.
-	goExe = "echo"
+	withGoExecutable(t, "echo")
 
 	err := InstallLatest("github.com/nao1215/gup")
 
@@ -418,14 +398,8 @@ func TestInstallLatest_golden(t *testing.T) {
 }
 
 func TestInstall_specificVersion_golden(t *testing.T) {
-	// Backup and defer restore
-	oldGoExe := goExe
-	defer func() {
-		goExe = oldGoExe
-	}()
-
 	// Mock the `go` to `echo` command to print instead of executing go.
-	goExe = "echo"
+	withGoExecutable(t, "echo")
 
 	err := Install("github.com/nao1215/gup", "v1.0.0")
 	if err != nil {
@@ -434,17 +408,11 @@ func TestInstall_specificVersion_golden(t *testing.T) {
 }
 
 func TestInstallMaster_golden(t *testing.T) {
-	// Backup and defer restore
-	OldGoExe := goExe
-	defer func() {
-		goExe = OldGoExe
-	}()
-
 	// Mock the `go` to `echo` command to print instead of executing go.
 	//
 	// This will succeed executing via `exec.Command` and will not execute the
 	// actual `go install <package>` command but `echo install <package>`.
-	goExe = "echo"
+	withGoExecutable(t, "echo")
 
 	err := InstallMainOrMaster("github.com/nao1215/gup")
 
@@ -1069,14 +1037,11 @@ func TestPackage_IsGoUpToDate_customBuildTag(t *testing.T) {
 }
 
 func TestInstallMainOrMaster_mainFailsGenericError_noMasterFallback(t *testing.T) {
-	oldGoExe := goExe
-	defer func() { goExe = oldGoExe }()
-
-	// Point goExe at a path that does not exist so the @main install fails on
-	// every OS (no "unknown revision main" on stderr), i.e. a generic
+	// Point the go command at a path that does not exist so the @main install
+	// fails on every OS (no "unknown revision main" on stderr), i.e. a generic
 	// (non-branch-not-found) failure. Per #340 gup must surface the @main error
 	// and must NOT fall back to @master.
-	goExe = filepath.Join(t.TempDir(), "no-such-go-binary")
+	withGoExecutable(t, filepath.Join(t.TempDir(), "no-such-go-binary"))
 
 	err := InstallMainOrMaster("github.com/example/tool")
 	if err == nil {
@@ -1198,11 +1163,9 @@ func errorCauseAfterPrefix(t *testing.T, err error, prefix string) string {
 // subprocess fails without writing to stderr (as a killed process does), the
 // error must still name a cause (from err.Error()) instead of being empty.
 func TestInstallWithContext_EmptyStderrFallback(t *testing.T) {
-	oldGoExe := goExe
-	defer func() { goExe = oldGoExe }()
 	// A missing command fails on every OS while leaving stderr empty, and with
 	// context.Background() ctx.Err() is nil so the fallback branch is reached.
-	goExe = "gup-nonexistent-go-command-for-test"
+	withGoExecutable(t, "gup-nonexistent-go-command-for-test")
 
 	err := InstallWithContext(context.Background(), timeoutTestImportPath, "latest")
 	if err == nil {
@@ -1220,9 +1183,7 @@ func TestInstallWithContext_EmptyStderrFallback(t *testing.T) {
 // TestGetVerWithContext_EmptyStderrFallback is the GetVerWithContext counterpart
 // of TestInstallWithContext_EmptyStderrFallback (issue #298).
 func TestGetVerWithContext_EmptyStderrFallback(t *testing.T) {
-	oldGoExe := goExe
-	defer func() { goExe = oldGoExe }()
-	goExe = "gup-nonexistent-go-command-for-test"
+	withGoExecutable(t, "gup-nonexistent-go-command-for-test")
 
 	_, err := GetVerWithContext(context.Background(), timeoutTestImportPath, "latest")
 	if err == nil {

--- a/internal/goutil/helperprocess_test.go
+++ b/internal/goutil/helperprocess_test.go
@@ -89,6 +89,20 @@ func withHelperProcessMainMasterFallback(t *testing.T, mainStderr string) {
 	}
 }
 
+// withGoExecutable swaps goCommandContext so every go invocation runs the given
+// executable (e.g. "echo" to succeed and echo the args back, or a nonexistent
+// path to force a failure) instead of the real go toolchain. It restores the
+// previous seam on cleanup. This replaces the former mutable goExe global swap.
+func withGoExecutable(t *testing.T, name string) {
+	t.Helper()
+	old := goCommandContext
+	t.Cleanup(func() { goCommandContext = old })
+
+	goCommandContext = func(ctx context.Context, args ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, name, args...) //#nosec G204 -- test seam, name is a test-controlled value
+	}
+}
+
 // TestHelperProcess is not a real test. It is re-executed as a subprocess by the
 // helpers above; when GO_WANT_HELPER_PROCESS is unset it returns immediately so
 // it is a no-op during a normal "go test" run.

--- a/internal/goutil/pkginfo.go
+++ b/internal/goutil/pkginfo.go
@@ -95,21 +95,21 @@ func isModuleBinary(mainModulePath string) bool {
 // (behave as --ignore-go-update); otherwise a transient "go version" failure
 // stamps "unknown" on every package and forces a needless reinstall of all
 // binaries (see issue #296).
-func GetPackageInformation(binList []string) ([]Package, bool) {
+func GetPackageInformation(p *print.Printer, binList []string) ([]Package, bool) {
 	goVer, err := GetInstalledGoVersion()
 	if err != nil {
-		print.Warn(fmt.Sprintf("failed to detect installed Go version (%v); "+
+		p.Warn(fmt.Sprintf("failed to detect installed Go version (%v); "+
 			"skipping Go-version comparison this run. Module versions are still checked.", err))
-		return collectPackageInformation(binList, unknown), false
+		return collectPackageInformation(p, binList, unknown), false
 	}
-	return collectPackageInformation(binList, goVer), true
+	return collectPackageInformation(p, binList, goVer), true
 }
 
 // GetPackageInformationWithoutGoVersion is like GetPackageInformation but skips
 // the "go version" subprocess. Use it for commands (list, export, migrate) that
 // never read Package.GoVersion, avoiding a needless subprocess per invocation.
-func GetPackageInformationWithoutGoVersion(binList []string) []Package {
-	return collectPackageInformation(binList, unknown)
+func GetPackageInformationWithoutGoVersion(p *print.Printer, binList []string) []Package {
+	return collectPackageInformation(p, binList, unknown)
 }
 
 // collectPackageInformation reads build info for each binary in parallel and
@@ -117,7 +117,7 @@ func GetPackageInformationWithoutGoVersion(binList []string) []Package {
 // the bounded worker pool to internal/parallel.Run so the concurrency logic is
 // not duplicated. No context or timeout is used because buildinfo.ReadFile is a
 // fast local read, so onCancel never fires.
-func collectPackageInformation(binList []string, goVer string) []Package {
+func collectPackageInformation(p *print.Printer, binList []string, goVer string) []Package {
 	if len(binList) == 0 {
 		return nil
 	}
@@ -135,7 +135,7 @@ func collectPackageInformation(binList []string, goVer string) []Package {
 		func(_ context.Context, v string) indexedPkg {
 			info, err := buildinfo.ReadFile(v)
 			if err != nil {
-				print.Warn(err)
+				p.Warn(err)
 				return indexedPkg{}
 			}
 			if !isModuleBinary(info.Main.Path) {

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -8,20 +8,22 @@ import (
 	"github.com/nao1215/gup/internal/print"
 )
 
-// Info notify information message at desktop.
-func Info(title, message string) {
-	assets.DeployIconIfNeeded()
+// Info notify information message at desktop. Diagnostics are written through
+// the provided Printer.
+func Info(p *print.Printer, title, message string) {
+	assets.DeployIconIfNeeded(p)
 	err := beeep.Notify(title, message, assets.InfoIconPath())
 	if err != nil {
-		print.Warn(err)
+		p.Warn(err)
 	}
 }
 
-// Warn notify warning message at desktop.
-func Warn(title, message string) {
-	assets.DeployIconIfNeeded()
+// Warn notify warning message at desktop. Diagnostics are written through the
+// provided Printer.
+func Warn(p *print.Printer, title, message string) {
+	assets.DeployIconIfNeeded(p)
 	err := beeep.Notify(title, message, assets.WarningIconPath())
 	if err != nil {
-		print.Warn(err)
+		p.Warn(err)
 	}
 }

--- a/internal/notify/notify_dragonfly.go
+++ b/internal/notify/notify_dragonfly.go
@@ -2,12 +2,14 @@
 
 package notify
 
+import "github.com/nao1215/gup/internal/print"
+
 // Info notify information message at desktop
-func Info(title, message string) {
+func Info(_ *print.Printer, _, _ string) {
 	return
 }
 
 // Warn notify warning message at desktop
-func Warn(title, message string) {
+func Warn(_ *print.Printer, _, _ string) {
 	return
 }

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -1,6 +1,6 @@
 //go:build !dragonfly
 
-//nolint:paralleltest // tests mutate the global xdg.ConfigHome and print.Stderr
+//nolint:paralleltest // tests mutate the global xdg.ConfigHome
 package notify
 
 import (
@@ -13,29 +13,24 @@ import (
 	"github.com/nao1215/gup/internal/print"
 )
 
-// useTempConfigHome points the asset directory at a fresh temp directory and
-// silences print output (beeep may warn when no desktop session is available).
+// useTempConfigHome points the asset directory at a fresh temp directory.
 func useTempConfigHome(t *testing.T) {
 	t.Helper()
 	orgConfig := xdg.ConfigHome
-	orgStderr := print.Stderr
-	orgStdout := print.Stdout
 	t.Cleanup(func() {
 		xdg.ConfigHome = orgConfig
-		print.Stderr = orgStderr
-		print.Stdout = orgStdout
 	})
 	xdg.ConfigHome = t.TempDir()
-	buf := &bytes.Buffer{}
-	print.Stderr = buf
-	print.Stdout = buf
 }
 
 func TestInfo(t *testing.T) {
 	useTempConfigHome(t)
 
+	buf := &bytes.Buffer{}
+	p := print.New(buf, buf)
+
 	// Should not panic even when no desktop notification backend is available.
-	Info("gup", "info message")
+	Info(p, "gup", "info message")
 
 	if !fileutil.IsFile(assets.InfoIconPath()) {
 		t.Errorf("Info should deploy the info icon at %s", assets.InfoIconPath())
@@ -45,7 +40,10 @@ func TestInfo(t *testing.T) {
 func TestWarn(t *testing.T) {
 	useTempConfigHome(t)
 
-	Warn("gup", "warning message")
+	buf := &bytes.Buffer{}
+	p := print.New(buf, buf)
+
+	Warn(p, "gup", "warning message")
 
 	if !fileutil.IsFile(assets.WarningIconPath()) {
 		t.Errorf("Warn should deploy the warning icon at %s", assets.WarningIconPath())

--- a/internal/pkgselect/pkgselect.go
+++ b/internal/pkgselect/pkgselect.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/nao1215/gup/internal/binname"
 	"github.com/nao1215/gup/internal/goutil"
+	"github.com/nao1215/gup/internal/print"
 )
 
 // BinaryPaths returns the absolute paths of the binaries installed under $GOBIN
@@ -39,13 +40,13 @@ func BinaryPaths() ([]string, error) {
 // PackageInfo returns package information for every installed binary without
 // reading the Go toolchain version. Use it for commands (list, export) that
 // never compare Package.GoVersion, avoiding a needless "go version" subprocess.
-func PackageInfo() ([]goutil.Package, error) {
+func PackageInfo(p *print.Printer) ([]goutil.Package, error) {
 	binList, err := BinaryPaths()
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", "can't get package info", err)
 	}
 
-	return goutil.GetPackageInformationWithoutGoVersion(binList), nil
+	return goutil.GetPackageInformationWithoutGoVersion(p, binList), nil
 }
 
 // PackageInfoByTargets returns package information for the installed binaries
@@ -58,14 +59,14 @@ func PackageInfo() ([]goutil.Package, error) {
 // a binary that exists in $GOBIN but whose build info can't be read (or that was
 // not installed by 'go install') is never mislabeled as "not found"; it is
 // present but unmanageable, and GetPackageInformation already warns about it.
-func PackageInfoByTargets(targets []string) (pkgs []goutil.Package, missing []string, goVersionAvailable bool, err error) {
+func PackageInfoByTargets(p *print.Printer, targets []string) (pkgs []goutil.Package, missing []string, goVersionAvailable bool, err error) {
 	binList, err := BinaryPaths()
 	if err != nil {
 		return nil, nil, false, fmt.Errorf("%s: %w", "can't get package info", err)
 	}
 
 	filtered := FilterBinaryPaths(binList, targets)
-	pkgs, goVersionAvailable = goutil.GetPackageInformation(filtered)
+	pkgs, goVersionAvailable = goutil.GetPackageInformation(p, filtered)
 	missing = MissingTargets(binList, targets)
 	return pkgs, missing, goVersionAvailable, nil
 }

--- a/internal/pkgselect/pkgselect_test.go
+++ b/internal/pkgselect/pkgselect_test.go
@@ -1,6 +1,7 @@
 package pkgselect
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/nao1215/gup/internal/goutil"
+	"github.com/nao1215/gup/internal/print"
 )
 
 const (
@@ -263,7 +265,7 @@ func TestBinaryPaths(t *testing.T) {
 func TestPackageInfoByTargets_filtersToTarget(t *testing.T) {
 	t.Setenv("GOBIN", filepath.Join("..", "..", "cmd", "testdata", "check_success"))
 
-	pkgs, missing, _, err := PackageInfoByTargets([]string{"gal"})
+	pkgs, missing, _, err := PackageInfoByTargets(print.New(io.Discard, io.Discard), []string{"gal"})
 	if err != nil {
 		t.Fatalf("PackageInfoByTargets() error = %v", err)
 	}
@@ -285,7 +287,7 @@ func TestPackageInfoByTargets_filtersToTarget(t *testing.T) {
 func TestPackageInfoByTargets_presentButUnreadableIsNotMissing(t *testing.T) {
 	t.Setenv("GOBIN", filepath.Join("..", "..", "cmd", "testdata", "check_fail"))
 
-	pkgs, missing, _, err := PackageInfoByTargets([]string{"dummy"})
+	pkgs, missing, _, err := PackageInfoByTargets(print.New(io.Discard, io.Discard), []string{"dummy"})
 	if err != nil {
 		t.Fatalf("PackageInfoByTargets() error = %v", err)
 	}

--- a/internal/print/print.go
+++ b/internal/print/print.go
@@ -3,6 +3,7 @@ package print
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -11,66 +12,82 @@ import (
 	"github.com/nao1215/gup/internal/cmdinfo"
 )
 
-var (
-	// Stdout is new instance of Writer which handles escape sequence for stdout.
-	Stdout = colorable.NewColorableStdout() //nolint:gochecknoglobals
-	// Stderr is new instance of Writer which handles escape sequence for stderr.
-	Stderr = colorable.NewColorableStderr() //nolint:gochecknoglobals
-)
+// Printer writes gup's colored, prefixed messages to a pair of writers. Threading
+// a *Printer through the command and helper layers (instead of reading
+// package-level Stdout/Stderr globals) lets each caller decide where output goes
+// and lets tests capture output by constructing a buffer-backed Printer and
+// passing it in, so they no longer mutate shared globals and can run in parallel.
+type Printer struct {
+	out    io.Writer
+	err    io.Writer
+	scanln func(a ...any) (n int, err error)
+	exit   func(code int)
+}
 
-// Info print information message at STDOUT in green.
-// This function is used to print some information (that is not error) to the user.
+// New returns a Printer that writes normal output to out and warnings/errors to
+// err. User input (Question) is read with fmt.Scanln and Fatal exits via os.Exit;
+// tests in this package override those fields directly.
+func New(out, err io.Writer) *Printer {
+	return &Printer{out: out, err: err, scanln: fmt.Scanln, exit: os.Exit}
+}
+
+// NewColorable returns the production Printer, writing to the colorable wrappers
+// of the process stdout/stderr so escape sequences render on every platform.
+func NewColorable() *Printer {
+	return New(colorable.NewColorableStdout(), colorable.NewColorableStderr())
+}
+
+// Out returns the writer used for normal output, for callers that must write
+// structured output (JSON, config files, formatted tables) directly.
+func (p *Printer) Out() io.Writer { return p.out }
+
+// ErrOut returns the writer used for warnings and errors.
+func (p *Printer) ErrOut() io.Writer { return p.err }
+
+// Info prints an information message to the normal output in green.
 //
 // NOTE: When we executed gup update, the standard output became quite wide.
 // To make the information more readable for the user, I removed the 'gup:INFO:' part.
-func Info(msg string) {
-	_, _ = fmt.Fprintf(Stdout, "%s\n", msg)
+func (p *Printer) Info(msg string) {
+	_, _ = fmt.Fprintf(p.out, "%s\n", msg)
 }
 
-// Warn print warning message at STDERR in yellow.
-// This function is used to print warning message to the user.
-func Warn(err interface{}) {
-	_, _ = fmt.Fprintf(Stderr, "%s:%s: %v\n",
+// Warn prints a warning message to the error output in yellow.
+func (p *Printer) Warn(err interface{}) {
+	_, _ = fmt.Fprintf(p.err, "%s:%s: %v\n",
 		cmdinfo.Name, color.YellowString("WARN "), err)
 }
 
-// Err print error message at STDERR in yellow.
-// This function is used to print error message to the user.
-func Err(err interface{}) {
-	_, _ = fmt.Fprintf(Stderr, "%s:%s: %v\n",
+// Err prints an error message to the error output in high-intensity yellow.
+func (p *Printer) Err(err interface{}) {
+	_, _ = fmt.Fprintf(p.err, "%s:%s: %v\n",
 		cmdinfo.Name, color.HiYellowString("ERROR"), err)
 }
 
-// Hint print a next-step suggestion at STDERR in cyan. It is used to follow up
-// an error with actionable guidance (e.g. which command to run next) so a
-// failure is not just reported but explained.
-func Hint(msg string) {
-	_, _ = fmt.Fprintf(Stderr, "%s:%s : %v\n",
+// Hint prints a next-step suggestion to the error output in cyan. It is used to
+// follow up an error with actionable guidance (e.g. which command to run next)
+// so a failure is not just reported but explained.
+func (p *Printer) Hint(msg string) {
+	_, _ = fmt.Fprintf(p.err, "%s:%s : %v\n",
 		cmdinfo.Name, color.CyanString("HINT"), msg)
 }
 
-// OsExit is wrapper for  os.Exit(). It's for unit test.
-var OsExit = os.Exit //nolint:gochecknoglobals
-
-// Fatal print dying message at STDERR in red.
-// After print message, process will exit.
-func Fatal(err interface{}) {
-	_, _ = fmt.Fprintf(Stderr, "%s:%s: %v\n",
+// Fatal prints a dying message to the error output in red and then exits.
+func (p *Printer) Fatal(err interface{}) {
+	_, _ = fmt.Fprintf(p.err, "%s:%s: %v\n",
 		cmdinfo.Name, color.RedString("FATAL"), err)
-	OsExit(1)
+	p.exit(1)
 }
 
-// FmtScanln is wrapper for fmt.Scanln(). It's for unit test.
-var FmtScanln = fmt.Scanln //nolint:gochecknoglobals
-
-// Question displays the question in the terminal and receives an answer from the user.
-func Question(ask string) bool {
+// Question displays the question on the normal output and receives an answer
+// from the user.
+func (p *Printer) Question(ask string) bool {
 	for {
 		var response string
 
-		_, _ = fmt.Fprintf(Stdout, "%s:%s: %s",
+		_, _ = fmt.Fprintf(p.out, "%s:%s: %s",
 			cmdinfo.Name, color.GreenString("CHECK"), ask+" [Y/n] ")
-		_, err := FmtScanln(&response)
+		_, err := p.scanln(&response)
 		if err != nil {
 			// If user input only enter, [Y/n] syntax is commonly used to denote that
 			// "yes" is the default.
@@ -78,7 +95,7 @@ func Question(ask string) bool {
 			if strings.Contains(err.Error(), "expected newline") {
 				return true
 			}
-			Err(err)
+			p.Err(err)
 			return false
 		}
 

--- a/internal/print/print.go
+++ b/internal/print/print.go
@@ -34,8 +34,17 @@ func New(out, err io.Writer) *Printer {
 // NewColorable returns the production Printer, writing to the colorable wrappers
 // of the process stdout/stderr so escape sequences render on every platform.
 func NewColorable() *Printer {
-	return New(colorable.NewColorableStdout(), colorable.NewColorableStderr())
+	return New(ColorableStdout(), ColorableStderr())
 }
+
+// ColorableStdout returns the process stdout wrapped so escape sequences render
+// on every platform. It lets the command layer wire the production output sink
+// onto the root command (via cobra SetOut) without importing go-colorable.
+func ColorableStdout() io.Writer { return colorable.NewColorableStdout() }
+
+// ColorableStderr returns the process stderr wrapped so escape sequences render
+// on every platform.
+func ColorableStderr() io.Writer { return colorable.NewColorableStderr() }
 
 // Out returns the writer used for normal output, for callers that must write
 // structured output (JSON, config files, formatted tables) directly.

--- a/internal/print/print.go
+++ b/internal/print/print.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/fatih/color"
 	"github.com/mattn/go-colorable"
@@ -17,7 +18,14 @@ import (
 // package-level Stdout/Stderr globals) lets each caller decide where output goes
 // and lets tests capture output by constructing a buffer-backed Printer and
 // passing it in, so they no longer mutate shared globals and can run in parallel.
+//
+// A single Printer is shared across parallel workers (for example
+// goutil.GetPackageInformation reports unreadable binaries via Warn from inside
+// a parallel.Run worker), so the message methods serialize their writes with mu.
+// This keeps diagnostics intact and the underlying writer (a bytes.Buffer in
+// tests, the colorable process streams in production) race-free.
 type Printer struct {
+	mu     sync.Mutex
 	out    io.Writer
 	err    io.Writer
 	scanln func(a ...any) (n int, err error)
@@ -29,6 +37,14 @@ type Printer struct {
 // tests in this package override those fields directly.
 func New(out, err io.Writer) *Printer {
 	return &Printer{out: out, err: err, scanln: fmt.Scanln, exit: os.Exit}
+}
+
+// printf formats and writes to w while holding mu, so concurrent message methods
+// (called from parallel workers) never write to the shared writer at once.
+func (p *Printer) printf(w io.Writer, format string, args ...any) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	_, _ = fmt.Fprintf(w, format, args...)
 }
 
 // NewColorable returns the production Printer, writing to the colorable wrappers
@@ -58,18 +74,18 @@ func (p *Printer) ErrOut() io.Writer { return p.err }
 // NOTE: When we executed gup update, the standard output became quite wide.
 // To make the information more readable for the user, I removed the 'gup:INFO:' part.
 func (p *Printer) Info(msg string) {
-	_, _ = fmt.Fprintf(p.out, "%s\n", msg)
+	p.printf(p.out, "%s\n", msg)
 }
 
 // Warn prints a warning message to the error output in yellow.
 func (p *Printer) Warn(err interface{}) {
-	_, _ = fmt.Fprintf(p.err, "%s:%s: %v\n",
+	p.printf(p.err, "%s:%s: %v\n",
 		cmdinfo.Name, color.YellowString("WARN "), err)
 }
 
 // Err prints an error message to the error output in high-intensity yellow.
 func (p *Printer) Err(err interface{}) {
-	_, _ = fmt.Fprintf(p.err, "%s:%s: %v\n",
+	p.printf(p.err, "%s:%s: %v\n",
 		cmdinfo.Name, color.HiYellowString("ERROR"), err)
 }
 
@@ -77,24 +93,25 @@ func (p *Printer) Err(err interface{}) {
 // follow up an error with actionable guidance (e.g. which command to run next)
 // so a failure is not just reported but explained.
 func (p *Printer) Hint(msg string) {
-	_, _ = fmt.Fprintf(p.err, "%s:%s : %v\n",
+	p.printf(p.err, "%s:%s : %v\n",
 		cmdinfo.Name, color.CyanString("HINT"), msg)
 }
 
 // Fatal prints a dying message to the error output in red and then exits.
 func (p *Printer) Fatal(err interface{}) {
-	_, _ = fmt.Fprintf(p.err, "%s:%s: %v\n",
+	p.printf(p.err, "%s:%s: %v\n",
 		cmdinfo.Name, color.RedString("FATAL"), err)
 	p.exit(1)
 }
 
 // Question displays the question on the normal output and receives an answer
-// from the user.
+// from the user. It is interactive and single-threaded (never shared with
+// parallel workers), so the blocking scanln runs outside the write lock.
 func (p *Printer) Question(ask string) bool {
 	for {
 		var response string
 
-		_, _ = fmt.Fprintf(p.out, "%s:%s: %s",
+		p.printf(p.out, "%s:%s: %s",
 			cmdinfo.Name, color.GreenString("CHECK"), ask+" [Y/n] ")
 		_, err := p.scanln(&response)
 		if err != nil {

--- a/internal/print/print_test.go
+++ b/internal/print/print_test.go
@@ -1,12 +1,9 @@
 // Package print defines functions to accept colored standard output and user input
-//
-//nolint:paralleltest
 package print
 
 import (
 	"bytes"
 	"errors"
-	"io"
 	"os"
 	"runtime"
 	"strings"
@@ -21,48 +18,21 @@ const (
 	testNoCheck      = "no check"
 )
 
-func TestInfo(t *testing.T) {
-	type args struct {
-		msg string
-	}
+func TestPrinter_Info(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
-		args args
+		msg  string
 		want []string
 	}{
-		{
-			name: testPrintMessage,
-			args: args{
-				msg: testMessage,
-			},
-			want: []string{testMessage, ""},
-		},
+		{name: testPrintMessage, msg: testMessage, want: []string{testMessage, ""}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			orgStdout := Stdout
-			orgStderr := Stderr
-			pr, pw, err := os.Pipe()
-			if err != nil {
-				t.Fatal(err)
-			}
-			Stdout = pw
-			Stderr = pw
-
-			Info(tt.args.msg)
-			if err := pw.Close(); err != nil {
-				t.Fatal(err)
-			}
-			Stdout = orgStdout
-			Stderr = orgStderr
-
-			buf := bytes.Buffer{}
-			_, err = io.Copy(&buf, pr)
-			if err != nil {
-				t.Error(err)
-			}
+			t.Parallel()
+			buf := &bytes.Buffer{}
+			New(buf, buf).Info(tt.msg)
 			got := strings.Split(buf.String(), "\n")
-
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("value is mismatch (-want +got):\n%s", diff)
 			}
@@ -70,48 +40,21 @@ func TestInfo(t *testing.T) {
 	}
 }
 
-func TestWarn(t *testing.T) {
-	type args struct {
-		msg string
-	}
+func TestPrinter_Warn(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
-		args args
+		msg  string
 		want []string
 	}{
-		{
-			name: testPrintMessage,
-			args: args{
-				msg: testMessage,
-			},
-			want: []string{"gup:WARN : test message", ""},
-		},
+		{name: testPrintMessage, msg: testMessage, want: []string{"gup:WARN : test message", ""}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			orgStdout := Stdout
-			orgStderr := Stderr
-			pr, pw, err := os.Pipe()
-			if err != nil {
-				t.Fatal(err)
-			}
-			Stdout = pw
-			Stderr = pw
-
-			Warn(tt.args.msg)
-			if err := pw.Close(); err != nil {
-				t.Fatal(err)
-			}
-			Stdout = orgStdout
-			Stderr = orgStderr
-
-			buf := bytes.Buffer{}
-			_, err = io.Copy(&buf, pr)
-			if err != nil {
-				t.Error(err)
-			}
+			t.Parallel()
+			buf := &bytes.Buffer{}
+			New(buf, buf).Warn(tt.msg)
 			got := strings.Split(buf.String(), "\n")
-
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("value is mismatch (-want +got):\n%s", diff)
 			}
@@ -119,96 +62,21 @@ func TestWarn(t *testing.T) {
 	}
 }
 
-func TestErr(t *testing.T) {
-	type args struct {
-		msg string
-	}
+func TestPrinter_Err(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
-		args args
+		msg  string
 		want []string
 	}{
-		{
-			name: testPrintMessage,
-			args: args{
-				msg: testMessage,
-			},
-			want: []string{"gup:ERROR: test message", ""},
-		},
+		{name: testPrintMessage, msg: testMessage, want: []string{"gup:ERROR: test message", ""}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			orgStdout := Stdout
-			orgStderr := Stderr
-			pr, pw, err := os.Pipe()
-			if err != nil {
-				t.Fatal(err)
-			}
-			Stdout = pw
-			Stderr = pw
-
-			Err(tt.args.msg)
-			if err := pw.Close(); err != nil {
-				t.Fatal(err)
-			}
-			Stdout = orgStdout
-			Stderr = orgStderr
-
-			buf := bytes.Buffer{}
-			_, err = io.Copy(&buf, pr)
-			if err != nil {
-				t.Error(err)
-			}
+			t.Parallel()
+			buf := &bytes.Buffer{}
+			New(buf, buf).Err(tt.msg)
 			got := strings.Split(buf.String(), "\n")
-
-			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("value is mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-func TestHint(t *testing.T) {
-	type args struct {
-		msg string
-	}
-	tests := []struct {
-		name string
-		args args
-		want []string
-	}{
-		{
-			name: testPrintMessage,
-			args: args{
-				msg: testMessage,
-			},
-			want: []string{"gup:HINT : test message", ""},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			orgStdout := Stdout
-			orgStderr := Stderr
-			pr, pw, err := os.Pipe()
-			if err != nil {
-				t.Fatal(err)
-			}
-			Stdout = pw
-			Stderr = pw
-
-			Hint(tt.args.msg)
-			if err := pw.Close(); err != nil {
-				t.Fatal(err)
-			}
-			Stdout = orgStdout
-			Stderr = orgStderr
-
-			buf := bytes.Buffer{}
-			_, err = io.Copy(&buf, pr)
-			if err != nil {
-				t.Error(err)
-			}
-			got := strings.Split(buf.String(), "\n")
-
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("value is mismatch (-want +got):\n%s", diff)
 			}
@@ -216,113 +84,72 @@ func TestHint(t *testing.T) {
 	}
 }
 
-func TestFatal(t *testing.T) {
-	type args struct {
-		msg string
+func TestPrinter_Hint(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		msg  string
+		want []string
+	}{
+		{name: testPrintMessage, msg: testMessage, want: []string{"gup:HINT : test message", ""}},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			buf := &bytes.Buffer{}
+			New(buf, buf).Hint(tt.msg)
+			got := strings.Split(buf.String(), "\n")
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("value is mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPrinter_Fatal(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
-		args     args
+		msg      string
 		want     []string
 		exitcode int
 	}{
-		{
-			name: testPrintMessage,
-			args: args{
-				msg: testMessage,
-			},
-			want:     []string{"gup:FATAL: test message", ""},
-			exitcode: 1,
-		},
+		{name: testPrintMessage, msg: testMessage, want: []string{"gup:FATAL: test message", ""}, exitcode: 1},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			orgStdout := Stdout
-			orgStderr := Stderr
-			pr, pw, err := os.Pipe()
-			if err != nil {
-				t.Fatal(err)
-			}
-			Stdout = pw
-			Stderr = pw
-
-			orgOsExit := OsExit
+			t.Parallel()
+			buf := &bytes.Buffer{}
+			p := New(buf, buf)
 			exitCode := 0
-			OsExit = func(code int) {
-				exitCode = code
-			}
-			defer func() { OsExit = orgOsExit }()
+			p.exit = func(code int) { exitCode = code }
 
-			Fatal(tt.args.msg)
-			if err := pw.Close(); err != nil {
-				t.Fatal(err)
-			}
-			Stdout = orgStdout
-			Stderr = orgStderr
-
-			buf := bytes.Buffer{}
-			_, err = io.Copy(&buf, pr)
-			if err != nil {
-				t.Error(err)
-			}
+			p.Fatal(tt.msg)
 			got := strings.Split(buf.String(), "\n")
-
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("value is mismatch (-want +got):\n%s", diff)
 			}
-
 			if exitCode != tt.exitcode {
 				t.Errorf("value is mismatch. want=%d got=%d", exitCode, tt.exitcode)
 			}
 		})
 	}
 }
-func TestQuestion(t *testing.T) {
-	type args struct {
-		ask string
-	}
+
+//nolint:paralleltest // mutates the process-global os.Stdin via mockStdin
+func TestPrinter_Question(t *testing.T) {
 	tests := []struct {
 		name  string
-		args  args
+		ask   string
 		input string
 		want  bool
 	}{
-		{
-			name:  "user input 'y'",
-			args:  args{testNoCheck},
-			input: "y",
-			want:  true,
-		},
-		{
-			name:  "user input 'yes'",
-			args:  args{testNoCheck},
-			input: "yes",
-			want:  true,
-		},
-		{
-			name:  "user input 'n'",
-			args:  args{testNoCheck},
-			input: "n",
-			want:  false,
-		},
-		{
-			name:  "user input 'no'",
-			args:  args{testNoCheck},
-			input: "no",
-			want:  false,
-		},
-		{
-			name:  "user input 'yes' after 'a'",
-			args:  args{testNoCheck},
-			input: "a\nyes",
-			want:  true,
-		},
-		{
-			name:  "user only input enter",
-			args:  args{testNoCheck},
-			input: "\nyes",
-			want:  true,
-		},
+		{name: "user input 'y'", ask: testNoCheck, input: "y", want: true},
+		{name: "user input 'yes'", ask: testNoCheck, input: "yes", want: true},
+		{name: "user input 'n'", ask: testNoCheck, input: "n", want: false},
+		{name: "user input 'no'", ask: testNoCheck, input: "no", want: false},
+		{name: "user input 'yes' after 'a'", ask: testNoCheck, input: "a\nyes", want: true},
+		{name: "user only input enter", ask: testNoCheck, input: "\nyes", want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -332,22 +159,25 @@ func TestQuestion(t *testing.T) {
 			}
 			defer funcDefer()
 
-			if got := Question(tt.args.ask); got != tt.want {
+			buf := &bytes.Buffer{}
+			if got := New(buf, buf).Question(tt.ask); got != tt.want {
 				t.Errorf("Question() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
-func TestQuestion_FmtScanlnErr(t *testing.T) {
-	t.Run("fmt.Scanln() return error", func(t *testing.T) {
-		orgFmtScanln := FmtScanln
-		FmtScanln = func(a ...any) (n int, err error) {
+func TestPrinter_Question_ScanlnErr(t *testing.T) {
+	t.Parallel()
+	t.Run("scanln returns error", func(t *testing.T) {
+		t.Parallel()
+		buf := &bytes.Buffer{}
+		p := New(buf, buf)
+		p.scanln = func(_ ...any) (n int, err error) {
 			return -1, errors.New("some error")
 		}
-		defer func() { FmtScanln = orgFmtScanln }()
 
-		if got := Question(testNoCheck); got != false {
+		if got := p.Question(testNoCheck); got != false {
 			t.Errorf("Question() = %v, want %v", got, false)
 		}
 	})

--- a/internal/print/print_test.go
+++ b/internal/print/print_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -164,6 +165,37 @@ func TestPrinter_Question(t *testing.T) {
 				t.Errorf("Question() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestPrinter_ConcurrentWrites verifies a Printer shared across goroutines (as
+// happens when goutil reports unreadable binaries from parallel.Run workers)
+// serializes its writes: under -race this fails if the methods drop the lock,
+// and every emitted line stays whole.
+func TestPrinter_ConcurrentWrites(t *testing.T) {
+	t.Parallel()
+	buf := &bytes.Buffer{}
+	p := New(buf, buf)
+
+	const goroutines = 32
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			p.Warn(testMessage)
+		}()
+	}
+	wg.Wait()
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != goroutines {
+		t.Fatalf("got %d lines, want %d (writes interleaved?)", len(lines), goroutines)
+	}
+	for _, l := range lines {
+		if l != "gup:WARN : test message" {
+			t.Fatalf("interleaved/garbled warning line: %q", l)
+		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	if err := cmd.Execute(); err != nil {
-		print.Err(err)
+		print.NewColorable().Err(err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #393. This removes the three categories of mutable package-level globals that existed only to enable test mocking, replacing each with explicit dependency injection. The globals forced widespread `//nolint:gochecknoglobals` / `//nolint:paralleltest` suppressions and created hidden test interdependencies. Behavior is unchanged; the work is split into three self-contained commits that each keep the build, tests, vet, gofmt and golangci-lint green.

## Changes

**Phase 1 — cmd operation seams (`cmd/dependencies.go`, `cmd/update.go`, `cmd/check.go`):** Removed the five `*Ctx` function-pointer globals and the test-only `init()` bridge with its legacy non-context stubs. `defaultDependencies()` now names the real `goutil` operations directly, and the `dependencies` value is threaded through `gup`/`check` down to `updateWithChannels` and `doCheck`/`doCheckJSON`/`doCheckWith`. Tests build a `dependencies` value (`testDeps`/`stubUpdateDeps`) and pass it in.

**Phase 3 — goExe seam (`internal/goutil/goutil.go`):** `goExe` is now an immutable `const` used only by the production default. The nine tests that swapped it to `"echo"` or a nonexistent path now swap the more complete command-builder seam `goCommandContext` via a new `withGoExecutable` helper.

**Phase 2 — print output seams (`internal/print/print.go` + ~30 call sites):** Replaced the mutable `print.Stdout`/`print.Stderr`/`OsExit`/`FmtScanln` globals and the free `Info`/`Warn`/`Err`/`Hint`/`Fatal`/`Question` functions with a `Printer` struct wrapping an out and an err `io.Writer`. A `*print.Printer` is created in each cobra `Run` closure (`print.NewColorable()` in production) and threaded through every command worker and shared helper (`executePackages`, `resultLineRenderer`, `encodeJSONPackages`, `handleEmptyEnvironment`, ...) plus the collaborating packages that emit diagnostics: `pkgselect.PackageInfo`/`PackageInfoByTargets`, `goutil.GetPackageInformation`/`GetPackageInformationWithoutGoVersion`, `notify.Info`/`Warn`, `assets.DeployIconIfNeeded`.

**Tests:** Migrated test files to inject collaborators instead of mutating globals. Output is captured with a buffer-backed Printer (`newTestPrinter` / `print.New`); `Execute()`-path integration tests capture the real `os.Stdout`/`os.Stderr` that the per-command Printer wraps. Seam-related tests that no longer touch globals now run with `t.Parallel()`.

## Design Decisions

Phase 3 consolidates onto `goCommandContext` rather than threading a go-path parameter through every toolchain function: `goExe` was only ever a partial seam (the helper-process tests already swapped `goCommandContext`), so removing the redundant global and keeping the one complete seam is the smallest change that preserves byte-for-byte behavior.

For Phase 2, `readJSON` keeps stdout and stderr in separate buffers and decodes only stdout, so the #291 contract (machine-readable JSON on stdout is never contaminated by warnings/errors on stderr) is still verified; `captureCheckOutput` intentionally merges both streams into one buffer, matching the previous single-pipe capture used by human-readable output tests.

The `dependencies`/`Printer` values are threaded as explicit parameters (not stored on a context or a new struct field) to keep the data flow visible at every call site and avoid reintroducing a single shared injection point that would behave like the globals being removed.

## Limitations

`cmd/import.go`'s `installByVersionCtx`, `cmd/migrate.go`'s `installByVersionMigrateCtx`, and `cmd/pin.go`'s `pinPackageInfo` remain package-level test seams; they are outside the three categories named in #393 and can be migrated to the same `dependencies` pattern in a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized console output routing (info/warnings/errors) across commands (check, list, export, import, update, pin/unpin, remove, migrate, man).
  * Improved JSON mode so machine-readable output stays on STDOUT while warnings/errors remain separate.
  * Notification and progress messaging now follows the same output handling for consistent behavior.
* **New Features**
  * More consistent color-capable output for version and command messaging.
* **Tests**
  * Updated/expanded output-capture and JSON-mode tests to better validate human vs machine-readable paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->