### PR TITLE
Preserve saved channels when exporting back to an alternate config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ If both the user-level `gup.json` and `./gup.json` exist, `import`, `check`, `up
 
 A malformed or invalid `gup.json` (invalid JSON, an unknown channel, an unsupported `schema_version`, or an unsafe pin) is treated as an error rather than silently ignored: `check`, `update`, and `export` fail fast and name the offending file, so saved per-package channels are never quietly downgraded to `latest` because the config could not be parsed. An unknown channel is never normalized to `latest`.
 
-`gup export` reads saved update channels from the same `gup.json` it writes to: a default export (no `--file`) reads from and writes to the canonical user-level `gup.json`, while `gup export --file <path>` reads from and writes to `<path>`. Exporting back to the same alternate config file therefore preserves its saved channels (round-trip safe) instead of resetting them to `latest` from another source. A first export to a brand-new file has no saved channels to read, so its packages are recorded as `latest`.
+When exporting to a file, `gup export` reads saved update channels from the same `gup.json` it writes to: a default export (no `--file`) reads from and writes to the canonical user-level `gup.json`, while `gup export --file <path>` reads from and writes to `<path>`. Exporting back to the same alternate config file therefore preserves its saved channels (round-trip safe) instead of resetting them to `latest` from another source. A first export to a brand-new file has no saved channels to read, so its packages are recorded as `latest`. With `--output`, `--file` still selects the channel source, but the exported config is printed to STDOUT instead of being written back to that path.
 
 ```shell
 ※ Environments A (e.g. ubuntu)

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ If both the user-level `gup.json` and `./gup.json` exist, `import`, `check`, `up
 
 A malformed or invalid `gup.json` (invalid JSON, an unknown channel, an unsupported `schema_version`, or an unsafe pin) is treated as an error rather than silently ignored: `check`, `update`, and `export` fail fast and name the offending file, so saved per-package channels are never quietly downgraded to `latest` because the config could not be parsed. An unknown channel is never normalized to `latest`.
 
-`gup export` always resolves saved update channels from the canonical user-level `gup.json`; `--file`/`--output` only change the export destination, so exporting to a new file never resets a package's channel back to `latest`.
+`gup export` reads saved update channels from the same `gup.json` it writes to: a default export (no `--file`) reads from and writes to the canonical user-level `gup.json`, while `gup export --file <path>` reads from and writes to `<path>`. Exporting back to the same alternate config file therefore preserves its saved channels (round-trip safe) instead of resetting them to `latest` from another source. A first export to a brand-new file has no saved channels to read, so its packages are recorded as `latest`.
 
 ```shell
 ※ Environments A (e.g. ubuntu)

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -56,10 +56,13 @@ func export(p *print.Printer, cmd *cobra.Command, _ []string) int {
 		return 1
 	}
 	pkgs = validPkgInfo(p, pkgs)
