### PR TITLE
Treat a missing GOBIN directory as an empty environment

### DIFF
--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -163,46 +163,23 @@ func Test_check_gobin_is_empty(t *testing.T) {
 			args:  args{},
 			want:  0,
 			stderr: []string{
-				"no binaries are installed under $GOPATH/bin or $GOBIN",
+				emptyEnvMessage,
 				"",
 			},
 		},
-	}
-
-	if runtime.GOOS == goosWindows {
-		tests = append(tests, struct {
-			name   string
-			gobin  string
-			args   args
-			want   int
-			stderr []string
-		}{
+		{
+			// A $GOBIN directory that does not exist yet is a normal first-run
+			// condition (#350): check treats it like an empty environment (exit 0
+			// + note) instead of failing with a read-dir error.
 			name:  testGobinEmpty,
 			gobin: testNoExistDir,
 			args:  args{},
-			want:  1,
+			want:  0,
 			stderr: []string{
-				"gup:ERROR: can't get package info: can't get binary-paths installed by 'go install': open no_exist_dir: The system cannot find the file specified.",
+				emptyEnvMessage,
 				"",
 			},
-		})
-	} else {
-		tests = append(tests, struct {
-			name   string
-			gobin  string
-			args   args
-			want   int
-			stderr []string
-		}{
-			name:  testGobinEmpty,
-			gobin: testNoExistDir,
-			args:  args{},
-			want:  1,
-			stderr: []string{
-				"gup:ERROR: can't get package info: can't get binary-paths installed by 'go install': open no_exist_dir: no such file or directory",
-				"",
-			},
-		})
+		},
 	}
 
 	if err := os.Mkdir(filepath.Join("testdata", "empty_dir"), 0755); err != nil {

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -94,41 +94,10 @@ func Test_export(t *testing.T) {
 		},
 	}
 
-	if runtime.GOOS == goosWindows {
-		tests = append(tests, struct {
-			name   string
-			args   []string
-			gobin  string
-			want   int
-			stderr []string
-		}{
-
-			name:  "not exist gobin directory",
-			gobin: filepath.Join("testdata", "dummy"),
-			want:  1,
-			stderr: []string{
-				"gup:ERROR: can't get package info: can't get binary-paths installed by 'go install': open " + filepath.Join("testdata", "dummy") + ": The system cannot find the file specified.",
-				"",
-			},
-		})
-	} else {
-		tests = append(tests, struct {
-			name   string
-			args   []string
-			gobin  string
-			want   int
-			stderr []string
-		}{
-
-			name:  "not exist gobin directory",
-			gobin: filepath.Join("testdata", "dummy"),
-			want:  1,
-			stderr: []string{
-				"gup:ERROR: can't get package info: can't get binary-paths installed by 'go install': open testdata/dummy: no such file or directory",
-				"",
-			},
-		})
-	}
+	// A missing $GOBIN directory is now treated as a normal empty environment
+	// (#350): export writes an empty config and exits 0. That behavior is covered
+	// with proper XDG isolation by Test_export_emptyEnv_missingGOBINWritesEmptyConfig,
+	// so it is intentionally not re-asserted in this permission-focused table.
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -344,6 +313,34 @@ func Test_export_emptyEnv_writesEmptyConfig(t *testing.T) {
 	p, _ := newTestPrinter()
 	if got := export(p, newExportCmd(), []string{}); got != 0 {
 		t.Fatalf("export() on empty env = %d, want 0", got)
+	}
+
+	pkgs, err := config.ReadConfFile(config.FilePath())
+	if err != nil {
+		t.Fatalf("exported config should be readable: %v", err)
+	}
+	if len(pkgs) != 0 {
+		t.Fatalf("exported config should have no packages, got %d", len(pkgs))
+	}
+}
+
+// Test_export_emptyEnv_missingGOBINWritesEmptyConfig verifies the #350 contract
+// for a $GOBIN directory that does not exist yet: export succeeds (exit 0) and
+// writes an empty gup.json instead of failing with a read-dir error.
+func Test_export_emptyEnv_missingGOBINWritesEmptyConfig(t *testing.T) {
+	if err := goutil.CanUseGoCmd(); err != nil {
+		t.Skip("go command is not available")
+	}
+
+	origConfigHome := xdg.ConfigHome
+	t.Cleanup(func() { xdg.ConfigHome = origConfigHome })
+	xdg.ConfigHome = t.TempDir()
+
+	t.Setenv("GOBIN", filepath.Join(t.TempDir(), "does-not-exist")) // missing directory
+
+	p, _ := newTestPrinter()
+	if got := export(p, newExportCmd(), []string{}); got != 0 {
+		t.Fatalf("export() on missing $GOBIN = %d, want 0", got)
 	}
 
 	pkgs, err := config.ReadConfFile(config.FilePath())

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -46,45 +45,23 @@ func Test_list_gobin_is_empty(t *testing.T) {
 			args:  args{},
 			want:  0,
 			stderr: []string{
-				"no binaries are installed under $GOPATH/bin or $GOBIN",
+				emptyEnvMessage,
 				"",
 			},
 		},
-	}
-	if runtime.GOOS == goosWindows {
-		tests = append(tests, struct {
-			name   string
-			gobin  string
-			args   args
-			want   int
-			stderr []string
-		}{
+		{
+			// A $GOBIN directory that does not exist yet is a normal first-run
+			// condition (#350): list treats it like an empty environment (exit 0
+			// + note) instead of failing with a read-dir error.
 			name:  testGobinEmpty,
 			gobin: testNoExistDir,
 			args:  args{},
-			want:  1,
+			want:  0,
 			stderr: []string{
-				"gup:ERROR: can't get package info: can't get binary-paths installed by 'go install': open no_exist_dir: The system cannot find the file specified.",
+				emptyEnvMessage,
 				"",
 			},
-		})
-	} else {
-		tests = append(tests, struct {
-			name   string
-			gobin  string
-			args   args
-			want   int
-			stderr []string
-		}{
-			name:  testGobinEmpty,
-			gobin: testNoExistDir,
-			args:  args{},
-			want:  1,
-			stderr: []string{
-				"gup:ERROR: can't get package info: can't get binary-paths installed by 'go install': open no_exist_dir: no such file or directory",
-				"",
-			},
-		})
+		},
 	}
 
 	if err := os.Mkdir(filepath.Join("testdata", "empty_dir"), 0o755); err != nil { //nolint:gosec

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -243,6 +243,24 @@ func Test_gup_emptyEnv_succeedsWithoutExplicitConfigProblem(t *testing.T) {
 	}
 }
 
