### PR TITLE
fix: preserve symlinked gup.json during atomic config writes

### DIFF
--- a/cmd/config_file.go
+++ b/cmd/config_file.go
@@ -24,6 +24,17 @@ func writeConfigFile(path string, pkgs []goutil.Package) (err error) {
 	if fileutil.IsDir(path) {
 		return fmt.Errorf("%s is a directory, not a file", path)
 	}
+	// Resolve symlinks at the destination so the atomic rename rewrites the link's
+	// target rather than replacing the link itself with a regular file. Dotfile
+	// managers (stow, chezmoi, yadm) commonly symlink gup.json into place; this
+	// preserves the link - including a dangling link whose target does not exist
+	// yet, the state right after a dotfile manager links a file before its first
+	// write.
+	resolvedPath, err := fileutil.ResolveSymlinkTarget(path)
+	if err != nil {
+		return fmt.Errorf("can not resolve config path %s: %w", path, err)
+	}
+	path = resolvedPath
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, fileutil.FileModeCreatingDir); err != nil {
 		return fmt.Errorf("%s: %w", "can not make config directory", err)

--- a/cmd/config_file_test.go
+++ b/cmd/config_file_test.go
@@ -362,6 +362,8 @@ func Test_writeConfigFile_preservesSymlink(t *testing.T) {
 		t.Fatalf("config was not written through the symlink to its target: %q", string(got))
 	}
 	assertNoTempFiles(t, dir, filepath.Base(link))
+	// Temps are staged next to the resolved target, so check that basename too.
+	assertNoTempFiles(t, dir, filepath.Base(realPath))
 }
 
 // Test_writeConfigFile_preservesDanglingSymlink verifies that when gup.json is a
@@ -401,6 +403,8 @@ func Test_writeConfigFile_preservesDanglingSymlink(t *testing.T) {
 		t.Fatalf("config was not written to the link target: %q", string(got))
 	}
 	assertNoTempFiles(t, dir, filepath.Base(link))