-	// The source of truth for saved channels is always the canonical user-level
-	// config; --file/--output only change the export destination, not where
-	// channels are read from (#341).
-	channelSource := config.FilePath()
+	// Saved channels are read from the same file export writes to, so exporting
+	// back to an alternate config passed with --file round-trips safely instead
+	// of resetting that file's channels to @latest from the canonical config
+	// (#341). configPath is the resolved destination: the explicit --file when
+	// given, otherwise the canonical user-level config, so the default (no --file)
+	// behavior of reading channels from the canonical config is unchanged.
+	channelSource := configPath
 	// A malformed channel-source config must fail fast instead of silently
 	// exporting every package as @latest, which would drop intentionally pinned
 	// channels such as @main from the written gup.json (#369).

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -142,12 +142,11 @@ func Test_export(t *testing.T) {
 // Test_applySavedChannels_prefersImportPath verifies that the saved channel is
 // matched by import_path first (#341), so a binary keeps its channel even when
 // its name differs from the saved entry.
-// Test_export_preservesChannelsFromCanonicalConfig verifies the #341 contract:
-// --file changes only the export destination, while saved channels are always
-// resolved from the canonical user-level config. The destination here is a fresh
-// file that has no channel data, so a wrong implementation would reset the
-// channel to "latest".
-func Test_export_preservesChannelsFromCanonicalConfig(t *testing.T) {
+// Test_export_defaultUsesCanonicalConfig verifies that a default export (no
+// --file) reads saved channels from the canonical user-level config and writes
+// them back, so the canonical channel data round-trips. A wrong implementation
+// would reset the channel to "latest".
+func Test_export_defaultUsesCanonicalConfig(t *testing.T) {
 	if err := goutil.CanUseGoCmd(); err != nil {
 		t.Skip("go command is not available")
 	}
@@ -167,18 +166,12 @@ func Test_export_preservesChannelsFromCanonicalConfig(t *testing.T) {
 
 	t.Setenv("GOBIN", filepath.Join("testdata", "check_success"))
 
-	dest := filepath.Join(t.TempDir(), "exported.json")
-	cmd := newExportCmd()
-	if err := cmd.Flags().Set("file", dest); err != nil {
-		t.Fatalf("failed to set --file: %v", err)
-	}
-
 	p, _ := newTestPrinter()
-	if got := export(p, cmd, []string{}); got != 0 {
+	if got := export(p, newExportCmd(), []string{}); got != 0 {
 		t.Fatalf("export() = %d, want 0", got)
 	}
 
-	exported, err := config.ReadConfFile(dest)
+	exported, err := config.ReadConfFile(config.FilePath())
 	if err != nil {
 		t.Fatalf("failed to read exported config: %v", err)
 	}
@@ -188,6 +181,65 @@ func Test_export_preservesChannelsFromCanonicalConfig(t *testing.T) {
 			found = true
 			if p.UpdateChannel != goutil.UpdateChannelMain {
 				t.Fatalf("posixer channel = %q, want %q (preserved from canonical config)", p.UpdateChannel, goutil.UpdateChannelMain)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("posixer not found in exported config: %+v", exported)
+	}
+}
+
+// Test_export_fileRoundTripPreservesChannels verifies that exporting back to an
+// alternate config file passed with --file preserves the saved channels from
+// that same file, so round-tripping it is safe: the file passed with --file is
+// both the channel source and the destination. The canonical config records a
+// different channel for the same package, so a wrong implementation that reads
+// channels from the canonical config would overwrite the alternate file's @main
+// with @latest.
+func Test_export_fileRoundTripPreservesChannels(t *testing.T) {
+	if err := goutil.CanUseGoCmd(); err != nil {
+		t.Skip("go command is not available")
+	}
+
+	origConfigHome := xdg.ConfigHome
+	t.Cleanup(func() { xdg.ConfigHome = origConfigHome })
+	xdg.ConfigHome = t.TempDir()
+
+	if err := os.MkdirAll(config.DirPath(), 0o750); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+	canonical := `{"schema_version":1,"packages":[{"name":"posixer","import_path":"` + testImportPathPosixer + `","version":"v0.1.0","channel":"latest"}]}` + "\n"
+	if err := os.WriteFile(config.FilePath(), []byte(canonical), 0o600); err != nil {
+		t.Fatalf("failed to seed canonical config: %v", err)
+	}
+
+	alt := filepath.Join(t.TempDir(), "alt.json")
+	altConf := `{"schema_version":1,"packages":[{"name":"posixer","import_path":"` + testImportPathPosixer + `","version":"v0.1.0","channel":"main"}]}` + "\n"
+	if err := os.WriteFile(alt, []byte(altConf), 0o600); err != nil {
+		t.Fatalf("failed to seed alternate config: %v", err)
+	}
+
+	t.Setenv("GOBIN", filepath.Join("testdata", "check_success"))
+
+	cmd := newExportCmd()
+	if err := cmd.Flags().Set("file", alt); err != nil {
+		t.Fatalf("failed to set --file: %v", err)
+	}
+	p, _ := newTestPrinter()
+	if got := export(p, cmd, []string{}); got != 0 {
+		t.Fatalf("export() = %d, want 0", got)
+	}
+
+	exported, err := config.ReadConfFile(alt)
+	if err != nil {
+		t.Fatalf("failed to read exported config: %v", err)
+	}
+	var found bool
+	for _, pkg := range exported {
+		if pkg.ImportPath == testImportPathPosixer {
+			found = true
+			if pkg.UpdateChannel != goutil.UpdateChannelMain {
+				t.Fatalf("posixer channel = %q, want %q (preserved from the alternate file)", pkg.UpdateChannel, goutil.UpdateChannelMain)
 			}
 		}
 	}
@@ -237,9 +289,11 @@ func Test_export_rejectsDirectoryDestination(t *testing.T) {
 	assertNoTempFiles(t, parent, filepath.Base(dest))
 }
 
-// Test_export_failsFastOnMalformedChannelSource verifies the #369 contract: a
-// malformed channel-source config makes export fail fast instead of silently
-// exporting every package as @latest.
+// Test_export_failsFastOnMalformedChannelSource verifies the #369 contract for
+// the --file source: when the alternate config (now both channel source and
+// destination) is malformed, export fails fast instead of silently overwriting
+// it with every package exported as @latest, so the malformed file is left
+// untouched for the user to inspect.
 func Test_export_failsFastOnMalformedChannelSource(t *testing.T) {
 	if err := goutil.CanUseGoCmd(); err != nil {
 		t.Skip("go command is not available")
@@ -248,25 +302,27 @@ func Test_export_failsFastOnMalformedChannelSource(t *testing.T) {
 	origConfigHome := xdg.ConfigHome
 	t.Cleanup(func() { xdg.ConfigHome = origConfigHome })
 	xdg.ConfigHome = t.TempDir()
-	if err := os.MkdirAll(config.DirPath(), 0o750); err != nil {
-		t.Fatalf("failed to create config dir: %v", err)
-	}
-	if err := os.WriteFile(config.FilePath(), []byte("{invalid"), 0o600); err != nil {
-		t.Fatalf("failed to seed malformed config: %v", err)
-	}
 	t.Setenv("GOBIN", filepath.Join("testdata", "check_success"))
 
-	dest := filepath.Join(t.TempDir(), "exported.json")
+	alt := filepath.Join(t.TempDir(), "exported.json")
+	if err := os.WriteFile(alt, []byte("{invalid"), 0o600); err != nil {
+		t.Fatalf("failed to seed malformed config: %v", err)
+	}
+
 	cmd := newExportCmd()
-	if err := cmd.Flags().Set("file", dest); err != nil {
+	if err := cmd.Flags().Set("file", alt); err != nil {
 		t.Fatalf("failed to set --file: %v", err)
 	}
 	p, _ := newTestPrinter()
 	if got := export(p, cmd, []string{}); got != 1 {
 		t.Fatalf("export() = %d, want 1 on malformed channel source", got)
 	}
-	if fileutil.IsFile(dest) {
-		t.Fatal("export must not write a destination file when the channel source is malformed")
+	data, err := os.ReadFile(filepath.Clean(alt))
+	if err != nil {
+		t.Fatalf("malformed channel source should survive, read err = %v", err)
+	}
+	if string(data) != "{invalid" {
+		t.Fatalf("export must not overwrite a malformed channel source, got: %q", string(data))
 	}
 }
 


### PR DESCRIPTION
## Summary
- `gup export --file <path>` now reads saved update channels from `<path>` (the same file it writes to), so round-tripping an alternate config file preserves its channels instead of resetting them to `latest`.

## Problem
- `export --file <path>` used `<path>` only as the destination but always read saved channels from the canonical user-level config (`config.FilePath()`). Exporting an alternate config file managed via `--file` therefore silently rewrote it with every package's channel reset to `latest`, breaking round-trip expectations (e.g. a tool pinned to `@main` in that file came back as `@latest`).

## Root cause
- In `export()`, `channelSource` was hard-coded to `config.FilePath()`, independent of the `--file` destination. The channels applied via `configstate.ApplySavedChannels` thus came from the canonical config even when the user named a different file.

## Expected behavior
- Implemented the finding's preferred behavior: the `--file` path is both the channel source and the destination.
  - Default export (no `--file`): reads from and writes to the canonical user-level `gup.json` (unchanged).
  - `export --file <path>`: reads from and writes to `<path>`.
- Exporting back to the same alternate file preserves its saved channels. A first export to a brand-new file has no saved channels to read, so its packages are recorded as `latest` (unchanged for fresh files).

## Changes
- `cmd/export.go`: set `channelSource := configPath` (the resolved destination from `config.ResolveExportFilePath`, i.e. the explicit `--file` when given, otherwise the canonical config) instead of always `config.FilePath()`.
- `README.md`: documented the round-trip behavior, replacing the old "always resolves from the canonical config" rule.

## Tests
- Added `Test_export_fileRoundTripPreservesChannels`: `export --file <alt>` where `<alt>` records `@main` keeps `@main` after export (would be reset to `@latest` from the canonical config under the old behavior).
- Reworked `Test_export_preservesChannelsFromCanonicalConfig` into `Test_export_defaultUsesCanonicalConfig`: confirms default export (no `--file`) still reads channels from the canonical config.
- Updated `Test_export_failsFastOnMalformedChannelSource` to place the malformed config at the `--file` source (now the channel source) and assert export fails fast and leaves the file untouched.
- `Test_export_failsFastOnUnsupportedSchema` (no `--file`) continues to cover fail-fast on a malformed canonical source.

## Non-goals
- No change to the default (no `--file`) export channel source.
- No change to `import`/`check`/`update`/`list` config resolution.
- No change to `--output` semantics beyond reading channels from the resolved `--file` when one is supplied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `gup export` now preserves saved update channels by reading them from the same config file used for `--file` exports (round-trip safe), instead of resetting to `@latest`.
  * Default `gup export` still uses the canonical user config for channel resolution.
  * Exporting to a brand-new file continues to fall back to `latest` when no saved channels exist.
  * Failed exports no longer overwrite an existing alternate config when the `--file` source is invalid.
* **Documentation**
  * Updated README clarifying how saved channels are resolved for `--file` and how `--output` affects where the exported config is written.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->