### PR TITLE
fix: write completion files and zshrc atomically

### DIFF
--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -166,6 +166,15 @@ func atomicWriteFile(path string, data []byte, what string) (err error) {
 	if fileutil.IsDir(path) {
 		return fmt.Errorf("%s path %s is a directory, not a file", what, path)
 	}
+	// Resolve symlinks so the rename rewrites the link's target rather than
+	// replacing the link itself with a regular file. Dotfile managers (stow,
+	// chezmoi, yadm) commonly symlink .zshrc into the home directory; the previous
+	// in-place write followed the link, and this preserves that behavior. When the
+	// path does not exist yet (a new completion file or .zshrc) EvalSymlinks fails,
+	// so the original path is kept and a fresh file is created.
+	if resolved, lerr := filepath.EvalSymlinks(path); lerr == nil {
+		path = resolved
+	}
 	dir := filepath.Dir(path)
 	if mkErr := os.MkdirAll(dir, fileutil.FileModeCreatingDir); mkErr != nil {
 		return fmt.Errorf("can not create directory for %s: %w", what, mkErr)

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -16,6 +16,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// renameFunc is os.Rename, indirected so tests can simulate a rename failure at
+// the atomic-commit step and assert the original file is left intact.
+var renameFunc = os.Rename //nolint:gochecknoglobals // swapped in tests
+
 // DeployShellCompletionFileIfNeeded creates the shell completion files.
 // If a file with the same contents already exists, it is not recreated.
 //
@@ -127,8 +131,10 @@ func (c completionFile) upToDate(cmd *cobra.Command) bool {
 
 // sync writes the completion file when it is missing or stale and leaves an
 // already up-to-date file untouched, so repeated --install runs do not rewrite
-// it. The parent directory is created as needed.
-func (c completionFile) sync(cmd *cobra.Command) (err error) {
+// it. The write is atomic (see atomicWriteFile), so a failure mid-install never
+// truncates or corrupts an existing completion file. The parent directory is
+// created as needed.
+func (c completionFile) sync(cmd *cobra.Command) error {
 	want, genErr := c.content(cmd)
 	if genErr != nil {
 		return genErr
@@ -139,23 +145,71 @@ func (c completionFile) sync(cmd *cobra.Command) (err error) {
 		return nil
 	}
 
-	if mkErr := os.MkdirAll(filepath.Dir(path), fileutil.FileModeCreatingDir); mkErr != nil {
-		return fmt.Errorf("can not create %s-completion file: %w", c.shell, mkErr)
+	return atomicWriteFile(path, want, c.shell+"-completion file")
+}
+
+// atomicWriteFile writes data to path atomically: it writes to a temp file in
+// the same directory, fsyncs and closes it, then renames it over path. A rename
+// on the same filesystem replaces the destination in one step, so a reader never
+// sees a half-written file and an interrupted install never truncates or
+// corrupts the existing one. On any failure before the rename the temp file is
+// removed and path keeps its previous contents. The parent directory is created
+// as needed. When path already exists its permissions are preserved; a new file
+// uses the restrictive 0600 mode os.CreateTemp applies. This mirrors the atomic
+// gup.json write in cmd/config_file.go. (Completion install is POSIX-only - the
+// caller returns early on Windows - so the plain os.Rename replace is atomic.)
+func atomicWriteFile(path string, data []byte, what string) (err error) {
+	path = filepath.Clean(path)
+	// Reject an existing directory before staging any temp file, so a mistaken
+	// path cannot turn into a confusing rename failure (mirrors the #367 guard in
+	// cmd/config_file.go).
+	if fileutil.IsDir(path) {
+		return fmt.Errorf("%s path %s is a directory, not a file", what, path)
 	}
-	fp, openErr := os.OpenFile(filepath.Clean(path), os.O_RDWR|os.O_CREATE|os.O_TRUNC, fileutil.FileModeCreatingFile)
-	if openErr != nil {
-		return fmt.Errorf("can not open %s-completion file: %w", c.shell, openErr)
+	dir := filepath.Dir(path)
+	if mkErr := os.MkdirAll(dir, fileutil.FileModeCreatingDir); mkErr != nil {
+		return fmt.Errorf("can not create directory for %s: %w", what, mkErr)
 	}
+
+	file, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("can not create temp file for %s: %w", what, err)
+	}
+	tmpPath := file.Name()
 	defer func() {
-		if closeErr := fp.Close(); closeErr != nil {
-			err = errors.Join(err, fmt.Errorf("can not close %s-completion file: %w", c.shell, closeErr))
+		if file != nil {
+			if closeErr := file.Close(); closeErr != nil && err == nil {
+				err = closeErr
+			}
+		}
+		if err != nil {
+			_ = os.Remove(tmpPath)
 		}
 	}()
 
-	if _, writeErr := fp.Write(want); writeErr != nil {
-		return fmt.Errorf("can not write %s-completion file: %w", c.shell, writeErr)
+	if _, err = file.Write(data); err != nil {
+		return fmt.Errorf("can not write %s: %w", what, err)
 	}
-	return err
+	// Preserve the permissions of the file being replaced; a new file keeps the
+	// 0600 mode os.CreateTemp already applied.
+	if info, statErr := os.Stat(path); statErr == nil {
+		if chmodErr := os.Chmod(tmpPath, info.Mode().Perm()); chmodErr != nil {
+			return fmt.Errorf("can not set permissions for %s: %w", what, chmodErr)
+		}
+	}
+	if err = file.Sync(); err != nil {
+		return fmt.Errorf("can not sync %s: %w", what, err)
+	}
+	if err = file.Close(); err != nil {
+		file = nil
+		return fmt.Errorf("can not close %s: %w", what, err)
+	}
+	file = nil
+
+	if err = renameFunc(tmpPath, path); err != nil {
+		return fmt.Errorf("can not finalize %s: %w", what, err)
+	}
+	return nil
 }
 
 func makeBashCompletionFileIfNeeded(cmd *cobra.Command) error {
@@ -215,12 +269,18 @@ func zshFpathSnippet() string {
 	return "\n" + zshFpathBlockBody()
 }
 
-func appendFpathAtZshrcIfNeeded() (err error) {
+// appendFpathAtZshrcIfNeeded reconciles gup's fpath block in .zshrc. Every final
+// write goes through atomicWriteFile so the user's .zshrc is never truncated or
+// left half-written if the install fails: the full intended content is staged in
+// a temp file and renamed into place in one step. The append case is therefore a
+// read-modify-write (read current content, concatenate the snippet, atomic write)
+// rather than an in-place O_APPEND.
+func appendFpathAtZshrcIfNeeded() error {
 	zshrcPath := zshrcPath()
 
-	// New .zshrc: write the snippet into a freshly created file.
+	// New .zshrc: the whole file is just the snippet.
 	if !fileutil.IsFile(zshrcPath) {
-		return writeZshrcString(zshrcPath, zshFpathSnippet(), os.O_RDWR|os.O_CREATE)
+		return atomicWriteFile(zshrcPath, []byte(zshFpathSnippet()), ".zshrc")
 	}
 
 	raw, readErr := os.ReadFile(filepath.Clean(zshrcPath))
@@ -239,30 +299,11 @@ func appendFpathAtZshrcIfNeeded() (err error) {
 		if updated == content {
 			return nil
 		}
-		return writeZshrcString(zshrcPath, updated, os.O_RDWR|os.O_TRUNC)
+		return atomicWriteFile(zshrcPath, []byte(updated), ".zshrc")
 	}
 
 	// No gup block yet: append a fresh one without disturbing existing content.
-	return writeZshrcString(zshrcPath, zshFpathSnippet(), os.O_RDWR|os.O_APPEND)
-}
-
-// writeZshrcString writes data to .zshrc using the given open flags, joining any
-// close error so a failed flush is surfaced.
-func writeZshrcString(path, data string, flag int) (err error) {
-	fp, openErr := os.OpenFile(filepath.Clean(path), flag, fileutil.FileModeCreatingFile)
-	if openErr != nil {
-		return fmt.Errorf("can not open .zshrc: %w", openErr)
-	}
-	defer func() {
-		if closeErr := fp.Close(); closeErr != nil {
-			err = errors.Join(err, fmt.Errorf("can not close .zshrc: %w", closeErr))
-		}
-	}()
-
-	if _, writeErr := fp.WriteString(data); writeErr != nil {
-		return fmt.Errorf("can not write zsh $fpath in .zshrc: %w", writeErr)
-	}
-	return err
+	return atomicWriteFile(zshrcPath, []byte(content+zshFpathSnippet()), ".zshrc")
 }
 
 func isSameBashCompletionFile(cmd *cobra.Command) bool {

--- a/internal/completion/completion_more_test.go
+++ b/internal/completion/completion_more_test.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -9,6 +10,142 @@ import (
 
 	"github.com/nao1215/gup/internal/fileutil"
 )
+
+// failingRename swaps renameFunc so the atomic-commit step fails, and restores
+// it after the test. It lets a test assert that a write that fails at the final
+// rename leaves the original file intact and drops no temp files.
+func failingRename(t *testing.T) {
+	t.Helper()
+	orig := renameFunc
+	renameFunc = func(string, string) error { return errors.New("simulated rename failure") }
+	t.Cleanup(func() { renameFunc = orig })
+}
+
+// countTempFiles returns how many of dir's entries look like the temp files
+// atomicWriteFile creates (".tmp-*"), so a test can assert none were left behind.
+func countTempFiles(t *testing.T, dir string) int {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir(%s) error = %v", dir, err)
+	}
+	n := 0
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp-") {
+			n++
+		}
+	}
+	return n
+}
+
+// TestMakeBashCompletion_atomicWriteFailureKeepsOriginal verifies that when the
+// final rename fails, an existing completion file keeps its original contents
+// (it is never truncated in place) and no temp file is left behind.
+func TestMakeBashCompletion_atomicWriteFailureKeepsOriginal(t *testing.T) {
+	if IsWindows() {
+		t.Skip("completion install is not supported on Windows")
+	}
+	t.Setenv("HOME", t.TempDir())
+	cmd := testCompletionCmd()
+
+	// Pre-create a completion file whose content differs from what gup generates,
+	// so sync attempts a (failing) rewrite rather than skipping.
+	path := bashCompletionFilePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	const original = "# original bash completion content\n"
+	if err := os.WriteFile(path, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	failingRename(t)
+
+	if err := makeBashCompletionFileIfNeeded(cmd); err == nil {
+		t.Fatal("expected an error when rename fails, got nil")
+	}
+
+	got, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("original completion file is gone: %v", err)
+	}
+	if string(got) != original {
+		t.Fatalf("original completion file was modified on failure:\n%s", got)
+	}
+	if n := countTempFiles(t, filepath.Dir(path)); n != 0 {
+		t.Errorf("temp file(s) left behind on failure: %d", n)
+	}
+}
+
+// TestAppendFpathAtZshrc_atomicWriteFailureKeepsOriginal verifies that when the
+// final rename fails while rewriting a stale gup block, an existing .zshrc keeps
+// its original contents and no temp file is left behind.
+func TestAppendFpathAtZshrc_atomicWriteFailureKeepsOriginal(t *testing.T) {
+	if IsWindows() {
+		t.Skip("zsh completion is not deployed on Windows")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// A .zshrc that already holds a (stale) gup block, so appendFpathAtZshrcIfNeeded
+	// takes the in-place rewrite path and attempts an atomic write.
+	rc := zshrcPath()
+	original := "# user content\n" + zshFpathMarker + "\nfpath=(/some/old/dir $fpath)\n"
+	if err := os.WriteFile(rc, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	failingRename(t)
+
+	if err := appendFpathAtZshrcIfNeeded(); err == nil {
+		t.Fatal("expected an error when rename fails, got nil")
+	}
+
+	got, err := os.ReadFile(filepath.Clean(rc))
+	if err != nil {
+		t.Fatalf("original .zshrc is gone: %v", err)
+	}
+	if string(got) != original {
+		t.Fatalf("original .zshrc was modified on failure:\n%s", got)
+	}
+	if n := countTempFiles(t, home); n != 0 {
+		t.Errorf("temp file(s) left behind on failure: %d", n)
+	}
+}
+
+// TestAppendFpathAtZshrc_atomicAppendFailureKeepsOriginal verifies the same
+// guarantee for the append path: a .zshrc with no gup block keeps its original
+// contents when the atomic write fails, rather than being partially appended.
+func TestAppendFpathAtZshrc_atomicAppendFailureKeepsOriginal(t *testing.T) {
+	if IsWindows() {
+		t.Skip("zsh completion is not deployed on Windows")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	rc := zshrcPath()
+	const original = "# user content with no gup block\nexport FOO=bar\n"
+	if err := os.WriteFile(rc, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	failingRename(t)
+
+	if err := appendFpathAtZshrcIfNeeded(); err == nil {
+		t.Fatal("expected an error when rename fails, got nil")
+	}
+
+	got, err := os.ReadFile(filepath.Clean(rc))
+	if err != nil {
+		t.Fatalf("original .zshrc is gone: %v", err)
+	}
+	if string(got) != original {
+		t.Fatalf("original .zshrc was modified on failure:\n%s", got)
+	}
+	if n := countTempFiles(t, home); n != 0 {
+		t.Errorf("temp file(s) left behind on failure: %d", n)
+	}
+}
 
 // TestMain clears the XDG/ZDOTDIR variables for the whole package so the many
 // tests that assert HOME-rooted completion paths are deterministic regardless of
@@ -580,7 +717,7 @@ func TestMakeBashCompletionFileIfNeeded_MkdirError(t *testing.T) {
 	}
 
 	err := makeBashCompletionFileIfNeeded(cmd)
-	if err == nil || !strings.Contains(err.Error(), "can not create bash-completion file") {
+	if err == nil || !strings.Contains(err.Error(), "can not create directory for bash-completion file") {
 		t.Errorf("expected MkdirAll error, got: %v", err)
 	}
 }
@@ -593,14 +730,14 @@ func TestMakeBashCompletionFileIfNeeded_OpenError(t *testing.T) {
 	}
 	cmd := testCompletionCmd()
 
-	// Create the completion path itself as a directory so OpenFile fails.
+	// Create the completion path itself as a directory so the atomic write rejects it.
 	if err := os.MkdirAll(bashCompletionFilePath(), 0o750); err != nil {
 		t.Fatal(err)
 	}
 
 	err := makeBashCompletionFileIfNeeded(cmd)
-	if err == nil || !strings.Contains(err.Error(), "can not open bash-completion file") {
-		t.Errorf("expected OpenFile error, got: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "is a directory") {
+		t.Errorf("expected directory-path error, got: %v", err)
 	}
 }
 
@@ -612,14 +749,14 @@ func TestMakeFishCompletionFileIfNeeded_GenError(t *testing.T) {
 	}
 	cmd := testCompletionCmd()
 
-	// Create the completion path as a directory so the file cannot be written.
+	// Create the completion path as a directory so the atomic write rejects it.
 	if err := os.MkdirAll(fishCompletionFilePath(), 0o750); err != nil {
 		t.Fatal(err)
 	}
 
 	err := makeFishCompletionFileIfNeeded(cmd)
-	if err == nil || !strings.Contains(err.Error(), "can not open fish-completion file") {
-		t.Errorf("expected fish generation error, got: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "is a directory") {
+		t.Errorf("expected directory-path error, got: %v", err)
 	}
 }
 
@@ -631,14 +768,14 @@ func TestMakeZshCompletionFileIfNeeded_GenError(t *testing.T) {
 	}
 	cmd := testCompletionCmd()
 
-	// Create the completion path as a directory so the file cannot be written.
+	// Create the completion path as a directory so the atomic write rejects it.
 	if err := os.MkdirAll(zshCompletionFilePath(), 0o750); err != nil {
 		t.Fatal(err)
 	}
 
 	err := makeZshCompletionFileIfNeeded(cmd)
-	if err == nil || !strings.Contains(err.Error(), "can not open zsh-completion file") {
-		t.Errorf("expected zsh generation error, got: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "is a directory") {
+		t.Errorf("expected directory-path error, got: %v", err)
 	}
 }
 
@@ -646,14 +783,14 @@ func TestAppendFpathAtZshrcIfNeeded_OpenError(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	// Make .zshrc a directory so the create-branch OpenFile fails.
+	// Make .zshrc a directory so the atomic write rejects it.
 	if err := os.MkdirAll(zshrcPath(), 0o750); err != nil {
 		t.Fatal(err)
 	}
 
 	err := appendFpathAtZshrcIfNeeded()
-	if err == nil || !strings.Contains(err.Error(), "can not open .zshrc") {
-		t.Errorf("expected .zshrc open error, got: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "is a directory") {
+		t.Errorf("expected .zshrc directory-path error, got: %v", err)
 	}
 }
 

--- a/internal/completion/completion_more_test.go
+++ b/internal/completion/completion_more_test.go
@@ -38,6 +38,58 @@ func countTempFiles(t *testing.T, dir string) int {
 	return n
 }
 
+// TestAppendFpathAtZshrc_preservesSymlink verifies that when .zshrc is a symlink
+// (as managed by dotfile tools like stow/chezmoi/yadm), the atomic write rewrites
+// the link's target rather than replacing the symlink with a regular file. The
+// previous in-place O_APPEND/O_TRUNC followed the link; a naive os.Rename onto the
+// link path would sever it, leaving a plain file in the user's home.
+func TestAppendFpathAtZshrc_preservesSymlink(t *testing.T) {
+	if IsWindows() {
+		t.Skip("zsh completion is not deployed on Windows")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// The real .zshrc lives in a separate "dotfiles" directory; ~/.zshrc is a
+	// symlink pointing at it.
+	dotfiles := t.TempDir()
+	realRc := filepath.Join(dotfiles, "zshrc")
+	const original = "# managed by a dotfile tool\n"
+	if err := os.WriteFile(realRc, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := zshrcPath()
+	if err := os.Symlink(realRc, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := appendFpathAtZshrcIfNeeded(); err != nil {
+		t.Fatalf("appendFpathAtZshrcIfNeeded() error = %v", err)
+	}
+
+	// The link must still be a symlink, not a regular file.
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf(".zshrc symlink was replaced by a regular file")
+	}
+
+	// The fpath block must have been written through the link to the real file,
+	// and the original content preserved.
+	got, err := os.ReadFile(filepath.Clean(realRc))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(string(got), original) {
+		t.Fatalf("original content not preserved in the real file:\n%s", got)
+	}
+	if !strings.Contains(string(got), zshFpathMarker) {
+		t.Fatalf("fpath block was not written through the symlink:\n%s", got)
+	}
+}
+
 // TestMakeBashCompletion_atomicWriteFailureKeepsOriginal verifies that when the
 // final rename fails, an existing completion file keeps its original contents
 // (it is never truncated in place) and no temp file is left behind.


### PR DESCRIPTION
@/tmp/claude-1000/-home-nao-ghq-github-com-nao1215-gup/948cbe88-bcaf-49f8-b72b-88e97f14ff70/scratchpad/pr4-body-en.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell completion installation and `.zshrc` fpath updates to use safer, all-or-nothing writes, reducing the risk of partial/corrupted changes.
  * If an update fails, the original completion/config files remain unchanged and any temporary artifacts are removed.
  * `.zshrc` fpath updates now preserve `~/.zshrc` symlinks by updating the symlink target.
  * Improved error messages for invalid directory targets during completion and `.zshrc` updates.

* **Tests**
  * Added coverage for atomic write/append failure scenarios and symlink preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->