### PR TITLE
fix: respect umask when setting generated manpage permissions

### DIFF
--- a/cmd/man.go
+++ b/cmd/man.go
@@ -16,9 +16,10 @@ import (
 	"github.com/spf13/cobra/doc"
 )
 
-// manpageFileMode is the default world-readable mode for generated man pages,
-// matching what os.Create (0666 & umask) produced before the atomic write.
-const manpageFileMode = 0o644
+// manpageCreateMode is the base mode requested for a newly created man page,
+// matching the 0666 os.Create opened with before the atomic write. The process
+// umask is applied to it (see applyUmask) so restrictive umasks are honored.
+const manpageCreateMode = 0o666
 
 func newManCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -163,10 +164,11 @@ func writeManpageAtomically(outputPath string, src io.Reader, gzName string) (er
 	}
 	dir := filepath.Dir(outputPath)
 
-	// os.CreateTemp creates the temp file with mode 0600, but man pages must stay
-	// world-readable as os.Create (0666 & umask) previously produced. Preserve an
-	// existing file's mode when replacing it, otherwise default to 0644.
-	mode := os.FileMode(manpageFileMode)
+	// os.CreateTemp creates the temp file with mode 0600. Reproduce os.Create's
+	// previous behavior instead: for a new file use 0666 with the process umask
+	// applied (so a restrictive umask such as 077 still yields 0600, not a wider
+	// 0644), and when replacing an existing file preserve that file's own mode.
+	mode := applyUmask(manpageCreateMode)
 	if info, statErr := os.Stat(outputPath); statErr == nil {
 		mode = info.Mode().Perm()
 	} else if !os.IsNotExist(statErr) {

--- a/cmd/man_perm_unix_test.go
+++ b/cmd/man_perm_unix_test.go
@@ -1,0 +1,89 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// Test_copyOneManpage_respectsUmask verifies that a newly generated man page
+// gets the same permissions os.Create produced (0666 & ^umask), rather than a
+// hardcoded 0644. Under a restrictive umask (e.g. 077) the file must NOT be
+// world-readable, so a fixed 0644 would be an unintended permission widening.
+//
+//nolint:paralleltest // mutates the process-global umask
+func Test_copyOneManpage_respectsUmask(t *testing.T) {
+	tests := []struct {
+		name  string
+		umask int
+		want  os.FileMode
+	}{
+		{name: "umask 022 -> 0644", umask: 0o022, want: 0o644},
+		{name: "umask 077 -> 0600", umask: 0o077, want: 0o600},
+		{name: "umask 002 -> 0664", umask: 0o002, want: 0o664},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			old := syscall.Umask(tt.umask)
+			defer syscall.Umask(old)
+
+			src := filepath.Join(t.TempDir(), "gup.1")
+			if err := os.WriteFile(src, []byte("manpage source"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			dst := t.TempDir()
+
+			if err := copyOneManpage(discardPrinter(), src, dst); err != nil {
+				t.Fatalf("copyOneManpage() error = %v", err)
+			}
+
+			info, err := os.Stat(filepath.Join(dst, "gup.1.gz"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := info.Mode().Perm(); got != tt.want {
+				t.Fatalf("man page mode = %#o, want %#o (umask %#o)", got, tt.want, tt.umask)
+			}
+		})
+	}
+}
+
+// Test_copyOneManpage_preservesExistingMode verifies that replacing an existing
+// man page keeps that file's own permissions instead of resetting them to the
+// new-file default.
+//
+//nolint:paralleltest // mutates the process-global umask
+func Test_copyOneManpage_preservesExistingMode(t *testing.T) {
+	// A permissive umask must not influence the result: the existing file's mode
+	// wins when the destination already exists.
+	old := syscall.Umask(0o000)
+	defer syscall.Umask(old)
+
+	src := filepath.Join(t.TempDir(), "gup.1")
+	if err := os.WriteFile(src, []byte("manpage source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dst := t.TempDir()
+	existing := filepath.Join(dst, "gup.1.gz")
+	// Group-readable but not world-readable; with umask 000 above, WriteFile keeps
+	// these exact bits, the non-default mode we expect copyOneManpage to preserve.
+	if err := os.WriteFile(existing, []byte("OLD"), 0o640); err != nil { //nolint:gosec // intentional non-default mode to assert preservation
+		t.Fatal(err)
+	}
+
+	if err := copyOneManpage(discardPrinter(), src, dst); err != nil {
+		t.Fatalf("copyOneManpage() error = %v", err)
+	}
+
+	info, err := os.Stat(existing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o640 {
+		t.Fatalf("replaced man page mode = %#o, want 0640 (preserved)", got)
+	}
+}

--- a/cmd/man_perm_unix_test.go
+++ b/cmd/man_perm_unix_test.go
@@ -5,7 +5,6 @@ package cmd
 import (
 	"os"
 	"path/filepath"
-	"syscall"
 	"testing"
 )
 
@@ -13,8 +12,10 @@ import (
 // gets the same permissions os.Create produced (0666 & ^umask), rather than a
 // hardcoded 0644. Under a restrictive umask (e.g. 077) the file must NOT be
 // world-readable, so a fixed 0644 would be an unintended permission widening.
+// The cached processUmask is injected so the assertion is deterministic and does
+// not mutate the real process umask.
 //
-//nolint:paralleltest // mutates the process-global umask
+//nolint:paralleltest // mutates the package-level processUmask
 func Test_copyOneManpage_respectsUmask(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -28,8 +29,9 @@ func Test_copyOneManpage_respectsUmask(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			old := syscall.Umask(tt.umask)
-			defer syscall.Umask(old)
+			old := processUmask
+			processUmask = tt.umask
+			defer func() { processUmask = old }()
 
 			src := filepath.Join(t.TempDir(), "gup.1")
 			if err := os.WriteFile(src, []byte("manpage source"), 0o600); err != nil {
@@ -54,14 +56,15 @@ func Test_copyOneManpage_respectsUmask(t *testing.T) {
 
 // Test_copyOneManpage_preservesExistingMode verifies that replacing an existing
 // man page keeps that file's own permissions instead of resetting them to the
-// new-file default.
+// new-file default, regardless of the umask.
 //
-//nolint:paralleltest // mutates the process-global umask
+//nolint:paralleltest // mutates the package-level processUmask
 func Test_copyOneManpage_preservesExistingMode(t *testing.T) {
 	// A permissive umask must not influence the result: the existing file's mode
 	// wins when the destination already exists.
-	old := syscall.Umask(0o000)
-	defer syscall.Umask(old)
+	old := processUmask
+	processUmask = 0o000
+	defer func() { processUmask = old }()
 
 	src := filepath.Join(t.TempDir(), "gup.1")
 	if err := os.WriteFile(src, []byte("manpage source"), 0o600); err != nil {
@@ -69,9 +72,12 @@ func Test_copyOneManpage_preservesExistingMode(t *testing.T) {
 	}
 	dst := t.TempDir()
 	existing := filepath.Join(dst, "gup.1.gz")
-	// Group-readable but not world-readable; with umask 000 above, WriteFile keeps
-	// these exact bits, the non-default mode we expect copyOneManpage to preserve.
-	if err := os.WriteFile(existing, []byte("OLD"), 0o640); err != nil { //nolint:gosec // intentional non-default mode to assert preservation
+	if err := os.WriteFile(existing, []byte("OLD"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Group-readable but not world-readable: a non-default mode that the real
+	// ambient umask cannot influence, so the assertion stays deterministic.
+	if err := os.Chmod(existing, 0o640); err != nil { //nolint:gosec // intentional non-default mode to assert preservation
 		t.Fatal(err)
 	}
 

--- a/cmd/man_test.go
+++ b/cmd/man_test.go
@@ -123,34 +123,6 @@ func Test_copyOneManpage_preservesSymlink(t *testing.T) {
 	}
 }
 
-// Test_copyOneManpage_worldReadable verifies the generated man page keeps a
-// world-readable mode (0644), matching the previous os.Create behavior, rather
-// than the 0600 that os.CreateTemp would otherwise leave behind.
-func Test_copyOneManpage_worldReadable(t *testing.T) {
-	if runtime.GOOS == goosWindows {
-		t.Skip("POSIX file mode semantics do not apply on Windows")
-	}
-	t.Parallel()
-
-	src := filepath.Join(t.TempDir(), "gup.1")
-	if err := os.WriteFile(src, []byte("manpage source"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	dst := t.TempDir()
-
-	if err := copyOneManpage(discardPrinter(), src, dst); err != nil {
-		t.Fatalf("copyOneManpage() error = %v", err)
-	}
-
-	info, err := os.Stat(filepath.Join(dst, "gup.1.gz"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := info.Mode().Perm(); got != 0o644 {
-		t.Fatalf("man page mode = %o, want 0644 (world-readable)", got)
-	}
-}
-
 // Test_copyOneManpage_rejectsDirectory verifies a destination that is a directory
 // is rejected before any temp file is staged, so the rename-replace flow cannot
 // clobber a directory tree.

--- a/cmd/man_umask_unix.go
+++ b/cmd/man_umask_unix.go
@@ -7,15 +7,26 @@ import (
 	"syscall"
 )
 
-// applyUmask returns perm with the current process umask cleared, mirroring how
-// os.Create (which opens with mode 0666) lets the OS apply the umask to a newly
-// created file. There is no read-only umask syscall, so we set it to 0 and
-// immediately restore the previous value to read it; man generation runs
-// sequentially, so the momentary change is safe.
-func applyUmask(perm os.FileMode) os.FileMode {
+// processUmask is the umask captured once at package initialization, while the
+// program is still single-threaded. Reading the umask requires temporarily
+// setting it (there is no read-only syscall), so capturing it here - rather than
+// on every call - avoids mutating the process-global umask at a point where other
+// goroutines might concurrently create files and observe a transient 0 mask. It
+// is a var so tests can substitute a known value.
+var processUmask = readProcessUmask() //nolint:gochecknoglobals // captured once at startup; overridden in tests
+
+// readProcessUmask returns the current process umask, restoring it immediately.
+func readProcessUmask() int {
 	mask := syscall.Umask(0)
 	syscall.Umask(mask)
+	return mask
+}
+
+// applyUmask returns perm with the cached process umask cleared, mirroring how
+// os.Create (which opens with mode 0666) lets the OS apply the umask to a newly
+// created file.
+func applyUmask(perm os.FileMode) os.FileMode {
 	// A umask only occupies the low permission bits, so the conversion cannot
 	// overflow; mask to os.ModePerm to make that explicit for the conversion.
-	return perm &^ (os.FileMode(mask) & os.ModePerm) //nolint:gosec // umask is a small permission bitmask
+	return perm &^ (os.FileMode(processUmask) & os.ModePerm) //nolint:gosec // umask is a small permission bitmask
 }

--- a/cmd/man_umask_unix.go
+++ b/cmd/man_umask_unix.go
@@ -1,0 +1,21 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"os"
+	"syscall"
+)
+
+// applyUmask returns perm with the current process umask cleared, mirroring how
+// os.Create (which opens with mode 0666) lets the OS apply the umask to a newly
+// created file. There is no read-only umask syscall, so we set it to 0 and
+// immediately restore the previous value to read it; man generation runs
+// sequentially, so the momentary change is safe.
+func applyUmask(perm os.FileMode) os.FileMode {
+	mask := syscall.Umask(0)
+	syscall.Umask(mask)
+	// A umask only occupies the low permission bits, so the conversion cannot
+	// overflow; mask to os.ModePerm to make that explicit for the conversion.
+	return perm &^ (os.FileMode(mask) & os.ModePerm) //nolint:gosec // umask is a small permission bitmask
+}

--- a/cmd/man_umask_windows.go
+++ b/cmd/man_umask_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package cmd
+
+import "os"
+
+// applyUmask is a no-op on Windows, which has no POSIX umask; os.Chmod only
+// toggles the read-only bit there, so the requested mode is returned unchanged.
+func applyUmask(perm os.FileMode) os.FileMode {
+	return perm
+}


### PR DESCRIPTION
## Summary
- Respect the process umask when setting permissions on a newly generated man page, instead of forcing a hardcoded `0644`.

## Problem
- PR #407 made man page writes atomic and, to avoid `os.CreateTemp`'s `0600`, `chmod`'d the staged file to a fixed `0644`. That ignores the umask. Under a restrictive umask (e.g. `077`) the previous `os.Create` produced `0600`, but the hardcoded `0644` widens it to world-readable — an unintended permission-loosening regression. `cmd/man_test.go` locked the regression by asserting a fixed `0644`.

## Root cause
- `os.Create(name)` opens with mode `0666`, and the OS applies the umask, yielding `0666 &^ umask`. The atomic-write replacement hardcoded `0644` for a new file rather than reproducing that umask-aware mode.

## Expected behavior
- A newly created man page gets `0666 &^ umask` (e.g. `0644` under umask `022`, `0600` under umask `077`, `0664` under umask `002`), matching the old `os.Create` behavior.
- When replacing an existing man page, that file's own mode is preserved.
- Windows (no POSIX umask) is unaffected.

## Changes
- `cmd/man.go`: derive the new-file mode from `applyUmask(0666)` instead of a fixed constant; existing-file mode preservation is unchanged.
- `cmd/man_umask_unix.go` / `cmd/man_umask_windows.go`: build-tagged `applyUmask` helper (`syscall.Umask` read-and-restore on unix; no-op on Windows).

## Tests
- `cmd/man_perm_unix_test.go`: `Test_copyOneManpage_respectsUmask` (table: umask `022→0644`, `077→0600`, `002→0664`) and `Test_copyOneManpage_preservesExistingMode` (existing `0640` is preserved).
- Removed the previous fixed-`0644` assertion (`Test_copyOneManpage_worldReadable`) that locked the regression.

## Non-goals
- No change to atomic-write behavior, symlink preservation, directory rejection, content, or output paths from #407.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted generated man page permissions to respect the system’s file-creation settings.
  * Preserved existing permission settings when updating an already-installed man page.
* **Tests**
  * Added coverage for permission behavior under different environment settings.
  * Removed an outdated test that expected all generated man pages to be world-readable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->