### PR TITLE
fix(goutil): explicitly skip Go standard library commands when scanning binaries

### DIFF
--- a/internal/goutil/goutil_test.go
+++ b/internal/goutil/goutil_test.go
@@ -621,6 +621,55 @@ func Test_isModuleBinary(t *testing.T) {
 	}
 }
 
+func Test_isStandardLibraryCommand(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		importPath string
+		want       bool
+	}{
+		{name: "cmd/go", importPath: "cmd/go", want: true},
+		{name: "cmd/gofmt", importPath: "cmd/gofmt", want: true},
+		{name: "bare cmd", importPath: "cmd", want: true},
+		{name: "third-party github", importPath: "github.com/nao1215/gup", want: false},
+		{name: "third-party with cmd subdir", importPath: "github.com/Songmu/ghch/cmd/ghch", want: false},
+		{name: "dotless host with cmd subdir", importPath: "localhost/cmd/tool", want: false},
+		{name: "empty", importPath: "", want: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isStandardLibraryCommand(tt.importPath); got != tt.want {
+				t.Errorf("isStandardLibraryCommand(%q) = %v, want %v", tt.importPath, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_shouldManageBinary(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		importPath     string
+		mainModulePath string
+		want           bool
+	}{
+		{name: "third-party module", importPath: "github.com/nao1215/gup", mainModulePath: "github.com/nao1215/gup", want: true},
+		{name: "stdlib command without main module", importPath: "cmd/gofmt", mainModulePath: "", want: false},
+		// Even if a standard library command ever records a main module, it must
+		// still be skipped: "go install cmd/gofmt@latest" is always rejected
+		// (issue #206).
+		{name: "stdlib command with main module", importPath: "cmd/gofmt", mainModulePath: "cmd/gofmt", want: false},
+		// GOPATH-mode/local build: no main module, so it cannot be managed
+		// (issue #299).
+		{name: "no main module", importPath: "github.com/x/y", mainModulePath: "", want: false},
+		// Dotless third-party hosts are still managed when a main module exists.
+		{name: "dotless host module", importPath: "localhost/tool", mainModulePath: "localhost/tool", want: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldManageBinary(tt.importPath, tt.mainModulePath); got != tt.want {
+				t.Errorf("shouldManageBinary(%q, %q) = %v, want %v", tt.importPath, tt.mainModulePath, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetPackageInformation_std_cmd_filtered(t *testing.T) {
 	// Find gofmt binary, which is a standard library command (Path: "cmd/gofmt",
 	// no main module). GetPackageInformation should filter it out because it

--- a/internal/goutil/pkginfo.go
+++ b/internal/goutil/pkginfo.go
@@ -86,6 +86,37 @@ func isModuleBinary(mainModulePath string) bool {
 	return mainModulePath != ""
 }
 
+// isStandardLibraryCommand reports whether an import path is a Go standard
+// library command such as "cmd/go" or "cmd/gofmt". These ship with the Go
+// toolchain and "go install <path>@latest" rejects them with "argument must not
+// be a package in the standard library", so gup must skip them.
+//
+// This matters when Go is installed via mise (and similar tools), which places
+// the toolchain commands in $GOBIN alongside user-installed binaries, so gup
+// finds them and would otherwise try to reinstall them (issue #206). All Go
+// commands live under the "cmd/" import-path prefix, and no third-party module
+// can claim that prefix (its import path always starts with a host element),
+// making this check unambiguous.
+func isStandardLibraryCommand(importPath string) bool {
+	return importPath == "cmd" || strings.HasPrefix(importPath, "cmd/")
+}
+
+// shouldManageBinary reports whether gup can manage a binary, given its import
+// path and main module path from build info. It skips Go standard library
+// commands (which cannot be reinstalled with "go install <path>@latest"; issue
+// #206) and binaries with no recorded main module, such as GOPATH-mode or local
+// "go build" binaries (issue #299).
+//
+// The standard library check is independent of the main module path so a
+// toolchain command is skipped even if its build info ever records a main module,
+// rather than relying solely on the empty-main-module heuristic.
+func shouldManageBinary(importPath, mainModulePath string) bool {
+	if isStandardLibraryCommand(importPath) {
+		return false
+	}
+	return isModuleBinary(mainModulePath)
+}
+
 // GetPackageInformation return golang package information including the latest
 // installed Go toolchain version. Use it for commands that compare Go versions
 // (check, update). Binary info is read in parallel using a worker pool.
@@ -138,7 +169,7 @@ func collectPackageInformation(p *print.Printer, binList []string, goVer string)
 				p.Warn(err)
 				return indexedPkg{}
 			}
-			if !isModuleBinary(info.Main.Path) {
+			if !shouldManageBinary(info.Path, info.Main.Path) {
 				return indexedPkg{}
 			}
 			pkg := Package{


### PR DESCRIPTION
## Background

A user running `gup update` against a `$GOBIN` populated by **mise** saw:

```
gup:ERROR: [ 1/15] gofmt can't install cmd/gofmt:
go: cmd/gofmt@latest: argument must not be a package in the standard library

gup:ERROR: [ 2/15] go can't install cmd/go:
go: cmd/go@latest: argument must not be a package in the standard library
```

This is issue #206: mise places the Go toolchain commands (`go`, `gofmt` →
import paths `cmd/go`, `cmd/gofmt`) in `$GOBIN` next to user-installed binaries.
gup discovers them and tries to reinstall them via `go install <path>@latest`,
which the Go command always rejects because they belong to the standard library.

The error in the report came from a very old gup (v0.27.9). Current `main`
already skips these binaries because they record no main module path
(`isModuleBinary`), and this is covered by `TestGetPackageInformation_std_cmd_filtered`.

## What this PR changes

This is a hardening on top of the existing fix. The standard library skip
currently relies *solely* on the empty-main-module heuristic. This PR detects
the `cmd/...` import path directly:

- `isStandardLibraryCommand(importPath)` — true for `cmd`, `cmd/go`, `cmd/gofmt`, …
- `shouldManageBinary(importPath, mainModulePath)` — unifies the two skip rules:
  standard library commands (issue #206) and binaries without a recorded main
  module such as GOPATH-mode/local `go build` binaries (issue #299).

As a result a toolchain command is skipped **even if its build info ever records
a main module**, instead of depending only on the empty-main-module heuristic.

The `cmd/` prefix is unambiguous: every Go command lives under it, and no
third-party module can claim that prefix (a real import path always starts with
a host element), so third-party `.../cmd/...` binaries (e.g.
`github.com/Songmu/ghch/cmd/ghch`) are unaffected.

## Tests

- `Test_isStandardLibraryCommand` — covers `cmd/go`, `cmd/gofmt`, bare `cmd`,
  third-party paths, and dotless hosts.
- `Test_shouldManageBinary` — including the new "stdlib command *with* a main
  module path is still skipped" case that the empty-main-module heuristic alone
  would not catch.
- Existing `Test_isModuleBinary` and `TestGetPackageInformation_std_cmd_filtered`
  continue to pass.

Refs #206

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of binaries built from Go toolchain commands so they are no longer treated as managed packages.
  * Refined binary management behavior for module-based builds, including better handling of non-standard import paths and builds without module metadata.
  * Added test coverage for standard-library command detection and managed-binary selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->