### PR TITLE
build(coverage): combine unit and self-hosted E2E coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,15 +7,25 @@ on:
   pull_request:
     branches: [main]
 
+# octocov needs to read/write the Actions-artifact datastore (report/diff in
+# .octocov.yml) and comment coverage on pull requests. The repo's default token
+# permissions are read-only, which makes those API calls 403, so grant the
+# needed scopes explicitly here.
+permissions:
+  contents: read
+  actions: write
+  pull-requests: write
+
 jobs:
-  unit_test:
-    name: Unit test (linux)
+  coverage:
+    name: Coverage (unit + e2e)
 
     strategy:
       matrix:
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -24,11 +34,21 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "1"
+          go-version-file: "go.mod"
           check-latest: true
 
-      - name: Run tests with coverage report output
-        run: go test -cover -coverpkg=./... -coverprofile=cover.out ./...
+      # The offline E2E suite drives the real CLI through atago; it builds a
+      # `go build -cover` gup and collects its covdata via GOCOVERDIR.
+      - name: Install atago
+        uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
+        with:
+          version: v0.1.0
+
+      # Combines unit-test coverage with self-hosted E2E coverage, then merges
+      # both into cover.out. The E2E suite is fully offline (it starts its own
+      # module proxy), so no extra dependencies are needed on the runner.
+      - name: Run combined unit + E2E coverage
+        run: make coverage
 
       - uses: k1LoW/octocov-action@b3b6ee60482a667950f87553abf1df63217235d9 # v1.5.1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ cover.*
 /completions
 
 cmd/testdata/gobin_tmp
+
+# `make coverage` scratch: raw covdata (unit + e2e) and the merged dir. The
+# final cover.out / cover.html are the only kept artifacts.
+.coverage/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test e2e clean vet fmt chkfmt changelog update-tools help coverage-tree
+.PHONY: build test e2e coverage clean vet fmt chkfmt changelog update-tools help coverage-tree
 
 APP         = gup
 VERSION     = $(shell git describe --tags --abbrev=0)
@@ -22,7 +22,7 @@ build:  ## Build binary
 	env GO111MODULE=on GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO_BUILD) $(GO_LDFLAGS) -o $(APP) main.go
 
 clean: ## Clean project
-	-rm -rf $(APP) cover.out cover.html
+	-rm -rf $(APP) cover.out cover.html .coverage
 
 
 test: ## Start test
@@ -31,6 +31,9 @@ test: ## Start test
 
 e2e: ## Run offline end-to-end tests against the real CLI (requires atago)
 	./e2e/run.sh
+
+coverage: ## Combine unit + self-hosted E2E coverage into cover.out / cover.html (uses a `go build -cover` gup; scratch under .coverage/)
+	bash ./scripts/coverage.sh
 
 vet: ## Start go vet
 	$(GO_VET) $(GO_PACKAGES)

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -39,8 +39,20 @@ trap cleanup EXIT
 
 mkdir -p "$TMP/bin"
 
+# COVER=1 builds a coverage-instrumented gup so `make coverage` can collect the
+# real CLI's runtime coverage. atago passes the environment (including
+# GOCOVERDIR, exported by the caller) through to every spec command, so each gup
+# child process writes its own covdata on exit. The default path (COVER unset)
+# stays byte-for-byte identical, keeping `make e2e` fast.
+GUP_COVER_FLAGS=""
+if [ -n "${COVER:-}" ]; then
+	GUP_COVER_FLAGS="-cover -covermode=atomic -coverpkg=./..."
+	echo "e2e: COVER=1 -> building coverage-instrumented gup"
+fi
+
 echo "e2e: building gup and the test proxy..."
