### PR TITLE
fix: fail fast when auto-detected gup.json candidates are directories

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -93,6 +93,19 @@ func ResolveImportFilePath(explicitPath string) (string, error) {
 
 	defaultPath := FilePath()
 	local := LocalFilePath()
+
+	// An auto-detected candidate that exists as a directory is a user mistake,
+	// not "no config". IsFile reports false for directories, so without this
+	// check the directory would be silently ignored and import would fall back
+	// to the other candidate or "not found". Reject it so the caller fails fast,
+	// matching configstate.ReadFileIfExists's directory handling (#367, #368).
+	if fileutil.IsDir(local) {
+		return "", fmt.Errorf("%s is a directory, not a gup.json file", local)
+	}
+	if fileutil.IsDir(defaultPath) {
+		return "", fmt.Errorf("%s is a directory, not a gup.json file", defaultPath)
+	}
+
 	defaultExists := fileutil.IsFile(defaultPath)
 	localExists := fileutil.IsFile(local)
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -340,6 +340,82 @@ func TestResolveImportFilePath(t *testing.T) { //nolint:paralleltest // changes 
 	}
 }
 
+// TestResolveImportFilePathDirectoryCandidate verifies that an auto-detected
+// gup.json candidate (./gup.json or the XDG user-level config) is rejected with
+// an error when it is a directory instead of a file. Previously such a directory
+// was silently ignored because IsFile returns false for directories, so import
+// fell back to "not found" or the other candidate without telling the user.
+func TestResolveImportFilePathDirectoryCandidate(t *testing.T) { //nolint:paralleltest // changes working dir
+	t.Run("local ./gup.json is a directory", func(t *testing.T) { //nolint:paralleltest // changes working dir
+		cleanup := withTempXDG(t)
+		defer cleanup()
+
+		wd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			_ = os.Chdir(wd)
+		})
+
+		tmpDir := t.TempDir()
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := os.Mkdir(filepath.Join(tmpDir, ConfigFileName), 0o750); err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := ResolveImportFilePath("")
+		if err == nil {
+			t.Fatalf("ResolveImportFilePath(local dir) = (%s, nil), want error", got)
+		}
+		if got != "" {
+			t.Fatalf("ResolveImportFilePath(local dir) path = %s, want empty", got)
+		}
+		if !strings.Contains(err.Error(), "directory") {
+			t.Fatalf("ResolveImportFilePath(local dir) error = %q, want it to mention it is a directory", err.Error())
+		}
+	})
+
+	t.Run("XDG gup.json is a directory", func(t *testing.T) { //nolint:paralleltest // changes working dir
+		cleanup := withTempXDG(t)
+		defer cleanup()
+
+		wd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			_ = os.Chdir(wd)
+		})
+
+		// Run from a directory with no local ./gup.json so only the XDG
+		// candidate is in play.
+		tmpDir := t.TempDir()
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		xdgFile := FilePath()
+		if err := os.MkdirAll(xdgFile, 0o750); err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := ResolveImportFilePath("")
+		if err == nil {
+			t.Fatalf("ResolveImportFilePath(xdg dir) = (%s, nil), want error", got)
+		}
+		if got != "" {
+			t.Fatalf("ResolveImportFilePath(xdg dir) path = %s, want empty", got)
+		}
+		if !strings.Contains(err.Error(), "directory") {
+			t.Fatalf("ResolveImportFilePath(xdg dir) error = %q, want it to mention it is a directory", err.Error())
+		}
+	})
+}
+
 func TestResolveExportFilePath(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
@/tmp/claude-1000/-home-nao-ghq-github-com-nao1215-gup/948cbe88-bcaf-49f8-b72b-88e97f14ff70/scratchpad/pr1-body-en.md