### PR TITLE
fix: preserve dangling symlinks when writing completion files atomically

### DIFF
--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -172,7 +172,11 @@ func atomicWriteFile(path string, data []byte, what string) (err error) {
 	// the previous in-place write followed the link, and this preserves that
 	// behavior - including for a dangling link whose target does not exist yet, the
 	// state right after a dotfile manager links a file before its first write.
-	path = resolveSymlinkTarget(path)
+	resolvedPath, resolveErr := resolveSymlinkTarget(path)
+	if resolveErr != nil {
+		return fmt.Errorf("can not resolve %s path %s: %w", what, path, resolveErr)
+	}
+	path = resolvedPath
 	dir := filepath.Dir(path)
 	if mkErr := os.MkdirAll(dir, fileutil.FileModeCreatingDir); mkErr != nil {
 		return fmt.Errorf("can not create directory for %s: %w", what, mkErr)
@@ -227,24 +231,33 @@ func atomicWriteFile(path string, data []byte, what string) (err error) {
 // used because it requires the whole path to exist and so fails on a dangling
 // link. A non-symlink path (including a missing plain file) is returned
 // unchanged; intermediate directory symlinks need no handling because the OS
-// resolves them transparently during create/rename. The hop limit guards against
-// a symlink cycle.
-func resolveSymlinkTarget(path string) string {
+// resolves them transparently during create/rename. Exhausting the hop limit
+// means a symlink cycle: that is reported as an error so the caller aborts,
+// rather than returning a still-symlink path that the atomic rename would then
+// clobber into a regular file.
+func resolveSymlinkTarget(path string) (string, error) {
 	for range 255 {
 		info, err := os.Lstat(path)
-		if err != nil || info.Mode()&os.ModeSymlink == 0 {
-			return path
+		if err != nil {
+			// path does not exist yet (e.g. a dangling link's final target): it is
+			// the destination to create, so stop here with no error.
+			return path, nil //nolint:nilerr // a missing target is the intended write path
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			return path, nil
 		}
 		dest, err := os.Readlink(path)
 		if err != nil {
-			return path
+			// The link is unreadable; fall back to treating path as the destination
+			// so the caller surfaces a concrete write error rather than this one.
+			return path, nil //nolint:nilerr // fall back to writing at path
 		}
 		if !filepath.IsAbs(dest) {
 			dest = filepath.Join(filepath.Dir(path), dest)
 		}
 		path = filepath.Clean(dest)
 	}
-	return path
+	return "", fmt.Errorf("symlink chain too deep (possible cycle) at %s", path)
 }
 
 func makeBashCompletionFileIfNeeded(cmd *cobra.Command) error {

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -166,15 +166,13 @@ func atomicWriteFile(path string, data []byte, what string) (err error) {
 	if fileutil.IsDir(path) {
 		return fmt.Errorf("%s path %s is a directory, not a file", what, path)
 	}
-	// Resolve symlinks so the rename rewrites the link's target rather than
-	// replacing the link itself with a regular file. Dotfile managers (stow,
-	// chezmoi, yadm) commonly symlink .zshrc into the home directory; the previous
-	// in-place write followed the link, and this preserves that behavior. When the
-	// path does not exist yet (a new completion file or .zshrc) EvalSymlinks fails,
-	// so the original path is kept and a fresh file is created.
-	if resolved, lerr := filepath.EvalSymlinks(path); lerr == nil {
-		path = resolved
-	}
+	// Resolve symlinks at the destination so the rename rewrites the link's target
+	// rather than replacing the link itself with a regular file. Dotfile managers
+	// (stow, chezmoi, yadm) commonly symlink .zshrc and completion files into place;
+	// the previous in-place write followed the link, and this preserves that
+	// behavior - including for a dangling link whose target does not exist yet, the
+	// state right after a dotfile manager links a file before its first write.
+	path = resolveSymlinkTarget(path)
 	dir := filepath.Dir(path)
 	if mkErr := os.MkdirAll(dir, fileutil.FileModeCreatingDir); mkErr != nil {
 		return fmt.Errorf("can not create directory for %s: %w", what, mkErr)
@@ -219,6 +217,34 @@ func atomicWriteFile(path string, data []byte, what string) (err error) {
 		return fmt.Errorf("can not finalize %s: %w", what, err)
 	}
 	return nil
+}
+
+// resolveSymlinkTarget follows the chain of symlinks at path and returns the
+// final target, even when that target does not exist yet (a dangling symlink -
+// e.g. a dotfile manager that linked ~/.zshrc before its target file was ever
+// written). This lets atomicWriteFile create or replace the link's target rather
+// than the link itself, preserving the symlink. filepath.EvalSymlinks cannot be
+// used because it requires the whole path to exist and so fails on a dangling
+// link. A non-symlink path (including a missing plain file) is returned
+// unchanged; intermediate directory symlinks need no handling because the OS
+// resolves them transparently during create/rename. The hop limit guards against
+// a symlink cycle.
+func resolveSymlinkTarget(path string) string {
+	for range 255 {
+		info, err := os.Lstat(path)
+		if err != nil || info.Mode()&os.ModeSymlink == 0 {
+			return path
+		}
+		dest, err := os.Readlink(path)
+		if err != nil {
+			return path
+		}
+		if !filepath.IsAbs(dest) {
+			dest = filepath.Join(filepath.Dir(path), dest)
+		}
+		path = filepath.Clean(dest)
+	}
+	return path
 }
 
 func makeBashCompletionFileIfNeeded(cmd *cobra.Command) error {

--- a/internal/completion/completion_more_test.go
+++ b/internal/completion/completion_more_test.go
@@ -90,6 +90,90 @@ func TestAppendFpathAtZshrc_preservesSymlink(t *testing.T) {
 	}
 }
 
+// TestAppendFpathAtZshrc_preservesDanglingSymlink verifies that when .zshrc is a
+// symlink whose target does not exist yet (a dangling link, e.g. a dotfile tool
+// linked it before the target was created), the install writes through the link
+// to create its target rather than replacing the symlink with a regular file.
+// EvalSymlinks fails on a dangling link, so the naive resolve regressed here.
+func TestAppendFpathAtZshrc_preservesDanglingSymlink(t *testing.T) {
+	if IsWindows() {
+		t.Skip("zsh completion is not deployed on Windows")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// ~/.zshrc points at a target that does not exist yet.
+	dotfiles := t.TempDir()
+	realRc := filepath.Join(dotfiles, "zshrc")
+	link := zshrcPath()
+	if err := os.Symlink(realRc, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := appendFpathAtZshrcIfNeeded(); err != nil {
+		t.Fatalf("appendFpathAtZshrcIfNeeded() error = %v", err)
+	}
+
+	// The dangling link must still be a symlink, not a regular file.
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("dangling .zshrc symlink was replaced by a regular file")
+	}
+	// The link target must have been created with the fpath block.
+	got, err := os.ReadFile(filepath.Clean(realRc))
+	if err != nil {
+		t.Fatalf("link target was not created through the symlink: %v", err)
+	}
+	if !strings.Contains(string(got), zshFpathMarker) {
+		t.Fatalf("fpath block was not written to the link target:\n%s", got)
+	}
+}
+
+// TestMakeBashCompletion_preservesDanglingSymlink verifies the same dangling-link
+// guarantee for a completion file: a symlink whose target does not exist yet is
+// preserved and the install creates the link target rather than replacing the
+// link.
+func TestMakeBashCompletion_preservesDanglingSymlink(t *testing.T) {
+	if IsWindows() {
+		t.Skip("completion install is not supported on Windows")
+	}
+	t.Setenv("HOME", t.TempDir())
+	cmd := testCompletionCmd()
+
+	link := bashCompletionFilePath()
+	if err := os.MkdirAll(filepath.Dir(link), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// The completion path is a symlink to a target that does not exist yet.
+	dotfiles := t.TempDir()
+	realComp := filepath.Join(dotfiles, "gup")
+	if err := os.Symlink(realComp, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := makeBashCompletionFileIfNeeded(cmd); err != nil {
+		t.Fatalf("makeBashCompletionFileIfNeeded() error = %v", err)
+	}
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("dangling completion symlink was replaced by a regular file")
+	}
+	got, err := os.ReadFile(filepath.Clean(realComp))
+	if err != nil {
+		t.Fatalf("link target was not created through the symlink: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatalf("link target was created empty, expected bash completion content")
+	}
+}
+
 // TestMakeBashCompletion_atomicWriteFailureKeepsOriginal verifies that when the
 // final rename fails, an existing completion file keeps its original contents
 // (it is never truncated in place) and no temp file is left behind.

--- a/internal/completion/completion_more_test.go
+++ b/internal/completion/completion_more_test.go
@@ -174,6 +174,43 @@ func TestMakeBashCompletion_preservesDanglingSymlink(t *testing.T) {
 	}
 }
 
+// TestAppendFpathAtZshrc_symlinkCycleFailsCleanly verifies that a symlink cycle
+// at .zshrc is reported as an error rather than silently replacing one of the
+// links with a regular file. Without surfacing hop-limit exhaustion, the resolver
+// would return a still-symlink path and the atomic rename would clobber the link.
+func TestAppendFpathAtZshrc_symlinkCycleFailsCleanly(t *testing.T) {
+	if IsWindows() {
+		t.Skip("zsh completion is not deployed on Windows")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Build a cycle: ~/.zshrc -> ~/.zshrc.cycle -> ~/.zshrc.
+	link := zshrcPath()
+	other := filepath.Join(home, ".zshrc.cycle")
+	if err := os.Symlink(other, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(link, other); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := appendFpathAtZshrcIfNeeded(); err == nil {
+		t.Fatal("expected an error for a symlink cycle, got nil")
+	}
+
+	// Neither link may be replaced by a regular file.
+	for _, p := range []string{link, other} {
+		info, err := os.Lstat(p)
+		if err != nil {
+			t.Fatalf("Lstat(%s) error = %v", p, err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("symlink %s in a cycle was replaced by a regular file", p)
+		}
+	}
+}
+
 // TestMakeBashCompletion_atomicWriteFailureKeepsOriginal verifies that when the
 // final rename fails, an existing completion file keeps its original contents
 // (it is never truncated in place) and no temp file is left behind.


### PR DESCRIPTION
## Background
PR #402 made completion-file and `.zshrc` writes atomic and, to avoid replacing a symlink with a regular file, resolved symlinks with `filepath.EvalSymlinks` before staging the temp file. This protected the common dotfile-manager case (stow, chezmoi, yadm) where `~/.zshrc` is a symlink into a managed directory.

However, `filepath.EvalSymlinks` requires the *entire* path — including the final target — to exist. For a **dangling symlink** (a link whose target does not exist yet) it returns an error, so the original symlink path was kept and `os.Rename` replaced the symlink with a regular file. This is exactly the state right after a dotfile manager links `~/.zshrc` (or a completion file) but before its target file has been written for the first time.

The old in-place implementation (`OpenFile(..., O_CREATE|O_TRUNC|O_APPEND)`) followed the symlink and created/updated the link target, so it preserved the link in this case. The atomic rewrite regressed it.

## Cause
`atomicWriteFile` relied on `filepath.EvalSymlinks`, which fails on a dangling link. On failure the destination stayed the symlink itself, so the subsequent `os.Rename` replaced the link with a regular file.

## Fix
Replace `EvalSymlinks` with a small `resolveSymlinkTarget` helper that follows the chain of symlinks at the destination using `os.Lstat` + `os.Readlink`, **even when the final target does not exist yet**, and returns that target path.

- For an existing-target symlink it returns the same path `EvalSymlinks` would (behavior unchanged).
- For a dangling symlink it returns the link target, so the temp file is staged in the target's directory and the rename creates the target through the link — the symlink is preserved.
- A non-symlink path (including a missing plain file) is returned unchanged, so new files are still created normally.
- Intermediate directory symlinks need no special handling: the OS resolves them transparently during create/rename.
- A hop limit guards against a symlink cycle.

The change is confined to the completion package's atomic-write seam.

## Tests
TDD (red → green). Added to `internal/completion/completion_more_test.go`:

- `TestAppendFpathAtZshrc_preservesDanglingSymlink`: `~/.zshrc` is a symlink to a not-yet-existing target; after install the link is still a symlink and the target file is created with the fpath block.
- `TestMakeBashCompletion_preservesDanglingSymlink`: the bash completion path is a dangling symlink; after install the link is preserved and its target is created with the generated content.

The existing non-dangling symlink test (`TestAppendFpathAtZshrc_preservesSymlink`) and all atomic-write / failure / idempotency tests keep passing.

Local verification:
- `go test ./...` green
- `go test -race ./...` green
- `go vet ./...` clean
- `golangci-lint run ./internal/completion/...` 0 issues

## Risk
Low. The change only swaps how the destination symlink is resolved before the atomic write; the write itself, permission preservation, idempotency, and the directory/relative-path guards are unchanged. Existing-target symlinks and plain files behave exactly as before; the only behavioral change is that a dangling symlink is now followed (matching the pre-#402 in-place behavior) instead of being replaced. On Windows it remains a no-op.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of shell configuration and completion files when the destination path is a symlink, including broken (dangling) symlinks.
  * Prevents accidental replacement of symlinks with regular files; updates are written through the symlink to create or update the missing target content.
  * Detects symlink cycles during updates and fails safely without clobbering the existing symlink paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->