### PR TITLE
fix: reject directory paths explicitly in gup import

### DIFF
--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -122,6 +122,33 @@ func Test_runImport_fileNotFound(t *testing.T) {
 	}
 }
 
+// Test_runImport_fileIsDirectory verifies that `gup import --file <dir>` fails
+// fast with a precise "directory, not a gup.json file" error instead of the
+// misleading "is not found" message it would otherwise produce (IsFile reports
+// false for a directory).
+func Test_runImport_fileIsDirectory(t *testing.T) {
+	cmd := newImportCmd()
+	dir := t.TempDir()
+	if err := cmd.Flags().Set("file", dir); err != nil {
+		t.Fatal(err)
+	}
+
+	p, buf := newTestPrinter()
+
+	got := runImport(p, cmd, nil)
+
+	if got != 1 {
+		t.Errorf("runImport() = %v, want 1", got)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "is a directory, not a gup.json file") {
+		t.Errorf("expected directory error, got: %s", out)
+	}
+	if strings.Contains(out, "is not found") {
+		t.Errorf("directory path should not report 'is not found', got: %s", out)
+	}
+}
+
 func Test_runImport_emptyConf(t *testing.T) {
 	// Create a temporary conf file with no packages
 	tmpDir := t.TempDir()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,6 +88,13 @@ func DirPath() string {
 func ResolveImportFilePath(explicitPath string) (string, error) {
 	explicitPath = strings.TrimSpace(explicitPath)
 	if explicitPath != "" {
+		// An explicit --file path that points at a directory is a user mistake.
+		// Reject it here with a precise error instead of letting import fall
+		// through to a misleading "not found" (IsFile reports false for a
+		// directory), matching the auto-detected-candidate handling below.
+		if fileutil.IsDir(explicitPath) {
+			return "", fmt.Errorf("%s is a directory, not a gup.json file", explicitPath)
+		}
 		return explicitPath, nil
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -414,6 +414,23 @@ func TestResolveImportFilePathDirectoryCandidate(t *testing.T) { //nolint:parall
 			t.Fatalf("ResolveImportFilePath(xdg dir) error = %q, want it to mention it is a directory", err.Error())
 		}
 	})
+
+	// An explicit --file path that points at a directory must be rejected with the
+	// same precise "directory, not a gup.json file" error, rather than falling
+	// through to a misleading "not found" failure in import.
+	t.Run("explicit --file is a directory", func(t *testing.T) { //nolint:paralleltest // sibling subtests change working dir
+		dir := t.TempDir()
+		got, err := ResolveImportFilePath(dir)
+		if err == nil {
+			t.Fatalf("ResolveImportFilePath(explicit dir) = (%s, nil), want error", got)
+		}
+		if got != "" {
+			t.Fatalf("ResolveImportFilePath(explicit dir) path = %s, want empty", got)
+		}
+		if !strings.Contains(err.Error(), "directory") {
+			t.Fatalf("ResolveImportFilePath(explicit dir) error = %q, want it to mention it is a directory", err.Error())
+		}
+	})
 }
 
 func TestResolveExportFilePath(t *testing.T) {


### PR DESCRIPTION
## Summary
- Make `gup import --file <directory>` fail fast with a precise "directory, not a gup.json file" error instead of a misleading "not found".

## Problem
- Passing a directory to `import --file` produced `<dir> is not found`, which wrongly suggests the path does not exist.

## Root cause
- `config.ResolveImportFilePath` returns an explicit `--file` path unchecked. `runImport` then guards with `fileutil.IsFile`, which reports `false` for a directory, so the code falls into the generic "is not found" branch. The auto-detected-candidate branch already rejected directories, but the explicit-path branch did not.

## Expected behavior
- `gup import --file <dir>` fails with `<dir> is a directory, not a gup.json file`, consistent with the auto-detected-candidate handling and `configstate.ReadFileIfExists`.
- A genuinely missing `--file` path still reports "is not found".
- Valid file imports are unchanged.

## Changes
- `internal/config/config.go`: in `ResolveImportFilePath`, reject an explicit path that is a directory with the precise error before returning it.

## Tests
- `internal/config`: `TestResolveImportFilePathDirectoryCandidate` gains an "explicit --file is a directory" subtest asserting the directory error and empty returned path.
- `cmd`: `Test_runImport_fileIsDirectory` is an end-to-end regression — `import --file <dir>` exits 1 with the directory error and does not print "is not found".
- Existing `Test_runImport_fileNotFound` keeps missing-file coverage intact.

## Non-goals
- No new features or flags; no change to valid imports, missing-file handling, ambiguous-candidate handling, or export.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file path handling so directory paths are reported clearly as directories instead of being mistaken for missing files.
  * Import commands now fail with a more specific message when `--file` points to a directory.
  * Added test coverage to confirm the correct error and exit behavior in this case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->