### PR TITLE
refactor(migrate): base missing-target warning on binary paths

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/nao1215/gup/internal/binname"
 	"github.com/nao1215/gup/internal/goutil"
 	"github.com/nao1215/gup/internal/pkgselect"
 	"github.com/nao1215/gup/internal/print"
@@ -124,10 +123,14 @@ func runMigrate(p *print.Printer, cmd *cobra.Command, args []string) int {
 		p.Err(fmt.Errorf("can't read binaries under %s: %w", beforePath, err))
 		return 1
 	}
-	binList = pkgselect.FilterBinaryPaths(binList, binaries)
+	// Derive "missing" from the binary paths before filtering, so a requested
+	// name that exists on disk but can't be read (no build info) is not
+	// mislabeled as "not found". This matches update/check via MissingTargets.
+	missing := pkgselect.MissingTargets(binList, binaries)
+	filtered := pkgselect.FilterBinaryPaths(binList, binaries)
 	// migrate never reads GoVersion, so skip the "go version" subprocess.
-	pkgs := goutil.GetPackageInformationWithoutGoVersion(p, binList)
-	warnMissingMigrateTargets(p, binaries, pkgs, beforePath)
+	pkgs := goutil.GetPackageInformationWithoutGoVersion(p, filtered)
+	warnMissingMigrateTargets(p, missing, beforePath)
 
 	if len(pkgs) == 0 {
 		p.Err(fmt.Errorf("no go-install binary to migrate under %s", beforePath))
@@ -268,32 +271,13 @@ func migratePackages(pr *print.Printer, pkgs []goutil.Package, afterPath string,
 	return result
 }
 
-// warnMissingMigrateTargets warns about each requested binary name that was not
-// found among the migration targets, mirroring the target-selection UX of
-// 'gup update'. It is a no-op when no binaries were explicitly requested.
-func warnMissingMigrateTargets(pr *print.Printer, targets []string, pkgs []goutil.Package, beforePath string) {
-	if len(targets) == 0 {
-		return
-	}
-
-	present := make(map[string]struct{}, len(pkgs))
-	for _, p := range pkgs {
-		present[binname.NormalizeForMatch(p.Name)] = struct{}{}
-	}
-
-	seen := make(map[string]struct{}, len(targets))
-	for _, raw := range targets {
-		normalized := binname.NormalizeForMatch(raw)
-		if normalized == "" {
-			continue
-		}
-		if _, dup := seen[normalized]; dup {
-			continue
-		}
-		seen[normalized] = struct{}{}
-		if _, ok := present[normalized]; !ok {
-			pr.Warn("not found '" + strings.TrimSpace(raw) + "' package in " + beforePath)
-		}
+// warnMissingMigrateTargets warns about each requested binary name that has no
+// binary under BEFORE_PATH, mirroring the target-selection UX of 'gup update'.
+// missing comes from pkgselect.MissingTargets (already trimmed and deduped, and
+// keyed off binary paths), so the migrate context only owns the wording.
+func warnMissingMigrateTargets(pr *print.Printer, missing []string, beforePath string) {
+	for _, name := range missing {
+		pr.Warn("not found '" + name + "' package in " + beforePath)
 	}
 }
 

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -83,6 +83,7 @@ const (
 	testNameSuccess       = "success"
 	testNameTest2         = "test2"
 	testUnknown           = "unknown"
+	testBinDummy          = "dummy"
 )
 
 // captureMigrateOutput runs fn with a buffer-backed printer and returns the
@@ -582,7 +583,7 @@ func Test_runMigrate_presentButUnreadableNotWarned(t *testing.T) {
 		// nothing migratable (the binary is present but unmanageable), NOT
 		// because the target was mislabeled as missing. Asserting only the
 		// absence of a warning would let a different failure mode slip in here.
-		if got := runMigrate(p, cmd, []string{before, after, "dummy"}); got != 1 {
+		if got := runMigrate(p, cmd, []string{before, after, testBinDummy}); got != 1 {
 			t.Fatalf("runMigrate() = %d, want 1 (nothing migratable)", got)
 		}
 	})

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -577,11 +577,21 @@ func Test_runMigrate_presentButUnreadableNotWarned(t *testing.T) {
 		// read, so it never becomes a managed package. The missing check must
 		// key off binary paths, not resolved packages, so naming it yields no
 		// "not found" warning. This mirrors pkgselect.MissingTargets.
-		runMigrate(p, cmd, []string{before, after, "dummy"})
+		//
+		// Pin the exit code and reason too: the run must fail because there is
+		// nothing migratable (the binary is present but unmanageable), NOT
+		// because the target was mislabeled as missing. Asserting only the
+		// absence of a warning would let a different failure mode slip in here.
+		if got := runMigrate(p, cmd, []string{before, after, "dummy"}); got != 1 {
+			t.Fatalf("runMigrate() = %d, want 1 (nothing migratable)", got)
+		}
 	})
 
 	if strings.Contains(out, "not found") {
 		t.Fatalf("present-but-unreadable binary must not be warned as not found, got: %s", out)
+	}
+	if !strings.Contains(out, "no go-install binary to migrate") {
+		t.Fatalf("expected the 'nothing migratable' error, got: %s", out)
 	}
 }
 

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -566,6 +566,48 @@ func Test_runMigrate_allTargetsMissingWarns(t *testing.T) {
 	}
 }
 
+func Test_runMigrate_presentButUnreadableNotWarned(t *testing.T) {
+	before := filepath.Join("testdata", "check_fail")
+	after := t.TempDir()
+	t.Setenv("GOBIN", t.TempDir())
+
+	cmd := newMigrateCmd()
+	out := captureMigrateOutput(t, func(p *print.Printer) {
+		// "dummy" exists on disk under check_fail but its build info can't be
+		// read, so it never becomes a managed package. The missing check must
+		// key off binary paths, not resolved packages, so naming it yields no
+		// "not found" warning. This mirrors pkgselect.MissingTargets.
+		runMigrate(p, cmd, []string{before, after, "dummy"})
+	})
+
+	if strings.Contains(out, "not found") {
+		t.Fatalf("present-but-unreadable binary must not be warned as not found, got: %s", out)
+	}
+}
+
+func Test_runMigrate_missingTargetTrimAndDedup(t *testing.T) {
+	before := filepath.Join("testdata", "check_success")
+	after := t.TempDir()
+	t.Setenv("GOBIN", t.TempDir())
+
+	original := installByVersionMigrateCtx
+	t.Cleanup(func() { installByVersionMigrateCtx = original })
+	installByVersionMigrateCtx = func(context.Context, string, string) error { return nil }
+
+	cmd := newMigrateCmd()
+	out := captureMigrateOutput(t, func(p *print.Printer) {
+		// A padded target and its duplicate must collapse to a single warning
+		// showing the trimmed name.
+		if got := runMigrate(p, cmd, []string{before, after, testBinPosixer, "  ghost  ", "ghost"}); got != 0 {
+			t.Fatalf("runMigrate() = %d, want 0", got)
+		}
+	})
+
+	if c := strings.Count(out, "not found 'ghost'"); c != 1 {
+		t.Fatalf("expected exactly one trimmed 'ghost' warning, got %d: %s", c, out)
+	}
+}
+
 func Test_runMigrate_sameDirError(t *testing.T) {
 	dir := t.TempDir()
 	cmd := newMigrateCmd()


### PR DESCRIPTION
@/tmp/claude-1000/-home-nao-ghq-github-com-nao1215-gup/948cbe88-bcaf-49f8-b72b-88e97f14ff70/scratchpad/pr395_body.md