+	// Temps are staged next to the resolved target, so check that basename too.
+	assertNoTempFiles(t, dir, filepath.Base(target))
 }
 
 func fileExists(t *testing.T, path string) bool {

--- a/cmd/config_file_test.go
+++ b/cmd/config_file_test.go
@@ -319,6 +319,90 @@ func Test_writeConfigFile_regularFileStillWorks(t *testing.T) {
 	assertNoTempFiles(t, dir, filepath.Base(path))
 }
 
+// Test_writeConfigFile_preservesSymlink verifies that when gup.json is a symlink
+// (e.g. a dotfile manager links it into place), writing the config rewrites the
+// link's target file and keeps the symlink intact rather than replacing it with a
+// regular file.
+func Test_writeConfigFile_preservesSymlink(t *testing.T) {
+	if runtime.GOOS == goosWindows {
+		t.Skip("symlink behavior is POSIX-specific")
+	}
+	t.Parallel()
+
+	dir := t.TempDir()
+	realPath := filepath.Join(dir, "real-gup.json")
+	if err := os.WriteFile(realPath, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "gup.json")
+	if err := os.Symlink(realPath, link); err != nil {
+		t.Fatal(err)
+	}
+
+	pkg := goutil.Package{Name: testBinAir, ImportPath: oldImport, Version: &goutil.Version{Current: testVersion123}}
+	if err := writeConfigFile(link, []goutil.Package{pkg}); err != nil {
+		t.Fatalf("writeConfigFile() error = %v", err)
+	}
+
+	// The link must remain a symlink, not be replaced by a regular file.
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("gup.json symlink was replaced by a regular file")
+	}
+
+	// The config must have been written through the link to the real target.
+	got, err := os.ReadFile(filepath.Clean(realPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), oldImport) {
+		t.Fatalf("config was not written through the symlink to its target: %q", string(got))
+	}
+	assertNoTempFiles(t, dir, filepath.Base(link))
+}
+
+// Test_writeConfigFile_preservesDanglingSymlink verifies that when gup.json is a
+// symlink whose target does not exist yet (a dotfile tool linked it before the
+// target was written), the config write creates the link target instead of
+// replacing the symlink with a regular file.
+func Test_writeConfigFile_preservesDanglingSymlink(t *testing.T) {
+	if runtime.GOOS == goosWindows {
+		t.Skip("symlink behavior is POSIX-specific")
+	}
+	t.Parallel()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real-gup.json")
+	link := filepath.Join(dir, "gup.json")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	pkg := goutil.Package{Name: testBinAir, ImportPath: oldImport, Version: &goutil.Version{Current: testVersion123}}
+	if err := writeConfigFile(link, []goutil.Package{pkg}); err != nil {
+		t.Fatalf("writeConfigFile() error = %v", err)
+	}
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("dangling gup.json symlink was replaced by a regular file")
+	}
+	got, err := os.ReadFile(filepath.Clean(target))
+	if err != nil {
+		t.Fatalf("link target was not created through the symlink: %v", err)
+	}
+	if !strings.Contains(string(got), oldImport) {
+		t.Fatalf("config was not written to the link target: %q", string(got))
+	}
+	assertNoTempFiles(t, dir, filepath.Base(link))
+}
+
 func fileExists(t *testing.T, path string) bool {
 	t.Helper()
 	info, err := os.Stat(path)

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -172,7 +172,7 @@ func atomicWriteFile(path string, data []byte, what string) (err error) {
 	// the previous in-place write followed the link, and this preserves that
 	// behavior - including for a dangling link whose target does not exist yet, the
 	// state right after a dotfile manager links a file before its first write.
-	resolvedPath, resolveErr := resolveSymlinkTarget(path)
+	resolvedPath, resolveErr := fileutil.ResolveSymlinkTarget(path)
 	if resolveErr != nil {
 		return fmt.Errorf("can not resolve %s path %s: %w", what, path, resolveErr)
 	}
@@ -221,43 +221,6 @@ func atomicWriteFile(path string, data []byte, what string) (err error) {
 		return fmt.Errorf("can not finalize %s: %w", what, err)
 	}
 	return nil
-}
-
-// resolveSymlinkTarget follows the chain of symlinks at path and returns the
-// final target, even when that target does not exist yet (a dangling symlink -
-// e.g. a dotfile manager that linked ~/.zshrc before its target file was ever
-// written). This lets atomicWriteFile create or replace the link's target rather
-// than the link itself, preserving the symlink. filepath.EvalSymlinks cannot be
-// used because it requires the whole path to exist and so fails on a dangling
-// link. A non-symlink path (including a missing plain file) is returned
-// unchanged; intermediate directory symlinks need no handling because the OS
-// resolves them transparently during create/rename. Exhausting the hop limit
-// means a symlink cycle: that is reported as an error so the caller aborts,
-// rather than returning a still-symlink path that the atomic rename would then
-// clobber into a regular file.
-func resolveSymlinkTarget(path string) (string, error) {
-	for range 255 {
-		info, err := os.Lstat(path)
-		if err != nil {
-			// path does not exist yet (e.g. a dangling link's final target): it is
-			// the destination to create, so stop here with no error.
-			return path, nil //nolint:nilerr // a missing target is the intended write path
-		}
-		if info.Mode()&os.ModeSymlink == 0 {
-			return path, nil
-		}
-		dest, err := os.Readlink(path)
-		if err != nil {
-			// The link is unreadable; fall back to treating path as the destination
-			// so the caller surfaces a concrete write error rather than this one.
-			return path, nil //nolint:nilerr // fall back to writing at path
-		}
-		if !filepath.IsAbs(dest) {
-			dest = filepath.Join(filepath.Dir(path), dest)
-		}
-		path = filepath.Clean(dest)
-	}
-	return "", fmt.Errorf("symlink chain too deep (possible cycle) at %s", path)
 }
 
 func makeBashCompletionFileIfNeeded(cmd *cobra.Command) error {

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -2,6 +2,7 @@
 package fileutil
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -31,4 +32,41 @@ func IsDir(path string) bool {
 func IsHiddenFile(filePath string) bool {
 	_, name := filepath.Split(filePath)
 	return IsFile(filePath) && strings.HasPrefix(name, ".")
+}
+
+// ResolveSymlinkTarget follows the chain of symlinks at path and returns the
+// final target, even when that target does not exist yet (a dangling symlink -
+// e.g. a dotfile manager that linked a config file before its target was ever
+// written). This lets an atomic write (temp file + rename) create or replace the
+// link's target rather than the link itself, preserving the symlink.
+// filepath.EvalSymlinks cannot be used because it requires the whole path to
+// exist and so fails on a dangling link. A non-symlink path (including a missing
+// plain file) is returned unchanged; intermediate directory symlinks need no
+// handling because the OS resolves them transparently during create/rename.
+// Exhausting the hop limit means a symlink cycle: that is reported as an error so
+// the caller aborts, rather than returning a still-symlink path that the atomic
+// rename would then clobber into a regular file.
+func ResolveSymlinkTarget(path string) (string, error) {
+	for range 255 {
+		info, err := os.Lstat(path)
+		if err != nil {
+			// path does not exist yet (e.g. a dangling link's final target): it is
+			// the destination to create, so stop here with no error.
+			return path, nil //nolint:nilerr // a missing target is the intended write path
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			return path, nil
+		}
+		dest, err := os.Readlink(path)
+		if err != nil {
+			// The link is unreadable; fall back to treating path as the destination
+			// so the caller surfaces a concrete write error rather than this one.
+			return path, nil //nolint:nilerr // fall back to writing at path
+		}
+		if !filepath.IsAbs(dest) {
+			dest = filepath.Join(filepath.Dir(path), dest)
+		}
+		path = filepath.Clean(dest)
+	}
+	return "", fmt.Errorf("symlink chain too deep (possible cycle) at %s", path)
 }

--- a/internal/fileutil/fileutil_test.go
+++ b/internal/fileutil/fileutil_test.go
@@ -114,3 +114,95 @@ func TestIsHiddenFile(t *testing.T) {
 		}
 	})
 }