+// Test_gup_emptyEnv_missingGOBINSucceeds verifies the #350 contract for a
+// $GOBIN directory that does not exist yet: update treats it like a normal empty
+// environment (exit 0) instead of failing with a read-dir error.
+func Test_gup_emptyEnv_missingGOBINSucceeds(t *testing.T) {
+	setupXDGBase(t)
+	chdirToTemp(t)
+	t.Setenv("GOBIN", filepath.Join(t.TempDir(), "does-not-exist")) // missing directory
+
+	got := 0
+	_ = captureCheckOutput(t, func(p *print.Printer) int {
+		got = gup(defaultDependencies(), p, newUpdateCmd(), []string{})
+		return got
+	})
+	if got != 0 {
+		t.Fatalf("gup() = %d, want 0 when $GOBIN directory is missing", got)
+	}
+}
+
 // Test_gup_invalidConfigFile verifies the #369 contract: a malformed gup.json is
 // not silently treated as "no config" (which would downgrade saved channels to
 // @latest); update fails fast and names the failing path instead.

--- a/internal/pkgselect/pkgselect.go
+++ b/internal/pkgselect/pkgselect.go
@@ -12,7 +12,9 @@
 package pkgselect
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -23,6 +25,11 @@ import (
 
 // BinaryPaths returns the absolute paths of the binaries installed under $GOBIN
 // (or $GOPATH/bin).
+//
+// A $GOBIN/$GOPATH/bin directory that does not exist yet is a normal first-run
+// condition, not an error: it is reported as an empty list so list/check/update/
+// export behave like any other empty installed-tool set instead of failing with
+// a read-dir error (#350).
 func BinaryPaths() ([]string, error) {
 	goBin, err := goutil.GoBin()
 	if err != nil {
@@ -31,6 +38,9 @@ func BinaryPaths() ([]string, error) {
 
 	binList, err := goutil.BinaryPathList(goBin)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return []string{}, nil
+		}
 		return nil, fmt.Errorf("%s: %w", "can't get binary-paths installed by 'go install'", err)
 	}
 

--- a/internal/pkgselect/pkgselect_test.go
+++ b/internal/pkgselect/pkgselect_test.go
@@ -262,6 +262,23 @@ func TestBinaryPaths(t *testing.T) {
 	}
 }
 
+// A first-run environment has no $GOBIN directory yet. Treating that as a
+// read-dir error would make list/check/update/export fail instead of behaving
+// like a normal empty installed-tool set, so BinaryPaths must return an empty
+// list and no error when the directory does not exist.
+func TestBinaryPaths_missingGOBINIsEmpty(t *testing.T) {
+	missingDir := filepath.Join(t.TempDir(), "does-not-exist")
+	t.Setenv("GOBIN", missingDir)
+
+	got, err := BinaryPaths()
+	if err != nil {
+		t.Fatalf("BinaryPaths() with missing $GOBIN should not error, got: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("BinaryPaths() with missing $GOBIN should be empty, got: %v", got)
+	}
+}
+
 func TestPackageInfoByTargets_filtersToTarget(t *testing.T) {
 	t.Setenv("GOBIN", filepath.Join("..", "..", "cmd", "testdata", "check_success"))
 


### PR DESCRIPTION
## Summary
- Treat a `$GOBIN` / `$GOPATH/bin` directory that does not exist yet as a normal first-run empty environment for `list`, `check`, `update`, and `export`.

## Problem
- When `$GOBIN` or `$GOPATH/bin` did not exist yet, `list`, `check`, `update`, and `export` failed with a read-dir error (`can't get binary-paths installed by 'go install': open <dir>: no such file or directory`) and exited 1.
- This contradicted the documented empty-environment behavior (#350): a first run with no installed tools should be a friendly success, not an error.

## Root cause
- `pkgselect.BinaryPaths()` calls `goutil.BinaryPathList(goBin)`, which does `os.ReadDir`. A non-existent directory returns an `os.ErrNotExist` error that propagated up to every command as a fatal error, instead of being treated as "no binaries installed".

## Expected behavior
- If the binary directory does not exist yet, gup treats it the same as an empty installed-tool set.
- `list`, `check`, and `update` exit 0 and show the existing empty-environment note.
- `export` exits 0 and writes an empty `gup.json`.
- Explicit target-selection and other usage-error behavior remain unchanged. `migrate` still rejects a non-existent `BEFORE_PATH`, because its explicit-path validation happens before `BinaryPathList` and `goutil.BinaryPathList`'s error contract is left intact.

## Changes
- `internal/pkgselect/pkgselect.go`: `BinaryPaths()` now returns an empty slice (and no error) when the resolved `$GOBIN`/`$GOPATH/bin` directory does not exist (`errors.Is(err, os.ErrNotExist)`). All other read-dir errors still surface.

## Tests
- `internal/pkgselect`: added `TestBinaryPaths_missingGOBINIsEmpty` (missing `$GOBIN` → empty list, no error).
- `cmd`: updated `Test_list_gobin_is_empty` and `Test_check_gobin_is_empty` so the missing-directory case now expects exit 0 with the first-run note (previously locked exit 1 + read-dir error).
- `cmd`: added `Test_gup_emptyEnv_missingGOBINSucceeds` (update) and `Test_export_emptyEnv_missingGOBINWritesEmptyConfig` (export writes an empty `gup.json`).
- `cmd`: removed the now-superseded "not exist gobin directory" case from `Test_export` (its new behavior is covered with proper XDG isolation by the dedicated export test).

## Non-goals
- No change to `goutil.BinaryPathList`'s contract for explicit paths (still errors on a missing path), so `migrate` BEFORE_PATH validation is unaffected.
- No new features and no change to genuinely invalid/permission-denied directory handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Treat a missing `GOBIN`/binary directory as an empty environment instead of an error.
  * Commands now exit successfully and show a consistent informational message when no binaries are found.
  * Export/update flows now handle first-run or missing-directory cases without failing.
* **Tests**
  * Added regression coverage for missing `GOBIN` across check, list, export, update, and binary path detection scenarios.
  * Simplified test expectations to remove platform-specific error assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->