### PR TITLE
fix(remove): treat a failed confirmation read as an error, not a cancel

### DIFF
--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -101,7 +101,16 @@ func removeLoop(p *print.Printer, gobin string, force bool, target []string) int
 				result = 1
 				continue
 			}
-			if !p.Question(fmt.Sprintf("remove %s?", target)) {
+			ok, err := p.Question(fmt.Sprintf("remove %s?", target))
+			if err != nil {
+				// A failed confirmation read (EOF, closed pipe, ...) is not a
+				// cancellation: report it and fail so the caller does not mistake a
+				// never-confirmed removal for a successful one.
+				p.Err(err)
+				result = 1
+				continue
+			}
+			if !ok {
 				p.Info("cancel removal " + target)
 				continue
 			}

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -225,6 +225,49 @@ func Test_removeLoop_forceNonExist(t *testing.T) {
 	}
 }
 
+// Test_removeLoop_stdinReadFailureIsError reproduces the bug where a failed
+// confirmation read (e.g. EOF / a closed stdin pipe) was treated as a user
+// "cancel": gup printed "cancel removal" and returned a success exit code, so a
+// caller could not tell that the removal had silently not happened. A read
+// failure must instead be reported as an error (exit 1) and must not delete the
+// target.
+//
+//nolint:paralleltest // mutates package-level stdinIsTerminal and process os.Stdin
+func Test_removeLoop_stdinReadFailureIsError(t *testing.T) {
+	gobin := t.TempDir()
+	binaryName := testBinPosixer
+	if GOOS == goosWindows {
+		binaryName += normalizeExecSuffix(GOOS, os.Getenv("GOEXE"))
+	}
+	binaryPath := filepath.Join(gobin, binaryName)
+	if err := os.WriteFile(binaryPath, []byte("dummy"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pretend stdin is a TTY so the interactive confirmation path runs, then feed
+	// it an empty stream so the confirmation read returns EOF.
+	origStdinIsTerminal := stdinIsTerminal
+	stdinIsTerminal = func() bool { return true }
+	t.Cleanup(func() { stdinIsTerminal = origStdinIsTerminal })
+
+	funcDefer, err := mockStdin(t, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer funcDefer()
+
+	p, buf := newTestPrinter()
+	if got := removeLoop(p, gobin, false, []string{testBinPosixer}); got != 1 {
+		t.Fatalf("removeLoop() on stdin read failure = %d, want 1", got)
+	}
+	if !fileutil.IsFile(binaryPath) {
+		t.Fatal("target must not be deleted when the confirmation read fails")
+	}
+	if strings.Contains(buf.String(), "cancel removal") {
+		t.Errorf("must not report 'cancel removal' on a read failure:\n%s", buf.String())
+	}
+}
+
 func Test_removeLoop_windowsFallbackGoexe(t *testing.T) {
 	origGOOS := GOOS
 	GOOS = goosWindows

--- a/internal/print/print.go
+++ b/internal/print/print.go
@@ -107,7 +107,14 @@ func (p *Printer) Fatal(err interface{}) {
 // Question displays the question on the normal output and receives an answer
 // from the user. It is interactive and single-threaded (never shared with
 // parallel workers), so the blocking scanln runs outside the write lock.
-func (p *Printer) Question(ask string) bool {
+//
+// The returned bool reports the user's answer (true for yes, false for no). The
+// returned error is non-nil only when reading the answer fails (e.g. EOF or a
+// closed stdin); callers must distinguish that read failure from a deliberate
+// "no", which returns (false, nil). Otherwise a failed read looks identical to a
+// cancellation, and a caller would treat a never-confirmed action as cancelled
+// with a success exit code.
+func (p *Printer) Question(ask string) (bool, error) {
 	for {
 		var response string
 
@@ -119,17 +126,16 @@ func (p *Printer) Question(ask string) bool {
 			// "yes" is the default.
 			// https://github.com/nao1215/gup/issues/146
 			if strings.Contains(err.Error(), "expected newline") {
-				return true
+				return true, nil
 			}
-			p.Err(err)
-			return false
+			return false, err
 		}
 
 		switch strings.ToLower(response) {
 		case "y", "yes":
-			return true
+			return true, nil
 		case "n", "no":
-			return false
+			return false, nil
 		default:
 		}
 	}

--- a/internal/print/print.go
+++ b/internal/print/print.go
@@ -112,7 +112,7 @@ func (p *Printer) Fatal(err interface{}) {
 // returned error is non-nil only when reading the answer fails (e.g. EOF or a
 // closed stdin); callers must distinguish that read failure from a deliberate
 // "no", which returns (false, nil). Otherwise a failed read looks identical to a
-// cancellation, and a caller would treat a never-confirmed action as cancelled
+// cancellation, and a caller would treat a never-confirmed action as canceled
 // with a success exit code.
 func (p *Printer) Question(ask string) (bool, error) {
 	for {

--- a/internal/print/print_test.go
+++ b/internal/print/print_test.go
@@ -161,7 +161,11 @@ func TestPrinter_Question(t *testing.T) {
 			defer funcDefer()
 
 			buf := &bytes.Buffer{}
-			if got := New(buf, buf).Question(tt.ask); got != tt.want {
+			got, err := New(buf, buf).Question(tt.ask)
+			if err != nil {
+				t.Errorf("Question() unexpected error: %v", err)
+			}
+			if got != tt.want {
 				t.Errorf("Question() = %v, want %v", got, tt.want)
 			}
 		})
@@ -205,12 +209,19 @@ func TestPrinter_Question_ScanlnErr(t *testing.T) {
 		t.Parallel()
 		buf := &bytes.Buffer{}
 		p := New(buf, buf)
+		wantErr := errors.New("some error")
 		p.scanln = func(_ ...any) (n int, err error) {
-			return -1, errors.New("some error")
+			return -1, wantErr
 		}
 
-		if got := p.Question(testNoCheck); got != false {
+		got, err := p.Question(testNoCheck)
+		if got != false {
 			t.Errorf("Question() = %v, want %v", got, false)
+		}
+		// A scanln read failure must surface as an error so callers can tell it
+		// apart from a deliberate "no".
+		if !errors.Is(err, wantErr) {
+			t.Errorf("Question() error = %v, want %v", err, wantErr)
 		}
 	})
 }


### PR DESCRIPTION
## What was broken
When `gup remove` (without `--force`) asks for confirmation and the stdin read fails — EOF, a closed pipe, or any scan error other than the bare-Enter "expected newline" case — `Printer.Question` returned `false`. `removeLoop` could not tell that read failure apart from a deliberate "no", so it:

- printed `cancel removal <target>`, and
- `continue`d **without** setting a non-zero exit code.

So a caller (script/CI) saw a **success exit status** even though the binary was never confirmed and never removed — a silent no-op that looks like success.

Reference: `cmd/remove.go`, `internal/print/print.go`.

## How it was reproduced
Added `Test_removeLoop_stdinReadFailureIsError` (`cmd/remove_test.go`): it pretends stdin is a TTY (so the interactive path runs) and feeds an empty stdin so the confirmation read returns EOF. Before the fix the test failed with `removeLoop() on stdin read failure = 0, want 1`.

Also tightened `TestPrinter_Question_ScanlnErr` (`internal/print/print_test.go`) to assert the read error is now surfaced.

## How it was fixed
- `Printer.Question` now returns `(bool, error)`: a deliberate "no" is `(false, nil)`; a read failure returns the underlying error (bare Enter still defaults to yes).
- `removeLoop` reports that error via `p.Err`, sets the exit code to 1, and does **not** print "cancel removal" or delete the target. A genuine "no" still prints "cancel removal" and exits 0.

## Compatibility / impact
- `Printer.Question` is in the internal `internal/print` package (not part of the public API); its only caller is `removeLoop`, which is updated in the same change.
- User-visible behavior change is limited to the failure path: a failed confirmation read now exits 1 instead of 0. The normal yes/no/bare-Enter flows are unchanged.

## Verification
- `go test ./...` ✅
- `go test -race ./...` ✅
- `go vet ./...` ✅
- `golangci-lint run` ✅ (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed interactive removal prompts so stdin read/scan failures are treated as errors, not as a simple “no”.
  * Improved confirmation handling so explicit “no” responses are treated separately from read failures.
  * Added coverage to ensure failed interactive input never deletes target files and returns the correct non-zero exit code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->