### PR TITLE
fix: keep human-readable output consistent with --ignore-go-update

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -175,6 +175,11 @@ func doCheckWith(deps dependencies, p *print.Printer, pkgs []goutil.Package, cpu
 				shouldUpdate := modulePathChanged || !p.IsPackageUpToDate() || (!ignoreGoUpdate && !p.IsGoUpToDate())
 				if shouldUpdate {
 					status = statusUpdateAvailable
+				} else {
+					// Up to date once the ignored Go delta is set aside: hide that
+					// delta so the rendered line matches the decision instead of
+					// showing a Go diff the command will not act on.
+					hideIgnoredGoDelta(&p, ignoreGoUpdate, jsonOut)
 				}
 			}
 		}

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -350,6 +350,45 @@ func Test_doCheck_modulePathChanged(t *testing.T) {
 	}
 }
 
+// Test_doCheck_ignoreGoUpdate_hidesGoOnlyDelta verifies that when only the Go
+// toolchain differs (the package version is up to date) and --ignore-go-update
+// is set, the human-readable line does not show a Go delta. Previously the check
+// decision correctly ignored the Go delta (no update reported) but the rendered
+// line still printed "current: goX, installed: goY", contradicting the decision.
+func Test_doCheck_ignoreGoUpdate_hidesGoOnlyDelta(t *testing.T) {
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionOne, nil }
+
+	p, buf := newTestPrinter()
+
+	pkgs := []goutil.Package{
+		{
+			Name:       testBinTool,
+			ImportPath: testImportPathTool,
+			ModulePath: testImportPathTool,
+			Version:    &goutil.Version{Current: testVersionOne},
+			GoVersion:  &goutil.Version{Current: testGoVersion1224, Latest: testGoVersionNoDwarf5},
+		},
+	}
+
+	// ignoreGoUpdate = true: a Go-only delta must not appear and must not look
+	// like an available update.
+	got := doCheck(deps, p, pkgs, 1, 0, true, false)
+	if got != 0 {
+		t.Fatalf("doCheck() = %v, want 0", got)
+	}
+	out := buf.String()
+	if strings.Contains(out, testGoVersionNoDwarf5) {
+		t.Fatalf("ignored Go delta leaked into output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Already up-to-date") {
+		t.Fatalf("expected 'Already up-to-date' output, got:\n%s", out)
+	}
+	if strings.Contains(out, "$ gup update tool ") {
+		t.Fatalf("unexpected update hint for ignored Go delta, got:\n%s", out)
+	}
+}
+
 func Test_doCheck_customGoBuildTag_noFalsePositiveUpdate(t *testing.T) {
 	deps := testDeps()
 	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionOne, nil }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -296,6 +296,10 @@ func updateWithChannels(deps dependencies, pr *print.Printer, pkgs []goutil.Pack
 		}
 
 		if !shouldUpdate {
+			// Up to date once the ignored Go delta is set aside: hide that delta so
+			// the rendered line reads "Already up-to-date" instead of a phantom
+			// "goX to goY" for a package that is not being reinstalled.
+			hideIgnoredGoDelta(&p, ignoreGoUpdate, jsonOut)
 			return updateResult{
 				updated: false,
 				pkg:     p,

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -827,6 +827,59 @@ func Test_updateWithChannels_alreadyUpToDate_customGoBuildTag(t *testing.T) {
 	}
 }
 
+// Test_updateWithChannels_ignoreGoUpdate_hidesGoOnlyDelta verifies that when
+// only the Go toolchain differs (the package version is up to date) and
+// --ignore-go-update is set, the package is not updated AND the human-readable
+// line does not show a Go delta. The displayed text must agree with the internal
+// decision: nothing was updated, so the line reads "Already up-to-date" instead
+// of a phantom "goX to goY".
+func Test_updateWithChannels_ignoreGoUpdate_hidesGoOnlyDelta(t *testing.T) {
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) { return testVersionOne, nil }
+	deps.installLatest = func(context.Context, string) error {
+		t.Fatal("installLatest should not be called when only an ignored Go delta exists")
+		return nil
+	}
+	deps.installMainOrMaster = func(context.Context, string) error {
+		t.Fatal("installMainOrMaster should not be called")
+		return nil
+	}
+	deps.installByVersion = func(context.Context, string, string) error {
+		t.Fatal("installByVersion should not be called")
+		return nil
+	}
+
+	p, buf := newTestPrinter()
+
+	pkgs := []goutil.Package{
+		{
+			Name:       testBinTool,
+			ImportPath: testImportPathTool,
+			ModulePath: testImportPathTool,
+			Version:    &goutil.Version{Current: testVersionOne},
+			GoVersion:  &goutil.Version{Current: testGoVersion1224, Latest: testGoVersionNoDwarf5},
+		},
+	}
+
+	channelMap := map[string]goutil.UpdateChannel{testBinTool: goutil.UpdateChannelLatest}
+	// 7th positional arg = ignoreGoUpdate = true.
+	result, succeeded, _ := updateWithChannels(deps, p, pkgs, false, false, 1, true, channelMap, nil, 0, false, false)
+
+	if result != 0 {
+		t.Fatalf("updateWithChannels() = %d, want 0", result)
+	}
+	if len(succeeded) != 1 {
+		t.Fatalf("succeeded = %d, want 1", len(succeeded))
+	}
+	out := buf.String()
+	if strings.Contains(out, testGoVersionNoDwarf5) {
+		t.Fatalf("ignored Go delta leaked into output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Already up-to-date") {
+		t.Fatalf("expected 'Already up-to-date' output consistent with no update, got:\n%s", out)
+	}
+}
+
 func Test_updateWithChannels_customGoBuildTag_goVersionDiffColor(t *testing.T) {
 	oldNoColor := color.NoColor
 	color.NoColor = false

--- a/cmd/versionrender.go
+++ b/cmd/versionrender.go
@@ -12,6 +12,21 @@ import (
 // recorded installed version).
 const unknownVersion = "unknown"
 
+// hideIgnoredGoDelta normalizes away a Go-toolchain delta that is being ignored
+// (--ignore-go-update, or an undetectable installed Go version) on a package that
+// is otherwise up to date, so the human-readable line reads consistently with the
+// "no update" decision instead of printing a phantom "goX to goY" the command
+// will not act on. It mirrors what checkPinned and updatePinned already do for
+// pinned packages. It is a no-op in --json mode so the machine-readable
+// installed_go_version stays the real installed toolchain (a documented,
+// factual field), keeping that contract unchanged.
+func hideIgnoredGoDelta(p *goutil.Package, ignoreGoUpdate, jsonOut bool) {
+	if jsonOut || !ignoreGoUpdate || p.GoVersion == nil {
+		return
+	}
+	p.GoVersion.Latest = p.GoVersion.Current
+}
+
 // currentToLatestStr renders the current->latest transition for an update,
 // coloring each version by whether it is the up-to-date side. The version
 // comparison rule itself is owned by goutil; this layer only decides how to

--- a/cmd/versionrender.go
+++ b/cmd/versionrender.go
@@ -12,14 +12,18 @@ import (
 // recorded installed version).
 const unknownVersion = "unknown"
 
-// hideIgnoredGoDelta normalizes away a Go-toolchain delta that is being ignored
-// (--ignore-go-update, or an undetectable installed Go version) on a package that
+// hideIgnoredGoDelta collapses an ignored Go-toolchain delta on a package that
 // is otherwise up to date, so the human-readable line reads consistently with the
 // "no update" decision instead of printing a phantom "goX to goY" the command
 // will not act on. It mirrors what checkPinned and updatePinned already do for
-// pinned packages. It is a no-op in --json mode so the machine-readable
-// installed_go_version stays the real installed toolchain (a documented,
-// factual field), keeping that contract unchanged.
+// pinned packages.
+//
+// The collapse happens only when ignoreGoUpdate is true. Callers set that flag
+// when --ignore-go-update is passed or when the installed Go version can't be
+// detected (ignoreGoUpdate = opts.ignoreGoUpdate || !goVersionAvailable), so both
+// reach here through the same single condition. It is a no-op in --json mode so
+// the machine-readable installed_go_version stays the real installed toolchain (a
+// documented, factual field), keeping that contract unchanged.
 func hideIgnoredGoDelta(p *goutil.Package, ignoreGoUpdate, jsonOut bool) {
 	if jsonOut || !ignoreGoUpdate || p.GoVersion == nil {
 		return

--- a/cmd/versionrender_test.go
+++ b/cmd/versionrender_test.go
@@ -305,3 +305,63 @@ func TestPinnedResultStr(t *testing.T) {
 		t.Errorf("no-current pinnedResultStr() = %q, want it to mention unknown", got)
 	}
 }
+
+// TestHideIgnoredGoDelta verifies the seam that suppresses an ignored Go
+// toolchain delta before rendering. When ignoreGoUpdate is set (and not in JSON
+// mode), a Go-only delta is collapsed so currentToLatestStr/versionCheckResultStr
+// render a clean "Already up-to-date" line. It must be a no-op when the delta is
+// not being ignored or when emitting JSON, and tolerate a nil GoVersion.
+func TestHideIgnoredGoDelta(t *testing.T) {
+	t.Parallel()
+
+	t.Run("suppresses Go-only delta when ignored", func(t *testing.T) {
+		t.Parallel()
+		p := goutil.Package{
+			Name:       rvName,
+			ImportPath: rvImport,
+			ModulePath: rvModule,
+			Version:    &goutil.Version{Current: rvV100, Latest: rvV100},
+			GoVersion:  &goutil.Version{Current: rvGoCurrent, Latest: rvGo1260ND},
+		}
+		hideIgnoredGoDelta(&p, true, false)
+		if p.GoVersion.Latest != p.GoVersion.Current {
+			t.Fatalf("GoVersion.Latest = %q, want collapsed to %q", p.GoVersion.Latest, p.GoVersion.Current)
+		}
+		if got := currentToLatestStr(p); !strings.Contains(got, "up-to-date") {
+			t.Fatalf("currentToLatestStr after suppression = %q, want it to read up-to-date", got)
+		}
+		if strings.Contains(versionCheckResultStr(p), rvGo1260ND) {
+			t.Fatalf("versionCheckResultStr still shows the ignored Go latest %q", rvGo1260ND)
+		}
+	})
+
+	t.Run("no-op when not ignoring", func(t *testing.T) {
+		t.Parallel()
+		p := goutil.Package{
+			Version:   &goutil.Version{Current: rvV100, Latest: rvV100},
+			GoVersion: &goutil.Version{Current: rvGoCurrent, Latest: rvGo1260ND},
+		}
+		hideIgnoredGoDelta(&p, false, false)
+		if p.GoVersion.Latest != rvGo1260ND {
+			t.Fatalf("GoVersion.Latest = %q, want unchanged %q when not ignoring", p.GoVersion.Latest, rvGo1260ND)
+		}
+	})
+
+	t.Run("no-op in JSON mode", func(t *testing.T) {
+		t.Parallel()
+		p := goutil.Package{
+			Version:   &goutil.Version{Current: rvV100, Latest: rvV100},
+			GoVersion: &goutil.Version{Current: rvGoCurrent, Latest: rvGo1260ND},
+		}
+		hideIgnoredGoDelta(&p, true, true)
+		if p.GoVersion.Latest != rvGo1260ND {
+			t.Fatalf("GoVersion.Latest = %q, want unchanged %q in JSON mode", p.GoVersion.Latest, rvGo1260ND)
+		}
+	})
+
+	t.Run("tolerates nil GoVersion", func(t *testing.T) {
+		t.Parallel()
+		p := goutil.Package{Version: &goutil.Version{Current: rvV100, Latest: rvV100}}
+		hideIgnoredGoDelta(&p, true, false) // must not panic
+	})
+}


### PR DESCRIPTION
@/tmp/claude-1000/-home-nao-ghq-github-com-nao1215-gup/948cbe88-bcaf-49f8-b72b-88e97f14ff70/scratchpad/pr2-body-en.md