### PR TITLE
fix(list,export,pin): don't require the go command for local-only work

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -35,11 +35,9 @@ apply it with 'gup import'.`,
 }
 
 func export(p *print.Printer, cmd *cobra.Command, _ []string) int {
-	if err := ensureGoCommandAvailable(); err != nil {
-		p.Err(err)
-		return 1
-	}
-
+	// export only reads local build info from $GOBIN and writes gup.json; it never
+	// invokes the Go toolchain, so it must not fail when 'go' is absent (mirrors
+	// 'gup unpin').
 	output, err := getFlagBool(cmd, "output")
 	if err != nil {
 		p.Err(err)

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/nao1215/gup/internal/config"
 	"github.com/nao1215/gup/internal/fileutil"
 	"github.com/nao1215/gup/internal/goutil"
-	"github.com/spf13/cobra"
 )
 
 // testImportPathPosixer is the import path of the posixer fixture binary under
@@ -55,30 +54,28 @@ func Test_validPkgInfo(t *testing.T) {
 	}
 }
 
-func Test_export_not_use_go_cmd(t *testing.T) {
-	t.Run("Not found go command", func(t *testing.T) {
-		t.Setenv("PATH", "")
+// Test_export_succeeds_without_go_command reproduces the bug where 'gup export'
+// failed with "you didn't install golang" when 'go' was absent, even though
+// export only reads local build info from $GOBIN and writes gup.json, never
+// invoking the Go toolchain.
+//
+//nolint:paralleltest // mutates process env (PATH, GOBIN, XDG)
+func Test_export_succeeds_without_go_command(t *testing.T) {
+	setupXDGBase(t)
+	t.Setenv("PATH", "")
+	t.Setenv("GOBIN", filepath.Join("testdata", "check_success"))
 
-		p, buf := newTestPrinter()
-
-		if got := export(p, &cobra.Command{}, []string{}); got != 1 {
-			t.Errorf("export() = %v, want %v", got, 1)
-		}
-		got := strings.Split(buf.String(), "\n")
-
-		want := []string{}
-		if runtime.GOOS == goosWindows {
-			want = append(want, `gup:ERROR: you didn't install golang: exec: "go": executable file not found in %PATH%`)
-			want = append(want, "")
-		} else {
-			want = append(want, `gup:ERROR: you didn't install golang: exec: "go": executable file not found in $PATH`)
-			want = append(want, "")
-		}
-
-		if diff := cmp.Diff(want, got); diff != "" {
-			t.Errorf("value is mismatch (-want +got):\n%s", diff)
-		}
-	})
+	p, buf := newTestPrinter()
+	cmd := newExportCmd()
+	if err := cmd.Flags().Set("output", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if got := export(p, cmd, []string{}); got != 0 {
+		t.Fatalf("export() without go = %d, want 0; output:\n%s", got, buf.String())
+	}
+	if strings.Contains(buf.String(), "you didn't install golang") {
+		t.Errorf("export must not require the go command:\n%s", buf.String())
+	}
 }
 
 func Test_export(t *testing.T) {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -32,11 +32,8 @@ func newListCmd() *cobra.Command {
 }
 
 func list(p *print.Printer, cmd *cobra.Command, _ []string) int {
-	if err := ensureGoCommandAvailable(); err != nil {
-		p.Err(err)
-		return 1
-	}
-
+	// list only reads local build info from $GOBIN and never invokes the Go
+	// toolchain, so it must not fail when 'go' is absent (mirrors 'gup unpin').
 	pkgs, err := pkgselect.PackageInfo(p)
 	if err != nil {
 		p.Err(err)

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -8,32 +8,23 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/spf13/cobra"
 )
 
-func Test_list_not_found_go_command(t *testing.T) {
-	t.Run("Not found go command", func(t *testing.T) {
-		t.Setenv("PATH", "")
+// Test_list_succeeds_without_go_command reproduces the bug where 'gup list'
+// failed with "you didn't install golang" when the 'go' command was absent, even
+// though listing only reads local build info from $GOBIN and never invokes the Go
+// toolchain.
+func Test_list_succeeds_without_go_command(t *testing.T) {
+	t.Setenv("PATH", "")
+	t.Setenv("GOBIN", filepath.Join("testdata", "check_success"))
 
-		p, buf := newTestPrinter()
-
-		if got := list(p, &cobra.Command{}, []string{}); got != 1 {
-			t.Errorf("list() = %v, want %v", got, 1)
-		}
-		got := strings.Split(buf.String(), "\n")
-
-		want := []string{}
-		if runtime.GOOS == goosWindows {
-			want = append(want, `gup:ERROR: you didn't install golang: exec: "go": executable file not found in %PATH%`)
-			want = append(want, "")
-		} else {
-			want = append(want, `gup:ERROR: you didn't install golang: exec: "go": executable file not found in $PATH`)
-			want = append(want, "")
-		}
-		if diff := cmp.Diff(want, got); diff != "" {
-			t.Errorf("value is mismatch (-want +got):\n%s", diff)
-		}
-	})
+	p, buf := newTestPrinter()
+	if got := list(p, newListCmd(), []string{}); got != 0 {
+		t.Fatalf("list() without go = %d, want 0; output:\n%s", got, buf.String())
+	}
+	if strings.Contains(buf.String(), "you didn't install golang") {
+		t.Errorf("list must not require the go command:\n%s", buf.String())
+	}
 }
 
 func Test_list_gobin_is_empty(t *testing.T) {

--- a/cmd/pin.go
+++ b/cmd/pin.go
@@ -103,11 +103,9 @@ func parsePinArgs(args []string) (target, version string, err error) {
 }
 
 func runPin(p *print.Printer, cmd *cobra.Command, args []string) int {
-	if err := ensureGoCommandAvailable(); err != nil {
-		p.Err(err)
-		return 1
-	}
-
+	// pin only reads local build info and edits gup.json (channel "pinned"); it
+	// never runs the Go toolchain, so it must not fail when 'go' is absent. This
+	// mirrors 'gup unpin', which already works without go.
 	target, version, err := parsePinArgs(args)
 	if err != nil {
 		p.Err(err)

--- a/cmd/pin_run_test.go
+++ b/cmd/pin_run_test.go
@@ -57,6 +57,26 @@ func TestRunPin_writesPinnedConfig(t *testing.T) {
 	}
 }
 
+// TestRunPin_succeedsWithoutGoCommand reproduces the bug where 'gup pin' failed
+// with "you didn't install golang" when 'go' was absent, even though pin only
+// reads local build info and edits gup.json (exactly like 'gup unpin', which
+// already works without go), never invoking the Go toolchain.
+func TestRunPin_succeedsWithoutGoCommand(t *testing.T) {
+	setupXDGBase(t)
+	t.Setenv("PATH", "")
+	stubPinPackageInfo(t, []goutil.Package{
+		{Name: testBinTool, ImportPath: pinnedTestImport, Version: &goutil.Version{Current: "v0.9.0"}},
+	})
+
+	p, buf := newTestPrinter()
+	if code := runPin(p, newPinCmd(), []string{testBinTool, testVersionOne}); code != 0 {
+		t.Fatalf("runPin() without go = %d, want 0; output:\n%s", code, buf.String())
+	}
+	if strings.Contains(buf.String(), "you didn't install golang") {
+		t.Errorf("pin must not require the go command:\n%s", buf.String())
+	}
+}
+
 //nolint:paralleltest // swaps package globals and XDG env; must not run in parallel
 func TestRunPin_unmanagedToolFails(t *testing.T) {
 	setupXDGBase(t)


### PR DESCRIPTION
## What was broken
`gup list`, `gup export`, and `gup pin` each started with `ensureGoCommandAvailable()` and exited `1` with `you didn't install golang` when the `go` binary was missing (or not on `$PATH`).

But their core work is entirely **local**:
- `list` / `export` read the build info already embedded in the binaries under `$GOBIN`,
- `export` / `pin` read & write `gup.json`,
- none of them invoke the Go toolchain.

So the guard made these commands fail needlessly on machines without `go`, even though `gup unpin` already runs fine without `go` for exactly the same reason (it carries a comment to that effect).

Reference: `cmd/list.go`, `cmd/export.go`, `cmd/pin.go`, `internal/pkgselect/pkgselect.go`.

## How it was reproduced
Added three tests that set `PATH=""` (so `exec.LookPath("go")` fails) and assert the command still succeeds:
- `Test_list_succeeds_without_go_command` (`cmd/list_test.go`)
- `Test_export_succeeds_without_go_command` (`cmd/export_test.go`)
- `TestRunPin_succeedsWithoutGoCommand` (`cmd/pin_run_test.go`)

Each failed before the fix (exit 1 with `you didn't install golang`). The pre-existing `Test_list_not_found_go_command` and `Test_export_not_use_go_cmd`, which asserted the now-removed failure behavior, were deleted and replaced by the success tests above.

## How it was fixed
Removed the `ensureGoCommandAvailable()` guard from `list`, `export`, and `runPin`. Commands that genuinely run the toolchain (`check`, `update`, `import`, `migrate`) keep the guard.

## Compatibility / impact
- `list`, `export`, `pin` now succeed without `go` installed (consistent with `unpin`). When `go` **is** installed, behavior is unchanged.
- No change to install-capable commands. No API/flag changes.

## Verification
- `go test ./...` ✅
- `go test -race ./...` ✅
- `go vet ./...` ✅
- `golangci-lint run` ✅ (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `export`, `list`, and `pin` now work even when the Go toolchain is not installed.
  * These commands continue to use local build/package information without failing on a missing `go` executable.
  * Removed the “you didn’t install golang” error from these workflows.

* **Tests**
  * Added coverage to verify `export`, `list`, and `pin` succeed when `go` is unavailable.
  * Updated expectations to confirm the commands complete successfully and produce the correct output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->