### PR TITLE
fix(migrate): validate AFTER_PATH creatability during --dry-run

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -174,16 +174,58 @@ func validateMigratePaths(beforePath, afterPath string, dryRun bool) error {
 			return fmt.Errorf("AFTER_PATH is not a directory: %s", afterPath)
 		}
 	case errors.Is(err, os.ErrNotExist):
-		if !dryRun {
-			if mkErr := os.MkdirAll(afterPath, afterPathDirPerm); mkErr != nil {
-				return fmt.Errorf("can't create AFTER_PATH %s: %w", afterPath, mkErr)
+		if dryRun {
+			// A real run creates AFTER_PATH with os.MkdirAll; dry-run must not
+			// mutate the filesystem, but it still has to report the same failure
+			// the real run would hit, instead of falsely promising a migration it
+			// can't perform. Verify the destination is creatable without creating
+			// it (see issue: dry-run overlooked this failure condition).
+			if cErr := ensureAfterPathCreatable(afterPath); cErr != nil {
+				return cErr
 			}
+		} else if mkErr := os.MkdirAll(afterPath, afterPathDirPerm); mkErr != nil {
+			return fmt.Errorf("can't create AFTER_PATH %s: %w", afterPath, mkErr)
 		}
 	default:
 		return fmt.Errorf("can't access AFTER_PATH %s: %w", afterPath, err)
 	}
 
 	return nil
+}
+
+// ensureAfterPathCreatable verifies, without creating AFTER_PATH, that a real
+// run's os.MkdirAll(afterPath) could succeed. It walks up to the nearest
+// existing ancestor and confirms it is a writable directory by creating and
+// immediately removing a temporary probe file there. dry-run uses this so it
+// surfaces the same "can't create AFTER_PATH" failure a real run would, rather
+// than reporting success for a destination that can never be written.
+func ensureAfterPathCreatable(afterPath string) error {
+	ancestor := afterPath
+	for {
+		parent := filepath.Dir(ancestor)
+		if parent == ancestor {
+			// Reached the filesystem root without finding a missing component.
+			return nil
+		}
+		info, err := os.Stat(parent)
+		if err == nil {
+			if !info.IsDir() {
+				return fmt.Errorf("can't create AFTER_PATH %s: %s is not a directory", afterPath, parent)
+			}
+			probe, perr := os.CreateTemp(parent, ".gup-migrate-probe-*")
+			if perr != nil {
+				return fmt.Errorf("can't create AFTER_PATH %s: %w", afterPath, perr)
+			}
+			name := probe.Name()
+			_ = probe.Close()
+			_ = os.Remove(name)
+			return nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("can't access AFTER_PATH %s: %w", afterPath, err)
+		}
+		ancestor = parent
+	}
 }
 
 // sameDirPath reports whether a and b point to the same location.

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -181,6 +182,35 @@ func Test_validateMigratePaths(t *testing.T) {
 		}
 		if _, err := os.Stat(after); !errors.Is(err, os.ErrNotExist) {
 			t.Fatal("AFTER_PATH should not be created during dry-run")
+		}
+	})
+
+	// Reproduces the dry-run validation gap: a real migrate creates AFTER_PATH
+	// with os.MkdirAll and fails when it can't (e.g. the parent directory is not
+	// writable). dry-run skipped that step entirely and reported success, so the
+	// dry-run promised a migration that the real run could never perform.
+	t.Run("dry-run fails when AFTER_PATH cannot be created", func(t *testing.T) {
+		if runtime.GOOS == goosWindows {
+			t.Skip("POSIX directory permission semantics are required")
+		}
+		if os.Geteuid() == 0 {
+			t.Skip("root bypasses directory write permissions")
+		}
+		before := t.TempDir()
+		parent := t.TempDir()
+		if err := os.Chmod(parent, 0o555); err != nil { //nolint:gosec // a read-only (but traversable) directory is the condition under test
+			t.Fatal(err)
+		}
+		// Restore write permission so t.TempDir cleanup can remove it.
+		t.Cleanup(func() { _ = os.Chmod(parent, 0o755) }) //nolint:gosec // restore standard dir perms for cleanup
+
+		after := filepath.Join(parent, "gobin")
+		if err := validateMigratePaths(before, after, true); err == nil {
+			t.Fatal("dry-run should fail when AFTER_PATH cannot be created")
+		}
+		// The probe must not leave the destination behind.
+		if _, err := os.Stat(after); !errors.Is(err, os.ErrNotExist) {
+			t.Fatal("AFTER_PATH must not be created during dry-run validation")
 		}
 	})
 }


### PR DESCRIPTION
## What was broken
A real `gup migrate BEFORE AFTER` creates `AFTER_PATH` via `os.MkdirAll` and fails if it can't (e.g. the parent directory is not writable). The `--dry-run` path **skipped that step and performed no equivalent check**, so it reported a successful trial migration for a destination that a real run could never write to.

Concretely: when `AFTER_PATH` doesn't exist, `os.Stat` returns `ErrNotExist` and the validator hit the branch that, in dry-run, did nothing. So `gup migrate --dry-run` "succeeded" even though the actual migration would fail at `MkdirAll`. The dry-run thus overlooked a real failure condition and gave a misleading green light.

Reference: `cmd/migrate.go`.

## How it was reproduced
Added subtest `Test_validateMigratePaths/dry-run fails when AFTER_PATH cannot be created` (`cmd/migrate_test.go`): it makes the parent directory read-only (`0o555`) and calls `validateMigratePaths(before, after, dryRun=true)`. Before the fix the call returned `nil` (`dry-run should fail when AFTER_PATH cannot be created`). The test skips on Windows (POSIX perms) and when running as root (root bypasses write perms).

## How it was fixed
`validateMigratePaths`, in dry-run mode, now calls the new `ensureAfterPathCreatable`, which verifies the destination is creatable **without creating it**: it walks to the nearest existing ancestor and confirms it is a writable directory (a temp probe file created and immediately removed). Dry-run now fails exactly where a real run would, and still never creates `AFTER_PATH` itself (the existing "AFTER_PATH is not created in dry-run" test still passes).

## Compatibility / impact
- Behavior change is limited to `--dry-run`: it now reports the destination-not-creatable failure (exit 1) instead of a false success. Real (non-dry-run) migration is unchanged.
- The dry-run probe touches only an already-existing ancestor directory transiently (create + remove a temp file) and never creates `AFTER_PATH`.

## Verification
- `go test ./...` ✅
- `go test -race ./...` ✅
- `go vet ./...` ✅
- `golangci-lint run` ✅ (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dry-run validation for migration paths so it now correctly reports when the destination cannot be created.
  * Added checks for writable parent directories, matching the behavior of a real migration more closely.
  * Expanded test coverage for this dry-run scenario to ensure failures are caught and no destination directory is created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->