### PR TITLE
fix: handle bug-report browser timeouts without false success

### DIFF
--- a/cmd/browser_command.go
+++ b/cmd/browser_command.go
@@ -2,12 +2,14 @@ package cmd
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"os/exec"
 	"time"
 )
 
-const openBrowserTimeout = 5 * time.Second
+// openBrowserTimeout bounds how long we wait for the browser launcher to return.
+// It is a var (not a const) so tests can shrink it to exercise the timeout path.
+var openBrowserTimeout = 5 * time.Second //nolint:gochecknoglobals // overridden in tests
 
 // runBrowserCommand executes browser launcher commands. This is swapped in tests.
 var runBrowserCommand = func(command string, args ...string) error { //nolint:gochecknoglobals
@@ -15,13 +17,22 @@ var runBrowserCommand = func(command string, args ...string) error { //nolint:go
 	defer cancel()
 
 	// Command names are hard-coded in openBrowser and URL is internally generated.
-	return browserCommandError(exec.CommandContext(ctx, command, args...).Run()) //nolint:gosec
+	err := exec.CommandContext(ctx, command, args...).Run() //nolint:gosec
+	return browserCommandError(ctx, err)
 }
 
-func browserCommandError(err error) error {
-	if errors.Is(err, context.DeadlineExceeded) {
-		// open/xdg-open may keep running for a while after successfully launching.
-		return nil
+// browserCommandError maps the result of launching the browser to success or
+// failure for bug-report. A launch timeout is treated as a failure, not success:
+// the launcher commands (xdg-open/open/rundll32) return promptly once the URL is
+// handed to the browser, so a launcher still running after openBrowserTimeout
+// means the launch did not complete reliably. Reporting it as an error lets
+// bug-report fall back to printing the issue template instead of silently doing
+// nothing. The decision is driven by ctx.Err() rather than the raw command error
+// because a killed process surfaces as an OS "signal: killed" error that does not
+// wrap context.DeadlineExceeded.
+func browserCommandError(ctx context.Context, err error) error {
+	if ctx.Err() != nil {
+		return fmt.Errorf("browser launch did not complete within %s: %w", openBrowserTimeout, ctx.Err())
 	}
 	return err
 }

--- a/cmd/browser_command_test.go
+++ b/cmd/browser_command_test.go
@@ -3,30 +3,74 @@ package cmd
 import (
 	"context"
 	"errors"
+	"runtime"
 	"testing"
+	"time"
 )
 
 func Test_browserCommandError(t *testing.T) {
 	t.Parallel()
 
 	otherErr := errors.New("some error")
-	tests := []struct {
-		name string
-		err  error
-		want error
-	}{
-		{name: "nil", err: nil, want: nil},
-		{name: "deadline exceeded", err: context.DeadlineExceeded, want: nil},
-		{name: "other", err: otherErr, want: otherErr},
+
+	t.Run("nil error with live context succeeds", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		if got := browserCommandError(ctx, nil); got != nil {
+			t.Fatalf("browserCommandError(live, nil) = %v, want nil", got)
+		}
+	})
+
+	t.Run("non-timeout error passes through", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		if got := browserCommandError(ctx, otherErr); !errors.Is(got, otherErr) {
+			t.Fatalf("browserCommandError(live, otherErr) = %v, want it to wrap %v", got, otherErr)
+		}
+	})
+
+	// A launch timeout must be reported as a failure, not silently treated as
+	// success, even when the raw command error is nil: the launcher commands
+	// return promptly once the URL is handed to the browser, so an expired context
+	// means the launch did not complete reliably and bug-report should fall back to
+	// printing the issue template.
+	t.Run("expired context is a failure even when err is nil", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+		defer cancel()
+		<-ctx.Done()
+		got := browserCommandError(ctx, nil)
+		if got == nil {
+			t.Fatal("browserCommandError(expired, nil) = nil, want an error")
+		}
+		if !errors.Is(got, context.DeadlineExceeded) {
+			t.Fatalf("browserCommandError(expired, nil) = %v, want it to wrap context.DeadlineExceeded", got)
+		}
+	})
+}
+
+// Test_runBrowserCommand_timeoutIsFailure exercises the real exec path: a
+// launcher that runs longer than openBrowserTimeout must surface a (non-nil)
+// error so openBrowser reports failure and bug-report shows the fallback guide,
+// rather than the timeout being swallowed as a false success.
+//
+//nolint:paralleltest // mutates the package-level openBrowserTimeout
+func Test_runBrowserCommand_timeoutIsFailure(t *testing.T) {
+	if runtime.GOOS == goosWindows {
+		t.Skip("relies on the POSIX 'sleep' command")
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := browserCommandError(tt.err)
-			if !errors.Is(got, tt.want) || (tt.want == nil && got != nil) {
-				t.Fatalf("browserCommandError(%v) = %v, want %v", tt.err, got, tt.want)
-			}
-		})
+	orig := openBrowserTimeout
+	t.Cleanup(func() { openBrowserTimeout = orig })
+	openBrowserTimeout = 50 * time.Millisecond
+
+	err := runBrowserCommand("sleep", "5")
+	if err == nil {
+		t.Fatal("runBrowserCommand() should return an error when the launcher times out")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("runBrowserCommand() error = %v, want it to wrap context.DeadlineExceeded", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Treat a browser-launch timeout in `gup bug-report` as a failure so the fallback issue template is shown, instead of silently reporting success.

## Problem
- When the browser launcher (`xdg-open` / `open` / `rundll32.exe`) did not return within the timeout, `browserCommandError` returned `nil`, so `openBrowser` reported success and `bugReport` skipped the fallback. The user could end up with neither an opened browser nor the printed issue template — a silent failure.

## Root cause
- `browserCommandError` special-cased `context.DeadlineExceeded` and returned `nil` ("the launcher may keep running after launching"). In addition, the check was unreliable: a launcher killed on context expiry surfaces as an OS `signal: killed` error that does **not** wrap `context.DeadlineExceeded`, so the timeout branch could not actually detect a real timeout.

## Expected behavior
- A launch that exceeds `openBrowserTimeout` is reported as an error, so `openBrowser` returns `false` and `bug-report` prints the fallback guidance/template.
- Normal success (launcher returns promptly, no error) and ordinary launch errors are unchanged: success → no fallback, error → fallback.

## Changes
- `cmd/browser_command.go`: decide success/failure from `ctx.Err()` rather than the raw command error, returning a descriptive wrapped error on timeout. `openBrowserTimeout` is now a `var` so tests can shrink it.

## Tests
- `Test_browserCommandError`: nil error with a live context succeeds; a non-timeout error passes through; an expired context is a failure even when the raw error is `nil` (wraps `context.DeadlineExceeded`).
- `Test_runBrowserCommand_timeoutIsFailure`: real `exec` path — a launcher that runs past the (shrunk) timeout returns a non-nil error wrapping `context.DeadlineExceeded` (skipped on Windows; relies on POSIX `sleep`).
- Existing `Test_bugReport_fallbackOutput` continues to lock the fallback rendering when `openBrowser` returns false.

## Non-goals
- No new features or flags; the issue URL/template content is unchanged.
- No change to the normal (prompt-return) success path or to per-platform launcher commands.