-(cd "$REPO_ROOT" && go build -ldflags '-X github.com/nao1215/gup/internal/cmdinfo.Version=v0.0.0-e2e' -o "$TMP/bin/gup" .)
+# shellcheck disable=SC2086 # GUP_COVER_FLAGS must word-split into separate args.
+(cd "$REPO_ROOT" && go build $GUP_COVER_FLAGS -ldflags '-X github.com/nao1215/gup/internal/cmdinfo.Version=v0.0.0-e2e' -o "$TMP/bin/gup" .)
 (cd "$REPO_ROOT" && go build -o "$TMP/bin/testproxy" ./e2e/testproxy)
 
 echo "e2e: starting offline module proxy..."

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# coverage.sh combines unit-test coverage with self-hosted E2E coverage into a
+# single cover.out. Unit tests report line coverage, but they never exercise the
+# real gup binary the way an end user does; the atago-driven E2E specs do. Go
+# 1.20+ lets us instrument a built binary (`go build -cover`) and collect its
+# runtime coverage via GOCOVERDIR, so we can merge "what the unit tests cover"
+# with "what a real CLI run covers" and get one honest number.
+#
+# This is intentionally a separate, heavier target: `make test` / `make e2e`
+# stay fast. Everything lands under .coverage/ (gitignored) except the final
+# cover.out / cover.html, which are the same artifacts `make test` already
+# produces so octocov and local tooling need no changes.
+set -euo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+COV="$REPO_ROOT/.coverage"
+rm -rf "$COV"
+mkdir -p "$COV/unit" "$COV/e2e" "$COV/merged"
+
+# 1. Unit-test coverage as raw covdata (GOCOVERDIR form) so it can be merged
+#    with the E2E covdata below. -covermode=atomic must match the binary build.
+echo ">> unit coverage -> $COV/unit"
+go test -count=1 -cover -covermode=atomic -coverpkg=./... ./... \
+	-args -test.gocoverdir="$COV/unit"
+
+# 2. Self-hosted E2E via the existing runner, but with COVER=1 (which builds a
+#    `go build -cover` gup) and GOCOVERDIR exported. atago passes GOCOVERDIR
+#    through to every spec command, so each gup child writes its own covdata.
+echo ">> e2e coverage -> $COV/e2e"
+COVER=1 GOCOVERDIR="$COV/e2e" "$REPO_ROOT/e2e/run.sh"
+
+# 3. Merge the raw covdata and render the combined text profile + reports.
+echo ">> merging unit + e2e covdata -> cover.out"
+go tool covdata merge -i="$COV/unit,$COV/e2e" -o="$COV/merged"
+go tool covdata textfmt -i="$COV/merged" -o="$REPO_ROOT/cover.out"
+
+go tool cover -func=cover.out | tail -n 1
+go tool cover -html=cover.out -o cover.html
+echo ">> wrote cover.out and cover.html (unit + e2e combined)"


### PR DESCRIPTION
## What

The coverage percentage reported by octocov (and shown in the README badge) came from **unit tests only**. Those never exercise the real `gup` binary the way an end user does — the atago-driven offline E2E suite does. This wires the coverage job to report **unit + E2E combined**.

## How

- **`scripts/coverage.sh`** (new): runs unit tests as raw covdata (`-test.gocoverdir`), runs the existing `e2e/run.sh` with `COVER=1` and an exported `GOCOVERDIR`, then `go tool covdata merge` + `textfmt` both into `cover.out` (+ `cover.html`) — the same artifacts `make test` already produces, so octocov needs no path change.
- **`e2e/run.sh`**: opt-in `COVER=1` switch builds a `go build -cover -covermode=atomic -coverpkg=./...` gup. atago passes `GOCOVERDIR` through to every spec command, so each gup child writes its own covdata on exit. The default path (COVER unset) is byte-for-byte unchanged, keeping `make e2e` fast.
- **`Makefile`**: new `coverage` target; `clean` and `.gitignore` extended with the gitignored `.coverage/` scratch tree.
- **`.github/workflows/coverage.yml`**: installs atago (pinned `nao1215/setup-atago`, same ref as the E2E workflow) and runs `make coverage`, feeding the combined `cover.out` to octocov with unchanged args. The E2E suite is fully offline (its own module proxy), so no extra runner dependencies. The separate multi-platform unit-test and E2E workflows are untouched.

## Result

- Unit-only: **86.3%**
- Combined (unit + E2E): **90.3%**

## Verified locally

- `make test` — passes (unchanged).
- `make e2e` — passes, 43 scenarios, default path unchanged.
- `make coverage` — passes, writes `cover.out` + `cover.html`, 43 E2E scenarios pass, **zero** `GOCOVERDIR not set` warnings, combined total (90.3%) > unit-only (86.3%).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added combined coverage generation for unit and end-to-end tests.
  * Coverage reports now include both a text summary and HTML output.
* **Bug Fixes**
  * Updated the CI coverage workflow to use the required permissions for posting coverage results.
  * Improved coverage artifact handling by keeping generated files organized and excluding scratch output from version control.
* **Chores**
  * Added a dedicated coverage command and updated cleanup behavior for generated coverage files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->