### PR TITLE
Fail fast on auto-detected config errors even in empty environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,8 @@ An empty global environment (no binaries installed by `go install` yet) is treat
 
 Naming a binary that is not installed, or excluding every binary, is still a usage error and exits `1`.
 
+A config problem is also still reported even on an empty environment: if the `gup.json` that would be read (an explicit `--file`, or an auto-detected one) is malformed, has an unsupported schema/channel/pin, or is ambiguous (both the user-level config and `./gup.json` exist with no `--file`), `check`, `update`, and `list --json` fail fast and exit `1` instead of silently ignoring it.
+
 ### Export／Import subcommand
 Use export/import when you want to install the same Go binaries across multiple systems.
 `gup.json` stores each tool's import path, the recorded binary `version`, and its update `channel` (`latest` / `main` / `master` / `pinned`). For `channel: "pinned"`, `version` is the exact target version the tool is held at; for the other channels it is the version that was recorded at export time. `import` installs the exact version written in the file, and a pinned package stays pinned after import.

--- a/cmd/check_channel_test.go
+++ b/cmd/check_channel_test.go
@@ -187,6 +187,67 @@ func Test_check_emptyEnv_validatesExplicitDirectoryFile(t *testing.T) {
 	}
 }
 
+// Test_check_emptyEnv_validatesAutoDetectedMalformedConfig verifies that an
+// empty environment fails fast on a malformed auto-detected (user-level) config
+// even when no --file is given. Without validation, a broken gup.json would be
+// silently ignored just because zero binaries are installed.
+func Test_check_emptyEnv_validatesAutoDetectedMalformedConfig(t *testing.T) {
+	setupXDGBase(t)
+	chdirToTemp(t)
+	t.Setenv("GOBIN", t.TempDir()) // empty environment
+
+	if err := os.MkdirAll(config.DirPath(), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(config.FilePath(), []byte("{invalid"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var got int
+	out := captureCheckOutput(t, func(p *print.Printer) int {
+		got = check(defaultDependencies(), p, newCheckCmd(), []string{})
+		return got
+	})
+	if got != 1 {
+		t.Fatalf("check() = %d, want 1 for a malformed auto-detected config on an empty environment", got)
+	}
+	if !strings.Contains(out, config.FilePath()) {
+		t.Errorf("error should name the failing config %q, got: %s", config.FilePath(), out)
+	}
+}
+
+// Test_check_emptyEnv_validatesAutoDetectedAmbiguousConfig verifies that an
+// empty environment still fails fast when both the user-level config and
+// ./gup.json exist and no --file is given (the same ambiguity a non-empty
+// environment rejects).
+func Test_check_emptyEnv_validatesAutoDetectedAmbiguousConfig(t *testing.T) {
+	setupXDGBase(t)
+	chdirToTemp(t)
+	t.Setenv("GOBIN", t.TempDir()) // empty environment
+
+	if err := os.MkdirAll(config.DirPath(), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(config.FilePath(), []byte(validImportConf), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(config.LocalFilePath(), []byte(validImportConf), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var got int
+	out := captureCheckOutput(t, func(p *print.Printer) int {
+		got = check(defaultDependencies(), p, newCheckCmd(), []string{})
+		return got
+	})
+	if got != 1 {
+		t.Fatalf("check() = %d, want 1 for an ambiguous auto-detected config on an empty environment", got)
+	}
+	if !strings.Contains(out, "multiple gup.json") || !strings.Contains(out, "--file") {
+		t.Errorf("expected ambiguity error mentioning --file, got: %s", out)
+	}
+}
+
 // Test_check_emptyEnv_succeedsWithoutExplicitConfigProblem is the #368 regression
 // guard: an empty environment with no explicit config problem still exits 0.
 func Test_check_emptyEnv_succeedsWithoutExplicitConfigProblem(t *testing.T) {

--- a/cmd/emptyenv.go
+++ b/cmd/emptyenv.go
@@ -12,16 +12,19 @@ import (
 // explicitSelection is true when the user narrowed the selection themselves
 // (positional targets, or update's --exclude); in that case the empty result is
 // a usage error reported with usageErr. Otherwise the empty environment is a
-// normal first-run condition, not an error (#350): an explicitly named --file is
-// still validated so honoring explicit user input does not depend on unrelated
-// environment state (#368), and the command emits an empty JSON array (--json)
-// or an informational note before exiting 0.
+// normal first-run condition, not an error (#350): the config gup would read
+// (explicit --file or auto-detected) is still validated so an empty environment
+// fails fast on the same config problems a non-empty one would — ambiguous
+// resolution, malformed file, invalid schema/channel/pin data (#368) — instead
+// of silently succeeding just because zero binaries are installed. With no
+// config problem, the command emits an empty JSON array (--json) or an
+// informational note before exiting 0.
 func handleEmptyEnvironment(p *print.Printer, confFile string, jsonOut, explicitSelection bool, usageErr string) int {
 	if explicitSelection {
 		p.Err(usageErr)
 		return 1
 	}
-	if err := configstate.ValidateExplicitFile(confFile); err != nil {
+	if err := configstate.ValidateResolvedConfig(confFile); err != nil {
 		p.Err(err)
 		return 1
 	}

--- a/cmd/jsonout_test.go
+++ b/cmd/jsonout_test.go
@@ -440,6 +440,8 @@ func Test_list_jsonFlag_ambiguousConfigFailsFast(t *testing.T) {
 // environment, list/check/update --json emit a valid empty JSON array and exit 0
 // instead of printing an error.
 func Test_emptyEnv_jsonEmitsEmptyArray(t *testing.T) {
+	setupXDGBase(t)
+	chdirToTemp(t)
 	emptyGobin := t.TempDir()
 
 	t.Run("list --json", func(t *testing.T) {
@@ -489,6 +491,35 @@ func Test_emptyEnv_jsonEmitsEmptyArray(t *testing.T) {
 			t.Fatalf("update --json on empty env should be [], got %d records", len(recs))
 		}
 	})
+}
+
+// Test_emptyEnv_listJSON_validatesAutoDetectedMalformedConfig verifies that
+// list --json on an empty environment fails fast on a malformed auto-detected
+// (user-level) config instead of emitting an empty array and exiting 0.
+func Test_emptyEnv_listJSON_validatesAutoDetectedMalformedConfig(t *testing.T) {
+	setupXDGBase(t)
+	chdirToTemp(t)
+	t.Setenv("GOBIN", t.TempDir()) // empty environment
+
+	if err := os.MkdirAll(config.DirPath(), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(config.FilePath(), []byte("{invalid"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newListCmd()
+	if err := cmd.Flags().Set("json", "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	p, buf := newTestPrinter()
+	if got := list(p, cmd, nil); got != 1 {
+		t.Fatalf("list --json with malformed auto-detected config = %d, want 1", got)
+	}
+	if !strings.Contains(buf.String(), config.FilePath()) {
+		t.Errorf("error should name the failing config %q, got: %s", config.FilePath(), buf.String())
+	}
 }
 
 // Test_gup_jsonFlag exercises gup() with --json (and --dry-run) so the

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -54,11 +54,12 @@ func list(p *print.Printer, cmd *cobra.Command, _ []string) int {
 
 	if jsonOut {
 		// An empty environment has no packages to annotate, so emit a valid
-		// empty JSON array and exit 0 without resolving config (#350). An
-		// explicitly named --file is still validated for consistency with
-		// check/update (#368).
+		// empty JSON array and exit 0. The config that would be read (explicit
+		// --file or auto-detected) is still validated for consistency with
+		// check/update, so an ambiguous or malformed config fails fast instead of
+		// being silently ignored just because no binaries are installed (#368).
 		if len(pkgs) == 0 {
-			if err := configstate.ValidateExplicitFile(confFile); err != nil {
+			if err := configstate.ValidateResolvedConfig(confFile); err != nil {
 				p.Err(err)
 				return 1
 			}

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -200,6 +200,34 @@ func Test_gup_emptyEnv_validatesExplicitMalformedFile(t *testing.T) {
 	}
 }
 
+// Test_gup_emptyEnv_validatesAutoDetectedMalformedConfig verifies that update
+// fails fast on a malformed auto-detected (user-level) config even on an empty
+// environment with no --file, instead of silently succeeding.
+func Test_gup_emptyEnv_validatesAutoDetectedMalformedConfig(t *testing.T) {
+	setupXDGBase(t)
+	chdirToTemp(t)
+	t.Setenv("GOBIN", t.TempDir()) // empty environment
+
+	if err := os.MkdirAll(config.DirPath(), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(config.FilePath(), []byte("{invalid"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var got int
+	out := captureCheckOutput(t, func(p *print.Printer) int {
+		got = gup(defaultDependencies(), p, newUpdateCmd(), []string{})
+		return got
+	})
+	if got != 1 {
+		t.Fatalf("gup() = %d, want 1 for a malformed auto-detected config on an empty environment", got)
+	}
+	if !strings.Contains(out, config.FilePath()) {
+		t.Errorf("error should name the failing config %q, got: %s", config.FilePath(), out)
+	}
+}
+
 // Test_gup_emptyEnv_validatesExplicitDirectoryFile verifies #368 for update when
 // --file points to a directory.
 func Test_gup_emptyEnv_validatesExplicitDirectoryFile(t *testing.T) {

--- a/internal/configstate/configstate.go
+++ b/internal/configstate/configstate.go
@@ -54,22 +54,25 @@ func ReadFileIfExists(path string) ([]goutil.Package, error) {
 	return pkgs, nil
 }
 
-// ValidateExplicitFile validates an explicitly provided --file path so that
-// 'check', 'update' and 'list' honor it even on an empty environment, where the
-// normal config read is otherwise skipped (#368). An empty confFile means no
-// --file was given, so there is nothing to validate. A malformed file, an
-// unsupported schema version, or a directory path is reported as an error; a
-// non-existent path is left as "no config", matching the non-empty-environment
-// behavior.
-func ValidateExplicitFile(confFile string) error {
-	if strings.TrimSpace(confFile) == "" {
-		return nil
-	}
-	path, err := config.ResolveImportFilePath(confFile)
+// ValidateResolvedConfig validates the gup.json that this run would read,
+// whether it is named explicitly with --file or auto-detected, so that an empty
+// environment fails fast on the same config problems a non-empty environment
+// would, instead of silently succeeding just because zero binaries are installed
+// (#368). An empty confFile means auto-detection: when both the user-level
+// config and ./gup.json exist the choice is ambiguous and an error is returned,
+// matching the non-empty path. A directory where a file is expected, a malformed
+// file, an unsupported schema version, or invalid channel/pin data are all
+// reported as errors; a non-existent resolved path is left as "no config".
+//
+// This mirrors the resolution ResolveAndApplyChannels performs (minus the
+// channel application, which is a no-op on an empty package list), so empty and
+// non-empty environments validate identically.
+func ValidateResolvedConfig(confFile string) error {
+	confReadPath, err := config.ResolveImportFilePath(confFile)
 	if err != nil {
 		return err
 	}
-	_, err = ReadFileIfExists(path)
+	_, err = ReadFileIfExists(confReadPath)
 	return err
 }
 

--- a/internal/configstate/configstate_test.go
+++ b/internal/configstate/configstate_test.go
@@ -104,7 +104,8 @@ func TestReadFileIfExists(t *testing.T) {
 	})
 }
 
-func TestValidateExplicitFile(t *testing.T) {
+// TestValidateResolvedConfig_explicitFile covers the explicit --file paths.
+func TestValidateResolvedConfig_explicitFile(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -122,7 +123,6 @@ func TestValidateExplicitFile(t *testing.T) {
 		confFile string
 		wantErr  bool
 	}{
-		{name: "empty is no-op", confFile: "", wantErr: false},
 		{name: "missing path is no config", confFile: filepath.Join(dir, "missing.json"), wantErr: false},
 		{name: "valid passes", confFile: valid, wantErr: false},
 		{name: "malformed fails", confFile: malformed, wantErr: true},
@@ -130,11 +130,62 @@ func TestValidateExplicitFile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if err := ValidateExplicitFile(tt.confFile); (err != nil) != tt.wantErr {
-				t.Fatalf("ValidateExplicitFile(%q) err = %v, wantErr %v", tt.confFile, err, tt.wantErr)
+			if err := ValidateResolvedConfig(tt.confFile); (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateResolvedConfig(%q) err = %v, wantErr %v", tt.confFile, err, tt.wantErr)
 			}
 		})
 	}
+}
+
+// TestValidateResolvedConfig_autoDetected verifies that an empty confFile (no
+// --file) still validates the auto-detected config: a malformed user-level
+// config and an ambiguous user-level + ./gup.json pair both fail, while a clean
+// environment with no config succeeds.
+//
+//nolint:paralleltest // mutates xdg.ConfigHome and the working directory
+func TestValidateResolvedConfig_autoDetected(t *testing.T) {
+	t.Run("no config succeeds", func(t *testing.T) {
+		setupConfigHome(t)
+		t.Chdir(t.TempDir())
+		if err := ValidateResolvedConfig(""); err != nil {
+			t.Fatalf("ValidateResolvedConfig(\"\") with no config err = %v, want nil", err)
+		}
+	})
+
+	t.Run("malformed user-level config fails", func(t *testing.T) {
+		setupConfigHome(t)
+		t.Chdir(t.TempDir())
+		if err := os.MkdirAll(config.DirPath(), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(config.FilePath(), []byte("{invalid"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := ValidateResolvedConfig(""); err == nil {
+			t.Fatal("ValidateResolvedConfig(\"\") with malformed auto-detected config = nil, want error")
+		}
+	})
+
+	t.Run("ambiguous config fails", func(t *testing.T) {
+		setupConfigHome(t)
+		t.Chdir(t.TempDir())
+		if err := os.MkdirAll(config.DirPath(), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(config.FilePath(), []byte(validConf), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(config.LocalFilePath(), []byte(validConf), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		err := ValidateResolvedConfig("")
+		if err == nil {
+			t.Fatal("ValidateResolvedConfig(\"\") with ambiguous config = nil, want error")
+		}
+		if !strings.Contains(err.Error(), "--file") {
+			t.Errorf("ambiguity error should mention --file, got: %v", err)
+		}
+	})
 }
 
 //nolint:paralleltest // mutates xdg.ConfigHome via setupConfigHome


### PR DESCRIPTION
## Summary
- On an empty environment, `check`, `update`, and `list --json` now validate the auto-detected `gup.json` (not just an explicit `--file`), so a broken or ambiguous config fails fast instead of being silently ignored.

## Problem
- When zero binaries were installed, the empty-environment path validated only an explicitly named `--file`. An auto-detected config (no `--file`) was never validated, so a malformed user-level `gup.json`, an invalid schema/channel/pin, or an ambiguous user-level + `./gup.json` pair was silently ignored and the command exited 0.
- This was inconsistent with the non-empty environment, which already fails fast on these same problems (#342, #364, #369).

## Root cause
- `handleEmptyEnvironment` (check/update) and `list --json`'s empty path called `configstate.ValidateExplicitFile`, which returns early with no validation when no `--file` is given. The auto-detection + validation that `ResolveAndApplyChannels` performs for non-empty environments was therefore skipped.

## Expected behavior
- Empty-environment handling fails fast for auto-detected config problems that would fail in a non-empty environment:
  - ambiguous resolution between the user-level `gup.json` and `./gup.json`,
  - malformed auto-detected config,
  - invalid auto-detected schema / channel / pin data.
- Explicit `--file` validation continues to work.
- A normal empty environment with no config problem still succeeds (exit 0 / empty `[]`).
- `export` is intentionally unchanged: it never auto-detects between the user-level config and `./gup.json` (it always reads the canonical config and already fails fast on a malformed one), so it has no auto-detection ambiguity to validate here.

## Changes
- `internal/configstate/configstate.go`: replaced `ValidateExplicitFile` with `ValidateResolvedConfig`, which resolves the config gup would read (explicit or auto-detected) via `config.ResolveImportFilePath` and validates it via `ReadFileIfExists` — mirroring the non-empty path minus the no-op channel application.
- `cmd/emptyenv.go`: `handleEmptyEnvironment` now calls `ValidateResolvedConfig` (covers `check` and `update`).
- `cmd/list.go`: `list --json`'s empty path now calls `ValidateResolvedConfig`.
- `README.md`: documented that config errors are reported even on an empty environment.

## Tests
- `internal/configstate`: `TestValidateResolvedConfig_explicitFile` (explicit paths) and `TestValidateResolvedConfig_autoDetected` (no-config success, malformed auto-detected fails, ambiguous fails).
- `cmd`: `Test_check_emptyEnv_validatesAutoDetectedMalformedConfig`, `Test_check_emptyEnv_validatesAutoDetectedAmbiguousConfig`, `Test_gup_emptyEnv_validatesAutoDetectedMalformedConfig`, `Test_emptyEnv_listJSON_validatesAutoDetectedMalformedConfig`.
- `cmd`: isolated `Test_emptyEnv_jsonEmitsEmptyArray` with `setupXDGBase`/`chdirToTemp` since it now resolves config.

## Non-goals
- No change to `export` behavior (covered separately).
- No change to the existing empty-environment success path when there is no config problem, and no change to explicit `--file` validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `gup check`, `gup update`, and `list --json` now fail fast when the selected config is malformed, invalid, or ambiguous.
  * Empty environments no longer silently pass when a usable config would still be problematic.
  * Ambiguous config selection now reports a clearer error and points to using `--file`.

* **Documentation**
  * Updated the README to reflect the new empty-environment behavior and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->