+
+func TestResolveSymlinkTarget(t *testing.T) {
+	if isWindows() {
+		t.Skip("symlink behavior is POSIX-specific")
+	}
+	t.Parallel()
+
+	t.Run("regular file returned unchanged", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "file")
+		if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		got, err := ResolveSymlinkTarget(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != path {
+			t.Fatalf("ResolveSymlinkTarget(%q) = %q, want unchanged", path, got)
+		}
+	})
+
+	t.Run("missing path returned unchanged", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "missing")
+		got, err := ResolveSymlinkTarget(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != path {
+			t.Fatalf("ResolveSymlinkTarget(%q) = %q, want unchanged", path, got)
+		}
+	})
+
+	t.Run("symlink resolves to target", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		target := filepath.Join(dir, "target")
+		if err := os.WriteFile(target, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		link := filepath.Join(dir, "link")
+		if err := os.Symlink(target, link); err != nil {
+			t.Fatal(err)
+		}
+		got, err := ResolveSymlinkTarget(link)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != target {
+			t.Fatalf("ResolveSymlinkTarget(%q) = %q, want %q", link, got, target)
+		}
+	})
+
+	t.Run("dangling symlink resolves to missing target", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		target := filepath.Join(dir, "target")
+		link := filepath.Join(dir, "link")
+		if err := os.Symlink(target, link); err != nil {
+			t.Fatal(err)
+		}
+		got, err := ResolveSymlinkTarget(link)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != target {
+			t.Fatalf("ResolveSymlinkTarget(%q) = %q, want %q", link, got, target)
+		}
+	})
+
+	t.Run("symlink cycle reports an error", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		a := filepath.Join(dir, "a")
+		b := filepath.Join(dir, "b")
+		if err := os.Symlink(a, b); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(b, a); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := ResolveSymlinkTarget(a); err == nil {
+			t.Fatal("ResolveSymlinkTarget() should error on a symlink cycle")
+		}
+	})
+}
+
+func isWindows() bool {
+	return os.PathSeparator == '\\'
+}


### PR DESCRIPTION
## Summary
- Preserve a symlinked `gup.json` when writing config (update/pin/unpin/export) instead of replacing the link with a regular file.

## Problem
- When `gup.json` is a symlink (e.g. managed by a dotfile tool such as stow/chezmoi/yadm), writing the config replaced the symlink with a regular file rather than updating the link's target.

## Root cause
- `writeConfigFile` performs an atomic write (temp file + `os.Rename`) targeting the destination path directly. `os.Rename` onto a symlink replaces the link itself, severing it. This mirrors the issue previously fixed for `.zshrc`/completion files in #402/#403.

## Expected behavior
- If the destination config path is a symlink, gup resolves the link chain to its final target and writes there atomically, keeping the symlink intact.
- A dangling symlink (target not created yet) is supported: the write creates the target through the link.
- Ordinary (non-symlink) file writes are unchanged.
- Directory rejection behavior (#367) is unchanged.

## Changes
- Extract the existing private `resolveSymlinkTarget` logic from `internal/completion` into a shared, exported `fileutil.ResolveSymlinkTarget`, and reuse it from `internal/completion` to avoid duplication.
- Resolve the symlink target in `cmd/config_file.go` `writeConfigFile` before staging the temp file.

## Tests
- `Test_writeConfigFile_preservesSymlink`: writing to a symlinked `gup.json` keeps the link and writes through to its target.
- `Test_writeConfigFile_preservesDanglingSymlink`: a dangling symlink target is created through the link.
- `Test_writeConfigFile_regularFileStillWorks` / existing success/idempotent/directory-rejection tests remain green (regression).
- `TestResolveSymlinkTarget`: unit coverage for the extracted helper (regular file, missing path, symlink, dangling symlink, cycle-error).

## Non-goals
- No new features, no CLI/flag changes, no behavior change for non-symlink paths.
- Windows rename-replace semantics are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Writing configuration files now resolves symlink destinations more safely: existing symlinks are preserved while updates apply to the intended target.
  * Improved handling for missing/dangling symlinks to reduce failures and prevent stray temporary artifacts.
  * Completion file updates now follow the same symlink-resolution rules for more consistent behavior.
* **Tests**
  * Added POSIX-only coverage for symlink and dangling-symlink scenarios, plus unit tests for symlink-chain resolution and cycle detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->