### PR TITLE
fix: write generated manpages atomically

### DIFF
--- a/cmd/man.go
+++ b/cmd/man.go
@@ -136,24 +136,58 @@ func copyOneManpage(p *print.Printer, file, dst string) (err error) {
 		}
 	}()
 
-	out, err := os.Create(outputPath)
+	return writeManpageAtomically(outputPath, in, strings.TrimSuffix(filepath.Base(file), ".1"))
+}
+
+// writeManpageAtomically gzips src into outputPath via a temp file in the same
+// directory followed by an atomic rename, so a failed or interrupted write can
+// never truncate or corrupt an existing man page; the destination is only
+// replaced once the new content is fully written. A symlinked destination is
+// preserved by resolving the link to its target first (matching how the previous
+// os.Create followed the link, and consistent with config_file.go).
+func writeManpageAtomically(outputPath string, src io.Reader, gzName string) (err error) {
+	resolvedPath, err := fileutil.ResolveSymlinkTarget(outputPath)
+	if err != nil {
+		return fmt.Errorf("can not resolve man page path %s: %w", outputPath, err)
+	}
+	outputPath = resolvedPath
+	dir := filepath.Dir(outputPath)
+
+	out, err := os.CreateTemp(dir, filepath.Base(outputPath)+".tmp-*")
 	if err != nil {
 		return err
 	}
+	tmpPath := out.Name()
 	defer func() {
-		if closeErr := out.Close(); closeErr != nil {
-			err = errors.Join(err, closeErr)
+		if out != nil {
+			if closeErr := out.Close(); closeErr != nil && err == nil {
+				err = closeErr
+			}
+		}
+		if err != nil {
+			_ = os.Remove(tmpPath)
 		}
 	}()
 
 	gz := gzip.NewWriter(out)
-	gz.Name = strings.TrimSuffix(filepath.Base(file), ".1")
-	defer func() {
-		if closeErr := gz.Close(); closeErr != nil {
-			err = errors.Join(err, closeErr)
-		}
-	}()
+	gz.Name = gzName
+	if _, err = io.Copy(gz, src); err != nil {
+		return err
+	}
+	if err = gz.Close(); err != nil {
+		return err
+	}
+	if err = out.Sync(); err != nil {
+		return fmt.Errorf("can not sync man page %s: %w", outputPath, err)
+	}
+	if err = out.Close(); err != nil {
+		out = nil
+		return fmt.Errorf("can not close man page %s: %w", outputPath, err)
+	}
+	out = nil
 
-	_, err = io.Copy(gz, in)
-	return err
+	if err = renameWithReplace(tmpPath, outputPath); err != nil {
+		return fmt.Errorf("can not finalize man page %s: %w", outputPath, err)
+	}
+	return nil
 }

--- a/cmd/man.go
+++ b/cmd/man.go
@@ -16,6 +16,10 @@ import (
 	"github.com/spf13/cobra/doc"
 )
 
+// manpageFileMode is the default world-readable mode for generated man pages,
+// matching what os.Create (0666 & umask) produced before the atomic write.
+const manpageFileMode = 0o644
+
 func newManCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "man",
@@ -151,7 +155,23 @@ func writeManpageAtomically(outputPath string, src io.Reader, gzName string) (er
 		return fmt.Errorf("can not resolve man page path %s: %w", outputPath, err)
 	}
 	outputPath = resolvedPath
+	// Reject a directory destination before staging any temp file, so a mistaken
+	// path cannot replace a directory tree via the rename-replace flow (mirrors the
+	// guard in cmd/config_file.go).
+	if fileutil.IsDir(outputPath) {
+		return fmt.Errorf("%s is a directory, not a file", outputPath)
+	}
 	dir := filepath.Dir(outputPath)
+
+	// os.CreateTemp creates the temp file with mode 0600, but man pages must stay
+	// world-readable as os.Create (0666 & umask) previously produced. Preserve an
+	// existing file's mode when replacing it, otherwise default to 0644.
+	mode := os.FileMode(manpageFileMode)
+	if info, statErr := os.Stat(outputPath); statErr == nil {
+		mode = info.Mode().Perm()
+	} else if !os.IsNotExist(statErr) {
+		return fmt.Errorf("can not stat man page %s: %w", outputPath, statErr)
+	}
 
 	out, err := os.CreateTemp(dir, filepath.Base(outputPath)+".tmp-*")
 	if err != nil {
@@ -176,6 +196,9 @@ func writeManpageAtomically(outputPath string, src io.Reader, gzName string) (er
 	}
 	if err = gz.Close(); err != nil {
 		return err
+	}
+	if err = out.Chmod(mode); err != nil {
+		return fmt.Errorf("can not set permissions on man page %s: %w", outputPath, err)
 	}
 	if err = out.Sync(); err != nil {
 		return fmt.Errorf("can not sync man page %s: %w", outputPath, err)

--- a/cmd/man_test.go
+++ b/cmd/man_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -36,6 +37,90 @@ func TestGenerateManpages(t *testing.T) {
 			t.Error("No man files found")
 		}
 	})
+}
+
+// Test_copyOneManpage_failedWriteDoesNotCorruptExisting verifies that when the
+// final rename fails, an existing destination man page is left untouched (not
+// truncated or partially overwritten) and no temp artifact is left behind.
+//
+//nolint:paralleltest // mutates the package-level renameFunc
+func Test_copyOneManpage_failedWriteDoesNotCorruptExisting(t *testing.T) {
+	origRename := renameFunc
+	t.Cleanup(func() { renameFunc = origRename })
+
+	src := filepath.Join(t.TempDir(), "gup.1")
+	if err := os.WriteFile(src, []byte("manpage source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := t.TempDir()
+	existing := filepath.Join(dst, "gup.1.gz")
+	if err := os.WriteFile(existing, []byte("PREVIOUS"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	renameFunc = func(_, _ string) error {
+		return errors.New("forced rename failure")
+	}
+
+	if err := copyOneManpage(discardPrinter(), src, dst); err == nil {
+		t.Fatal("copyOneManpage() should return an error when the rename fails")
+	}
+
+	got, err := os.ReadFile(filepath.Clean(existing))
+	if err != nil {
+		t.Fatalf("existing man page should survive a failed write: %v", err)
+	}
+	if string(got) != "PREVIOUS" {
+		t.Fatalf("existing man page was corrupted: got %q, want %q", string(got), "PREVIOUS")
+	}
+
+	assertNoTempFiles(t, dst, "gup.1.gz")
+}
+
+// Test_copyOneManpage_preservesSymlink verifies that when the destination man
+// page is a symlink, the atomic write rewrites the link target and keeps the
+// symlink intact rather than replacing it with a regular file.
+func Test_copyOneManpage_preservesSymlink(t *testing.T) {
+	if runtime.GOOS == goosWindows {
+		t.Skip("symlink behavior is POSIX-specific")
+	}
+	t.Parallel()
+
+	src := filepath.Join(t.TempDir(), "gup.1")
+	if err := os.WriteFile(src, []byte("manpage source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := t.TempDir()
+	realTarget := filepath.Join(t.TempDir(), "real-gup.1.gz")
+	if err := os.WriteFile(realTarget, []byte("OLD"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dst, "gup.1.gz")
+	if err := os.Symlink(realTarget, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyOneManpage(discardPrinter(), src, dst); err != nil {
+		t.Fatalf("copyOneManpage() error = %v", err)
+	}
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("man page symlink was replaced by a regular file")
+	}
+	// The link target must now hold the freshly generated gzip content, not "OLD".
+	got, err := os.ReadFile(filepath.Clean(realTarget))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) == "OLD" || len(got) == 0 {
+		t.Fatalf("man page was not written through the symlink to its target: %q", string(got))
+	}
 }
 
 func TestManPaths(t *testing.T) {

--- a/cmd/man_test.go
+++ b/cmd/man_test.go
@@ -123,6 +123,60 @@ func Test_copyOneManpage_preservesSymlink(t *testing.T) {
 	}
 }
 
+// Test_copyOneManpage_worldReadable verifies the generated man page keeps a
+// world-readable mode (0644), matching the previous os.Create behavior, rather
+// than the 0600 that os.CreateTemp would otherwise leave behind.
+func Test_copyOneManpage_worldReadable(t *testing.T) {
+	if runtime.GOOS == goosWindows {
+		t.Skip("POSIX file mode semantics do not apply on Windows")
+	}
+	t.Parallel()
+
+	src := filepath.Join(t.TempDir(), "gup.1")
+	if err := os.WriteFile(src, []byte("manpage source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dst := t.TempDir()
+
+	if err := copyOneManpage(discardPrinter(), src, dst); err != nil {
+		t.Fatalf("copyOneManpage() error = %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(dst, "gup.1.gz"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o644 {
+		t.Fatalf("man page mode = %o, want 0644 (world-readable)", got)
+	}
+}
+
+// Test_copyOneManpage_rejectsDirectory verifies a destination that is a directory
+// is rejected before any temp file is staged, so the rename-replace flow cannot
+// clobber a directory tree.
+func Test_copyOneManpage_rejectsDirectory(t *testing.T) {
+	t.Parallel()
+
+	src := filepath.Join(t.TempDir(), "gup.1")
+	if err := os.WriteFile(src, []byte("manpage source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dst := t.TempDir()
+	// Pre-create a directory exactly where the .gz output would be written.
+	if err := os.Mkdir(filepath.Join(dst, "gup.1.gz"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	err := copyOneManpage(discardPrinter(), src, dst)
+	if err == nil {
+		t.Fatal("copyOneManpage() should reject a directory destination")
+	}
+	if info, statErr := os.Stat(filepath.Join(dst, "gup.1.gz")); statErr != nil || !info.IsDir() {
+		t.Fatalf("directory destination should be untouched, stat err = %v", statErr)
+	}
+	assertNoTempFiles(t, dst, "gup.1.gz")
+}
+
 func TestManPaths(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == goosWindows {


### PR DESCRIPTION
## Summary
- Make `gup man` write generated man pages atomically so a failed/interrupted write cannot truncate or corrupt an existing man page.

## Problem
- Manpage generation wrote each `.gz` directly to its destination with `os.Create`, which truncates the target before the new content is written. A failure or interruption mid-write could leave an existing man page truncated or corrupted.

## Root cause
- `copyOneManpage` opened the destination with `os.Create(outputPath)` and streamed gzip output straight into it, with no staging or rollback. This is less robust than the repository's other write paths (config files, completion files), which write to a temp file and rename.

## Expected behavior
- The destination man page is only replaced once the new content is fully written; a failed write leaves the existing file untouched and leaves no temp artifact behind.
- Successful generation behavior is unchanged (same output path and gzip content).
- A symlinked destination is preserved (the link target is rewritten), matching how the previous `os.Create` followed the link and consistent with `cmd/config_file.go`.

## Changes
- `cmd/man.go`: extract `writeManpageAtomically`, which gzips into a temp file in the destination directory, fsyncs, and atomically renames into place via the existing `renameWithReplace` (handles the Windows overwrite case). The destination symlink is resolved with `fileutil.ResolveSymlinkTarget` before staging.

## Tests
- `Test_copyOneManpage_failedWriteDoesNotCorruptExisting`: with a forced rename failure, an existing man page keeps its original content and no temp file is left behind.
- `Test_copyOneManpage_preservesSymlink`: a symlinked destination stays a symlink and the link target receives the new content (regression guard for the symlink-following behavior).
- Existing `TestGenerateManpages` and `TestMan` continue to lock the normal successful generation path.

## Non-goals
- No new features or flags; no change to man page content, output paths, or MANPATH resolution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved manpage generation so updates are written atomically, reducing the risk of truncated or corrupted files during interruptions or errors.
  * Existing manpages are now preserved if a write fails, instead of being partially overwritten.
  * Symlinked manpage destinations are handled correctly, updating the target while keeping the symlink in place.

* **Tests**
  * Added coverage for failed writes and symlink behavior to guard against regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->