### PR TITLE
test(coverage): broaden atago E2E and unit tests, raise acceptable to 90%

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -2,12 +2,13 @@
 coverage:
   paths:
     - cover.out
-  acceptable: 80%
+  acceptable: 90%
+  # Every shipped source file is now measured: the atago-driven E2E suite drives
+  # the real CLI (including 'gup man', 'gup bug-report', unknown-command and the
+  # root command wiring), so main.go/root.go/man.go/bug_report.go no longer need
+  # to be excluded. Only the offline module proxy under e2e/testproxy remains
+  # excluded: it is E2E test infrastructure, not part of the gup binary.
   exclude:
-    - "github.com/nao1215/gup/main.go"
-    - "github.com/nao1215/gup/cmd/root.go"
-    - "github.com/nao1215/gup/cmd/man.go"
-    - "github.com/nao1215/gup/cmd/bug_report.go"
     - "github.com/nao1215/gup/e2e/testproxy/main.go"
   badge:
     path: doc/coverage.svg

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -436,3 +436,19 @@ func Test_doCheck_customGoBuildTag_goVersionDiffColor(t *testing.T) {
 		t.Fatalf("expected latest go version in green, got:\n%s", buf.String())
 	}
 }
+
+// TestDoCheckWith_notInstalledByGoInstall covers the branch that flags a binary
+// with no resolvable module path as "not installed by 'go install'".
+func TestDoCheckWith_notInstalledByGoInstall(t *testing.T) {
+	t.Parallel()
+	pkgs := []goutil.Package{{
+		Name:       "legacy",
+		ModulePath: "", // no module path -> can not be checked against a proxy
+		Version:    &goutil.Version{Current: "v0.0.1"},
+	}}
+	// jsonOut=true keeps output machine-readable and avoids color/tty concerns.
+	code := doCheckWith(testDeps(), discardPrinter(), pkgs, 1, 0, false, false, true)
+	if code == 0 {
+		t.Fatal("doCheckWith() exit = 0, want non-zero for an uncheckable binary")
+	}
+}

--- a/cmd/config_file_test.go
+++ b/cmd/config_file_test.go
@@ -26,7 +26,7 @@ func TestRenameWithBackupSwap_Success(t *testing.T) {
 	if err := os.WriteFile(src, []byte("new"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(dst, []byte("old"), 0o600); err != nil {
+	if err := os.WriteFile(dst, []byte(testNameOld), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -54,7 +54,7 @@ func TestRenameWithBackupSwap_RestoreOnFailure(t *testing.T) {
 	src := filepath.Join(dir, "missing.tmp")
 	dst := filepath.Join(dir, "gup.json")
 
-	if err := os.WriteFile(dst, []byte("old"), 0o600); err != nil {
+	if err := os.WriteFile(dst, []byte(testNameOld), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -75,7 +75,7 @@ func Test_shouldRetryRenameWithReplace(t *testing.T) {
 	t.Parallel()
 
 	dst := filepath.Join(t.TempDir(), "gup.json")
-	if err := os.WriteFile(dst, []byte("old"), 0o600); err != nil {
+	if err := os.WriteFile(dst, []byte(testNameOld), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -101,7 +101,7 @@ func Test_renameWithReplace_errorWhenSrcMissing(t *testing.T) {
 	dir := t.TempDir()
 	src := filepath.Join(dir, "missing.tmp")
 	dst := filepath.Join(dir, "gup.json")
-	if err := os.WriteFile(dst, []byte("old"), 0o600); err != nil {
+	if err := os.WriteFile(dst, []byte(testNameOld), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -188,7 +188,7 @@ func Test_renameWithBackupSwap_restoreFailure(t *testing.T) {
 	if err := os.WriteFile(src, []byte("new"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(dst, []byte("old"), 0o600); err != nil {
+	if err := os.WriteFile(dst, []byte(testNameOld), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -430,5 +430,63 @@ func assertNoTempFiles(t *testing.T, dir, base string) {
 		if strings.HasPrefix(name, base+".tmp-") || strings.HasPrefix(name, base+".bak-") {
 			t.Fatalf("stray temp/backup file left behind: %s", name)
 		}
+	}
+}
+
+// TestWriteConfigFile_createTempFailure covers the temp-file creation error
+// branch when the destination directory is not writable.
+//
+//nolint:paralleltest // relies on process-wide filesystem state
+func TestWriteConfigFile_createTempFailure(t *testing.T) {
+	skipIfRoot(t)
+	dir := t.TempDir()
+	roDir := filepath.Join(dir, "readonly")
+	if err := os.Mkdir(roDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(roDir, 0o700) }) //nolint:gosec // restore dir perms so t.TempDir cleanup can remove it
+
+	err := writeConfigFile(filepath.Join(roDir, "gup.json"), []goutil.Package{{Name: "x"}})
+	if err == nil {
+		t.Fatal("writeConfigFile() err = nil, want error creating temp file in a read-only dir")
+	}
+}
+
+// TestWriteConfigFile_backupSwapPath drives the rename-backup-swap fallback used
+// when os.Rename can not overwrite the destination (the Windows path), by making
+// the first rename report os.ErrExist so shouldRetryRenameWithReplace triggers
+// the backup swap; the swap itself uses the real rename.
+//
+//nolint:paralleltest // mutates package-level renameFunc
+func TestWriteConfigFile_backupSwapPath(t *testing.T) {
+	origRename := renameFunc
+	t.Cleanup(func() { renameFunc = origRename })
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gup.json")
+	if err := os.WriteFile(path, []byte(testNameOld), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := 0
+	renameFunc = func(oldpath, newpath string) error {
+		calls++
+		if calls == 1 {
+			// First tmp->dst rename: pretend the destination can not be
+			// overwritten, so renameWithReplace falls back to the backup swap.
+			return os.ErrExist
+		}
+		return origRename(oldpath, newpath)
+	}
+
+	if err := writeConfigFile(path, []goutil.Package{{Name: "x", ImportPath: "example.com/x", Version: &goutil.Version{Current: testVersionOne}}}); err != nil {
+		t.Fatalf("writeConfigFile() err = %v", err)
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // test-controlled path
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "example.com/x") {
+		t.Fatalf("config not written through backup swap: %s", data)
 	}
 }

--- a/cmd/config_file_test.go
+++ b/cmd/config_file_test.go
@@ -438,7 +438,7 @@ func assertNoTempFiles(t *testing.T, dir, base string) {
 //
 //nolint:paralleltest // relies on process-wide filesystem state
 func TestWriteConfigFile_createTempFailure(t *testing.T) {
-	skipIfRoot(t)
+	skipIfDirWriteFaultUnsupported(t)
 	dir := t.TempDir()
 	roDir := filepath.Join(dir, "readonly")
 	if err := os.Mkdir(roDir, 0o500); err != nil {

--- a/cmd/dependencies_test.go
+++ b/cmd/dependencies_test.go
@@ -3,7 +3,10 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
+	"os"
+	"testing"
 
 	"github.com/nao1215/gup/internal/print"
 )
@@ -13,6 +16,23 @@ import (
 func discardPrinter() *print.Printer {
 	return print.New(io.Discard, io.Discard)
 }
+
+// skipIfRoot skips a test that relies on filesystem permission enforcement,
+// because root bypasses the read-only bit and the I/O failure never happens.
+// gup's CI runs as the non-root runner user, so these branches are still
+// exercised there.
+func skipIfRoot(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() == 0 {
+		t.Skip("skipping: read-only permissions are bypassed when running as root")
+	}
+}
+
+// errReader is an io.Reader that always fails, used to drive the io.Copy error
+// branch in the gzip/atomic-write helpers.
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("forced read failure") }
 
 // newTestPrinter returns a Printer whose normal and error output both go to a
 // single buffer, plus the buffer for assertions. It replaces the old pattern of

--- a/cmd/dependencies_test.go
+++ b/cmd/dependencies_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/nao1215/gup/internal/print"
@@ -17,14 +18,19 @@ func discardPrinter() *print.Printer {
 	return print.New(io.Discard, io.Discard)
 }
 
-// skipIfRoot skips a test that relies on filesystem permission enforcement,
-// because root bypasses the read-only bit and the I/O failure never happens.
-// gup's CI runs as the non-root runner user, so these branches are still
-// exercised there.
-func skipIfRoot(t *testing.T) {
+// skipIfDirWriteFaultUnsupported skips a test that forces an I/O failure by
+// making a directory read-only (chmod 0500). That trick only works where Unix
+// directory permissions gate writes: root bypasses the read-only bit, and
+// Windows ignores these bits for directory writability. gup's coverage CI runs
+// as the non-root Linux runner user, so these branches are still exercised
+// there.
+func skipIfDirWriteFaultUnsupported(t *testing.T) {
 	t.Helper()
 	if os.Geteuid() == 0 {
 		t.Skip("skipping: read-only permissions are bypassed when running as root")
+	}
+	if runtime.GOOS == goosWindows {
+		t.Skip("skipping: Windows does not enforce read-only dir permissions for writes")
 	}
 }
 

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -234,3 +234,31 @@ func TestGetTimeoutFlag(t *testing.T) {
 		}
 	})
 }
+
+// TestMustRegisterFlagCompletion_panicsOnUnknownFlag covers the panic guard that
+// fires when a completion function is attached to a flag that does not exist -
+// a build-time programmer error, surfaced as a panic rather than a silent noop.
+func TestMustRegisterFlagCompletion_panicsOnUnknownFlag(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("mustRegisterFlagCompletion() did not panic for an unknown flag")
+		}
+	}()
+	mustRegisterFlagCompletion(&cobra.Command{}, "no-such-flag",
+		func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		})
+}
+
+// TestMustMarkFileFlagAsJSON_panicsOnMissingFileFlag covers the panic guard that
+// fires when the shared --file flag has not been registered.
+func TestMustMarkFileFlagAsJSON_panicsOnMissingFileFlag(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("mustMarkFileFlagAsJSON() did not panic when --file is absent")
+		}
+	}()
+	mustMarkFileFlagAsJSON(&cobra.Command{})
+}

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -413,7 +413,7 @@ func Test_runImport_ambiguousConfig(t *testing.T) {
 	if !strings.Contains(out, "multiple gup.json") {
 		t.Errorf("expected ambiguity error, got: %s", out)
 	}
-	if !strings.Contains(out, "--file") {
+	if !strings.Contains(out, testFlagFile) {
 		t.Errorf("expected error to mention --file, got: %s", out)
 	}
 }
@@ -526,5 +526,15 @@ func Test_runImport_timeoutZeroDisablesDeadline(t *testing.T) {
 
 	if sawDeadline {
 		t.Error("install operation should not receive a deadline when --timeout is 0")
+	}
+}
+
+// TestInstallFromConfig_missingVersion covers the installer branch that fails a
+// package whose gup.json entry has no usable version.
+func TestInstallFromConfig_missingVersion(t *testing.T) {
+	t.Parallel()
+	pkgs := []goutil.Package{{Name: "tool", ImportPath: testImportExampleTool, Version: nil}}
+	if code := installFromConfig(discardPrinter(), pkgs, false, false, 1, 0); code == 0 {
+		t.Fatal("installFromConfig() exit = 0, want non-zero for a version-less package")
 	}
 }

--- a/cmd/man_test.go
+++ b/cmd/man_test.go
@@ -275,7 +275,7 @@ func TestWriteManpageAtomically_copyFailure(t *testing.T) {
 //
 //nolint:paralleltest // relies on process-wide filesystem state
 func TestWriteManpageAtomically_createTempFailure(t *testing.T) {
-	skipIfRoot(t)
+	skipIfDirWriteFaultUnsupported(t)
 	dir := t.TempDir()
 	roDir := filepath.Join(dir, "readonly")
 	if err := os.Mkdir(roDir, 0o500); err != nil {

--- a/cmd/man_test.go
+++ b/cmd/man_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -252,4 +253,37 @@ func TestMan(t *testing.T) {
 			t.Fatalf("man() = %d, want 1", got)
 		}
 	})
+}
+
+// TestWriteManpageAtomically_copyFailure covers the io.Copy error branch: a
+// source reader that fails mid-copy must surface an error and leave no man page.
+//
+//nolint:paralleltest // relies on process-wide filesystem state
+func TestWriteManpageAtomically_copyFailure(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "gup.1.gz")
+	if err := writeManpageAtomically(out, errReader{}, "gup"); err == nil {
+		t.Fatal("writeManpageAtomically() err = nil, want copy failure")
+	}
+	if _, err := os.Stat(out); !os.IsNotExist(err) {
+		t.Fatalf("man page should not exist after failed copy, stat err = %v", err)
+	}
+}
+
+// TestWriteManpageAtomically_createTempFailure covers the temp-file creation
+// error branch when the destination directory is not writable.
+//
+//nolint:paralleltest // relies on process-wide filesystem state
+func TestWriteManpageAtomically_createTempFailure(t *testing.T) {
+	skipIfRoot(t)
+	dir := t.TempDir()
+	roDir := filepath.Join(dir, "readonly")
+	if err := os.Mkdir(roDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(roDir, 0o700) }) //nolint:gosec // restore dir perms so t.TempDir cleanup can remove it
+
+	if err := writeManpageAtomically(filepath.Join(roDir, "gup.1.gz"), strings.NewReader("body"), "gup"); err == nil {
+		t.Fatal("writeManpageAtomically() err = nil, want temp-create failure")
+	}
 }

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -55,6 +55,7 @@ const (
 	testFlagDryRun        = "--dry-run"
 	testFlagNotify        = "--notify"
 	testFlagJobs          = "--jobs"
+	testFlagFile          = "--file"
 	testCmdGup            = "gup"
 	testCmdList           = "list"
 	testCmdExport         = "export"
@@ -74,6 +75,9 @@ const (
 	testVersion123        = "v1.2.3"
 	testVersionTwo        = "v2.0.0"
 	testBinTool           = "tool"
+	testNameOld           = "old"
+	testImportExampleOld  = "example.com/old"
+	testVersionZeroNine   = "v0.9.0"
 	testBinPosixerExe     = "posixer.exe"
 	testBinToolA          = "tool-a"
 	testCmdVersion        = "version"
@@ -685,5 +689,104 @@ func Test_binaryExistsInDir(t *testing.T) {
 	}
 	if binaryExistsInDir(dir, "") {
 		t.Fatal("empty name should not be detected")
+	}
+}
+
+// TestWithGoBin_restoresUnsetState covers withGoBin's branch that unsets GOBIN
+// again when it was not present before.
+//
+//nolint:paralleltest // mutates the GOBIN environment variable
+func TestWithGoBin_restoresUnsetState(t *testing.T) {
+	_ = os.Unsetenv("GOBIN")
+	t.Cleanup(func() { _ = os.Unsetenv("GOBIN") })
+	dir := t.TempDir()
+	restore, err := withGoBin(dir)
+	if err != nil {
+		t.Fatalf("withGoBin() err = %v", err)
+	}
+	if got := os.Getenv("GOBIN"); got != dir {
+		t.Fatalf("GOBIN = %q, want %q", got, dir)
+	}
+	restore()
+	if _, ok := os.LookupEnv("GOBIN"); ok {
+		t.Fatal("GOBIN should be unset again after restore")
+	}
+}
+
+// TestMigratePackages_modulePathRetryFailure covers the branch that retries the
+// install at a renamed module path and still surfaces an error when the retry
+// itself fails.
+//
+//nolint:paralleltest // mutates package-level installByVersionMigrateCtx and GOBIN
+func TestMigratePackages_modulePathRetryFailure(t *testing.T) {
+	t.Setenv("GOBIN", t.TempDir())
+	orig := installByVersionMigrateCtx
+	t.Cleanup(func() { installByVersionMigrateCtx = orig })
+
+	calls := 0
+	installByVersionMigrateCtx = func(context.Context, string, string) error {
+		calls++
+		if calls == 1 {
+			// A module-path-mismatch error triggers the rename+retry path.
+			return errors.New("module declares its path as: example.com/new\n\tbut was required as: example.com/old")
+		}
+		return errors.New("retry still broken")
+	}
+
+	pkgs := []goutil.Package{{Name: testNameOld, ImportPath: testImportExampleOld, Version: &goutil.Version{Current: testVersionOne}}}
+	code := migratePackages(discardPrinter(), pkgs, t.TempDir(), false, false, 1, true, 0)
+	if code == 0 {
+		t.Fatal("migratePackages() exit = 0, want non-zero after retry failure")
+	}
+	if calls != 2 {
+		t.Fatalf("install attempts = %d, want 2 (initial + retry)", calls)
+	}
+}
+
+// TestValidateMigratePaths_mkdirAfterPathFailure covers the branch that reports
+// a failure to create AFTER_PATH when its parent is a regular file.
+//
+//nolint:paralleltest // filesystem-only
+func TestValidateMigratePaths_mkdirAfterPathFailure(t *testing.T) {
+	before := t.TempDir()
+	fileParent := filepath.Join(t.TempDir(), "afile")
+	if err := os.WriteFile(fileParent, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	after := filepath.Join(fileParent, "sub") // parent is a file, MkdirAll must fail
+	if err := validateMigratePaths(before, after, false); err == nil {
+		t.Fatal("validateMigratePaths() err = nil, want create failure")
+	}
+}
+
+// TestValidateMigratePaths_dryRunUncreatableAfterPath covers the dry-run branch
+// that reports AFTER_PATH can not be created because an ancestor is not a
+// directory, without touching the filesystem.
+//
+//nolint:paralleltest // filesystem-only
+func TestValidateMigratePaths_dryRunUncreatableAfterPath(t *testing.T) {
+	before := t.TempDir()
+	fileParent := filepath.Join(t.TempDir(), "afile")
+	if err := os.WriteFile(fileParent, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	after := filepath.Join(fileParent, "sub")
+	if err := validateMigratePaths(before, after, true); err == nil {
+		t.Fatal("validateMigratePaths() dry-run err = nil, want uncreatable AFTER_PATH")
+	}
+}
+
+// TestValidateMigratePaths_symlinkedSameDir covers the branch that rejects an
+// AFTER_PATH which is a symlink resolving to BEFORE_PATH.
+//
+//nolint:paralleltest // filesystem-only
+func TestValidateMigratePaths_symlinkedSameDir(t *testing.T) {
+	before := t.TempDir()
+	after := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(before, after); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if err := validateMigratePaths(before, after, false); err == nil {
+		t.Fatal("validateMigratePaths() err = nil, want same-directory rejection")
 	}
 }

--- a/cmd/parseflags_test.go
+++ b/cmd/parseflags_test.go
@@ -9,6 +9,24 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Bare flag-name constants shared by the per-flag error tests below (the
+// command flags are registered by long name only). "file", "timeout" and
+// "latest" reuse the production constants fileFlagName/timeoutFlagName/
+// latestKeyword.
+const (
+	fnDryRun         = "dry-run"
+	fnNotify         = "notify"
+	fnJobs           = "jobs"
+	fnIgnoreGoUpdate = "ignore-go-update"
+	fnJSON           = "json"
+	fnQuiet          = "quiet"
+	fnExclude        = "exclude"
+	fnMain           = "main"
+	fnMaster         = "master"
+	fnForce          = "force"
+	fnOutput         = "output"
+)
+
 func TestParseUpdateFlags_defaults(t *testing.T) {
 	t.Parallel()
 	cmd := newUpdateCmd()
@@ -55,7 +73,7 @@ func TestParseUpdateFlags_values(t *testing.T) {
 		"--main", "m1",
 		"--master", "m2",
 		"--latest", "l1",
-		"--file", "/tmp/gup.json",
+		testFlagFile, "/tmp/gup.json",
 	}
 	if err := cmd.ParseFlags(args); err != nil {
 		t.Fatalf("ParseFlags() error = %v", err)
@@ -146,7 +164,7 @@ func TestParseCheckFlags_values(t *testing.T) {
 		"--json",
 		"--quiet",
 		"--timeout", "90s",
-		"--file", "x.json",
+		testFlagFile, "x.json",
 	}
 	if err := cmd.ParseFlags(args); err != nil {
 		t.Fatalf("ParseFlags() error = %v", err)
@@ -190,5 +208,254 @@ func TestParseCheckFlags_error(t *testing.T) {
 	t.Parallel()
 	if _, err := parseCheckFlags(&cobra.Command{}); err == nil {
 		t.Error("parseCheckFlags() error = nil, want error for command without flags")
+	}
+}
+
+// registerUpToUpdate registers the update command's flags, in the exact order
+// parseUpdateFlags reads them, stopping just before stopAt. The resulting
+// command therefore has every flag parseUpdateFlags consults before stopAt but
+// is missing stopAt itself, so the corresponding getFlag* call fails and the
+// matching error branch runs.
+func registerUpToUpdate(stopAt string) *cobra.Command {
+	cmd := &cobra.Command{}
+	f := cmd.Flags()
+	order := []struct {
+		name string
+		reg  func()
+	}{
+		{fnDryRun, func() { f.BoolP(fnDryRun, "n", false, "") }},
+		{fnNotify, func() { f.BoolP(fnNotify, "N", false, "") }},
+		{fnJobs, func() { f.IntP(fnJobs, "j", 1, "") }},
+		{fnIgnoreGoUpdate, func() { f.Bool(fnIgnoreGoUpdate, false, "") }},
+		{fnJSON, func() { f.Bool(fnJSON, false, "") }},
+		{fnQuiet, func() { f.BoolP(fnQuiet, "q", false, "") }},
+		{timeoutFlagName, func() { f.Duration(timeoutFlagName, 0, "") }},
+		{fnExclude, func() { f.StringSliceP(fnExclude, "e", nil, "") }},
+		{fnMain, func() { f.StringSliceP(fnMain, "m", nil, "") }},
+		{fnMaster, func() { f.StringSlice(fnMaster, nil, "") }},
+		{latestKeyword, func() { f.StringSlice(latestKeyword, nil, "") }},
+		{fileFlagName, func() { f.StringP(fileFlagName, "f", "", "") }},
+	}
+	for _, o := range order {
+		if o.name == stopAt {
+			break
+		}
+		o.reg()
+	}
+	return cmd
+}
+
+// TestParseUpdateFlags_perFlagError drives each getFlag error branch in
+// parseUpdateFlags by handing it a command missing exactly one flag.
+func TestParseUpdateFlags_perFlagError(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{
+		fnDryRun, fnNotify, fnJobs, fnIgnoreGoUpdate, fnJSON, fnQuiet,
+		timeoutFlagName, fnExclude, fnMain, fnMaster, latestKeyword, fileFlagName,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			cmd := registerUpToUpdate(name)
+			if _, err := parseUpdateFlags(cmd); err == nil {
+				t.Errorf("parseUpdateFlags() missing %q: error = nil, want error", name)
+			}
+		})
+	}
+}
+
+func registerUpToCheck(stopAt string) *cobra.Command {
+	cmd := &cobra.Command{}
+	f := cmd.Flags()
+	order := []struct {
+		name string
+		reg  func()
+	}{
+		{fnJobs, func() { f.IntP(fnJobs, "j", 1, "") }},
+		{fnIgnoreGoUpdate, func() { f.Bool(fnIgnoreGoUpdate, false, "") }},
+		{fnJSON, func() { f.Bool(fnJSON, false, "") }},
+		{fnQuiet, func() { f.BoolP(fnQuiet, "q", false, "") }},
+		{timeoutFlagName, func() { f.Duration(timeoutFlagName, 0, "") }},
+		{fileFlagName, func() { f.StringP(fileFlagName, "f", "", "") }},
+	}
+	for _, o := range order {
+		if o.name == stopAt {
+			break
+		}
+		o.reg()
+	}
+	return cmd
+}
+
+// TestParseCheckFlags_perFlagError drives each getFlag error branch in
+// parseCheckFlags.
+func TestParseCheckFlags_perFlagError(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{fnJobs, fnIgnoreGoUpdate, fnJSON, fnQuiet, timeoutFlagName, fileFlagName} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			cmd := registerUpToCheck(name)
+			if _, err := parseCheckFlags(cmd); err == nil {
+				t.Errorf("parseCheckFlags() missing %q: error = nil, want error", name)
+			}
+		})
+	}
+}
+
+// registerUpToMigrate registers the flags runMigrate reads, in order, stopping
+// before stopAt.
+func registerUpToMigrate(stopAt string) *cobra.Command {
+	cmd := &cobra.Command{}
+	f := cmd.Flags()
+	order := []struct {
+		name string
+		reg  func()
+	}{
+		{fnDryRun, func() { f.BoolP(fnDryRun, "n", false, "") }},
+		{fnNotify, func() { f.BoolP(fnNotify, "N", false, "") }},
+		{fnJobs, func() { f.IntP(fnJobs, "j", 1, "") }},
+		{fnForce, func() { f.Bool(fnForce, false, "") }},
+		{timeoutFlagName, func() { f.Duration(timeoutFlagName, 0, "") }},
+	}
+	for _, o := range order {
+		if o.name == stopAt {
+			break
+		}
+		o.reg()
+	}
+	return cmd
+}
+
+// TestRunMigrate_perFlagError drives each getFlag error branch in runMigrate.
+// ensureGoCommandAvailable runs first and succeeds because the go toolchain is
+// on PATH under `go test`; the flag reads then fail one at a time.
+func TestRunMigrate_perFlagError(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{fnDryRun, fnNotify, fnJobs, fnForce, timeoutFlagName} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			cmd := registerUpToMigrate(name)
+			p, buf := newTestPrinter()
+			if got := runMigrate(p, cmd, []string{"before", "after"}); got != 1 {
+				t.Errorf("runMigrate() missing %q: exit = %d, want 1", name, got)
+			}
+			if buf.Len() == 0 {
+				t.Errorf("runMigrate() missing %q: expected an error message", name)
+			}
+		})
+	}
+}
+
+// registerUpToImport registers the flags runImport reads, in order, stopping
+// before stopAt.
+func registerUpToImport(stopAt string) *cobra.Command {
+	cmd := &cobra.Command{}
+	f := cmd.Flags()
+	order := []struct {
+		name string
+		reg  func()
+	}{
+		{fnDryRun, func() { f.BoolP(fnDryRun, "n", false, "") }},
+		{fileFlagName, func() { f.StringP(fileFlagName, "f", "", "") }},
+		{fnNotify, func() { f.BoolP(fnNotify, "N", false, "") }},
+		{fnJobs, func() { f.IntP(fnJobs, "j", 1, "") }},
+		{timeoutFlagName, func() { f.Duration(timeoutFlagName, 0, "") }},
+	}
+	for _, o := range order {
+		if o.name == stopAt {
+			break
+		}
+		o.reg()
+	}
+	return cmd
+}
+
+// TestRunImport_perFlagError drives the getFlag error branches in runImport.
+func TestRunImport_perFlagError(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{fnDryRun, fileFlagName, fnNotify, fnJobs, timeoutFlagName} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			cmd := registerUpToImport(name)
+			p, buf := newTestPrinter()
+			if got := runImport(p, cmd, nil); got != 1 {
+				t.Errorf("runImport() missing %q: exit = %d, want 1", name, got)
+			}
+			if buf.Len() == 0 {
+				t.Errorf("runImport() missing %q: expected an error message", name)
+			}
+		})
+	}
+}
+
+// TestList_perFlagError drives the getFlag error branches in list. list first
+// reads local build info (which succeeds), then the json and file flags.
+func TestList_perFlagError(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{fnJSON, fileFlagName} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			cmd := &cobra.Command{}
+			f := cmd.Flags()
+			if name != fnJSON {
+				f.Bool(fnJSON, false, "")
+			}
+			p, buf := newTestPrinter()
+			if got := list(p, cmd, nil); got != 1 {
+				t.Errorf("list() missing %q: exit = %d, want 1", name, got)
+			}
+			if buf.Len() == 0 {
+				t.Errorf("list() missing %q: expected an error message", name)
+			}
+		})
+	}
+}
+
+// TestExport_perFlagError drives the getFlag error branches in export.
+func TestExport_perFlagError(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{fnOutput, fileFlagName} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			cmd := &cobra.Command{}
+			f := cmd.Flags()
+			if name != fnOutput {
+				f.BoolP(fnOutput, "o", false, "")
+			}
+			p, buf := newTestPrinter()
+			if got := export(p, cmd, nil); got != 1 {
+				t.Errorf("export() missing %q: exit = %d, want 1", name, got)
+			}
+			if buf.Len() == 0 {
+				t.Errorf("export() missing %q: expected an error message", name)
+			}
+		})
+	}
+}
+
+// TestRunPin_fileFlagError drives the getFlagString(fileFlagName) error branch in
+// runPin. parsePinArgs succeeds on valid args, then the missing file flag fails.
+func TestRunPin_fileFlagError(t *testing.T) {
+	t.Parallel()
+	cmd := &cobra.Command{} // no --file flag registered
+	p, buf := newTestPrinter()
+	if got := runPin(p, cmd, []string{testBinTool, testVersionOne}); got != 1 {
+		t.Errorf("runPin() exit = %d, want 1", got)
+	}
+	if buf.Len() == 0 {
+		t.Error("runPin() expected an error message")
+	}
+}
+
+// TestRunUnpin_fileFlagError drives the getFlagString(fileFlagName) error branch in
+// runUnpin.
+func TestRunUnpin_fileFlagError(t *testing.T) {
+	t.Parallel()
+	cmd := &cobra.Command{} // no --file flag registered
+	p, buf := newTestPrinter()
+	if got := runUnpin(p, cmd, []string{testBinTool}); got != 1 {
+		t.Errorf("runUnpin() exit = %d, want 1", got)
+	}
+	if buf.Len() == 0 {
+		t.Error("runUnpin() expected an error message")
 	}
 }

--- a/cmd/pin_run_test.go
+++ b/cmd/pin_run_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -37,7 +39,7 @@ func writeUserConfig(t *testing.T, content string) {
 func TestRunPin_writesPinnedConfig(t *testing.T) {
 	setupXDGBase(t)
 	stubPinPackageInfo(t, []goutil.Package{
-		{Name: testBinTool, ImportPath: pinnedTestImport, Version: &goutil.Version{Current: "v0.9.0"}},
+		{Name: testBinTool, ImportPath: pinnedTestImport, Version: &goutil.Version{Current: testVersionZeroNine}},
 	})
 
 	p, _ := newTestPrinter()
@@ -65,7 +67,7 @@ func TestRunPin_succeedsWithoutGoCommand(t *testing.T) {
 	setupXDGBase(t)
 	t.Setenv("PATH", "")
 	stubPinPackageInfo(t, []goutil.Package{
-		{Name: testBinTool, ImportPath: pinnedTestImport, Version: &goutil.Version{Current: "v0.9.0"}},
+		{Name: testBinTool, ImportPath: pinnedTestImport, Version: &goutil.Version{Current: testVersionZeroNine}},
 	})
 
 	p, buf := newTestPrinter()
@@ -182,5 +184,90 @@ func TestRunPin_malformedConfigFails(t *testing.T) {
 	p, _ := newTestPrinter()
 	if code := runPin(p, newPinCmd(), []string{testBinTool, testVersionOne}); code != 1 {
 		t.Fatalf("runPin() with a malformed config = %d, want 1", code)
+	}
+}
+
+// TestRunPin_packageInfoError covers the branch that surfaces a failure to read
+// the installed binaries when resolving the pin target.
+//
+//nolint:paralleltest // mutates package-level pinPackageInfo
+func TestRunPin_packageInfoError(t *testing.T) {
+	orig := pinPackageInfo
+	t.Cleanup(func() { pinPackageInfo = orig })
+	pinPackageInfo = func(*print.Printer) ([]goutil.Package, error) {
+		return nil, errors.New("cannot list binaries")
+	}
+	cmd := newPinCmd()
+	if err := cmd.ParseFlags(nil); err != nil {
+		t.Fatal(err)
+	}
+	p, buf := newTestPrinter()
+	if got := runPin(p, cmd, []string{testBinTool, testVersionOne}); got != 1 {
+		t.Fatalf("runPin() exit = %d, want 1", got)
+	}
+	if buf.Len() == 0 {
+		t.Error("runPin() expected an error message")
+	}
+}
+
+// TestRunPin_writeConfigFailure covers the branch that reports a failure to
+// persist the pin to gup.json.
+//
+//nolint:paralleltest // mutates package-level pinPackageInfo and writeConfFile
+func TestRunPin_writeConfigFailure(t *testing.T) {
+	origInfo := pinPackageInfo
+	origWrite := writeConfFile
+	t.Cleanup(func() { pinPackageInfo = origInfo; writeConfFile = origWrite })
+
+	pinPackageInfo = func(*print.Printer) ([]goutil.Package, error) {
+		return []goutil.Package{{Name: testBinTool, ImportPath: testImportExampleTool, Version: &goutil.Version{Current: testVersionOne}}}, nil
+	}
+	writeConfFile = func(io.Writer, []goutil.Package) error {
+		return errors.New("disk full")
+	}
+
+	cmd := newPinCmd()
+	dir := t.TempDir()
+	if err := cmd.ParseFlags([]string{testFlagFile, filepath.Join(dir, "gup.json")}); err != nil {
+		t.Fatal(err)
+	}
+	p, buf := newTestPrinter()
+	if got := runPin(p, cmd, []string{testBinTool, testVersionOne}); got != 1 {
+		t.Fatalf("runPin() exit = %d, want 1", got)
+	}
+	if buf.Len() == 0 {
+		t.Error("runPin() expected an error message")
+	}
+}
+
+// TestRunUnpin_writeConfigFailure covers the branch that reports a failure to
+// persist an unpin to gup.json. The config already carries a pin so RemovePin
+// reports a change and the write is attempted.
+//
+//nolint:paralleltest // mutates package-level writeConfFile
+func TestRunUnpin_writeConfigFailure(t *testing.T) {
+	origWrite := writeConfFile
+	t.Cleanup(func() { writeConfFile = origWrite })
+
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "gup.json")
+	pinned := `{"schema_version":2,"packages":[{"name":"tool","import_path":"example.com/tool","version":"v1.0.0","channel":"pinned"}]}`
+	if err := os.WriteFile(cfg, []byte(pinned), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeConfFile = func(io.Writer, []goutil.Package) error {
+		return errors.New("disk full")
+	}
+
+	cmd := newUnpinCmd()
+	if err := cmd.ParseFlags([]string{testFlagFile, cfg}); err != nil {
+		t.Fatal(err)
+	}
+	p, buf := newTestPrinter()
+	if got := runUnpin(p, cmd, []string{testBinTool}); got != 1 {
+		t.Fatalf("runUnpin() exit = %d, want 1", got)
+	}
+	if buf.Len() == 0 {
+		t.Error("runUnpin() expected an error message")
 	}
 }

--- a/cmd/pin_test.go
+++ b/cmd/pin_test.go
@@ -104,3 +104,12 @@ func TestTargetPackage(t *testing.T) {
 		t.Errorf("targetPackage(path) = %+v", byPath)
 	}
 }
+
+// TestParsePinArgs_tooManyArgs covers the default branch that rejects more than
+// two arguments.
+func TestParsePinArgs_tooManyArgs(t *testing.T) {
+	t.Parallel()
+	if _, _, err := parsePinArgs([]string{"a", "b", "c"}); err == nil {
+		t.Fatal("parsePinArgs() err = nil, want error for three args")
+	}
+}

--- a/cmd/pinned_update_test.go
+++ b/cmd/pinned_update_test.go
@@ -2,15 +2,146 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/nao1215/gup/internal/goutil"
 )
 
-const pinnedTestImport = "example.com/tool"
+// TestUpdatePinned_missingVersionField exercises the defensive nil-Version
+// initialization in updatePinned: a pinned package with no Version struct is
+// still installed at its pin, not skipped.
+func TestUpdatePinned_missingVersionField(t *testing.T) {
+	t.Parallel()
+	installed := ""
+	deps := testDeps()
+	deps.installByVersion = func(_ context.Context, importPath, version string) error {
+		installed = importPath + "@" + version
+		return nil
+	}
+	p := goutil.Package{
+		Name:          testBinTool,
+		ImportPath:    testImportExampleTool,
+		UpdateChannel: goutil.UpdateChannelPinned,
+		PinnedVersion: testVersionOne,
+		Version:       nil, // no version info yet
+	}
+	res := updatePinned(deps, context.Background(), p, false)
+	if res.err != nil {
+		t.Fatalf("updatePinned() err = %v, want nil", res.err)
+	}
+	if installed != "example.com/tool@v1.0.0" {
+		t.Fatalf("installed = %q, want example.com/tool@v1.0.0", installed)
+	}
+}
 
-// pinnedTestPkg builds an installed package for "example.com/tool" with a
+// TestUpdatePinned_emptyPinTarget covers the defensive guard that refuses to
+// install when a pinned package has no recorded version.
+func TestUpdatePinned_emptyPinTarget(t *testing.T) {
+	t.Parallel()
+	p := goutil.Package{
+		Name:          testBinTool,
+		ImportPath:    testImportExampleTool,
+		UpdateChannel: goutil.UpdateChannelPinned,
+		PinnedVersion: "   ",
+	}
+	res := updatePinned(testDeps(), context.Background(), p, false)
+	if res.err == nil {
+		t.Fatal("updatePinned() err = nil, want error for empty pin target")
+	}
+}
+
+// TestUpdatePinned_noImportPath covers the branch that reports a pinned package
+// gup can not reinstall because its import path is unknown.
+func TestUpdatePinned_noImportPath(t *testing.T) {
+	t.Parallel()
+	p := goutil.Package{
+		Name:          testBinTool,
+		ImportPath:    "", // unknown import path
+		UpdateChannel: goutil.UpdateChannelPinned,
+		PinnedVersion: testVersionOne,
+		Version:       &goutil.Version{Current: testVersionZeroNine}, // pin not satisfied
+	}
+	res := updatePinned(testDeps(), context.Background(), p, false)
+	if res.err == nil {
+		t.Fatal("updatePinned() err = nil, want error for missing import path")
+	}
+}
+
+// TestUpdatePinned_installFailure covers the branch that surfaces an install
+// error at the pinned version.
+func TestUpdatePinned_installFailure(t *testing.T) {
+	t.Parallel()
+	deps := testDeps()
+	deps.installByVersion = func(context.Context, string, string) error {
+		return errors.New("boom")
+	}
+	p := goutil.Package{
+		Name:          testBinTool,
+		ImportPath:    testImportExampleTool,
+		UpdateChannel: goutil.UpdateChannelPinned,
+		PinnedVersion: testVersionOne,
+		Version:       &goutil.Version{Current: testVersionZeroNine},
+	}
+	res := updatePinned(deps, context.Background(), p, false)
+	if res.err == nil {
+		t.Fatal("updatePinned() err = nil, want install error")
+	}
+}
+
+// TestInstallWithSelectedVersion_pinnedRejected covers the guard that never
+// installs a pinned package through the channel installer.
+func TestInstallWithSelectedVersion_pinnedRejected(t *testing.T) {
+	t.Parallel()
+	err := installWithSelectedVersion(testDeps(), context.Background(), testImportExampleTool, goutil.UpdateChannelPinned)
+	if err == nil {
+		t.Fatal("installWithSelectedVersion() err = nil, want error for pinned channel")
+	}
+}
+
+// TestInstallWithSelectedVersion_masterAndMain routes the master/main channels
+// to their installers.
+func TestInstallWithSelectedVersion_masterAndMain(t *testing.T) {
+	t.Parallel()
+	var called string
+	deps := testDeps()
+	deps.installByVersion = func(_ context.Context, _, version string) error { called = "byVersion:" + version; return nil }
+	deps.installMainOrMaster = func(context.Context, string) error { called = "mainOrMaster"; return nil }
+
+	if err := installWithSelectedVersion(deps, context.Background(), testImportExampleTool, goutil.UpdateChannelMaster); err != nil {
+		t.Fatalf("master: err = %v", err)
+	}
+	if called != "byVersion:master" {
+		t.Fatalf("master routed to %q", called)
+	}
+	if err := installWithSelectedVersion(deps, context.Background(), testImportExampleTool, goutil.UpdateChannelMain); err != nil {
+		t.Fatalf("main: err = %v", err)
+	}
+	if called != "mainOrMaster" {
+		t.Fatalf("main routed to %q", called)
+	}
+}
+
+// TestCheckPinned_nilVersion covers the nil-Version initialization in checkPinned.
+func TestCheckPinned_nilVersion(t *testing.T) {
+	t.Parallel()
+	p := goutil.Package{
+		Name:          testBinTool,
+		UpdateChannel: goutil.UpdateChannelPinned,
+		PinnedVersion: testVersionOne,
+		Version:       nil,
+	}
+	res := checkPinned(p, false)
+	// With no installed version the pin is not satisfied -> pin-mismatch.
+	if res.status != statusPinMismatch {
+		t.Fatalf("checkPinned() status = %q, want %q", res.status, statusPinMismatch)
+	}
+}
+
+const pinnedTestImport = testImportExampleTool
+
+// pinnedTestPkg builds an installed package for testImportExampleTool with a
 // resolved pin (channel + PinnedVersion), as configstate would hand to
 // updateWithChannels.
 func pinnedTestPkg(installed, pinned string) goutil.Package {
@@ -90,7 +221,7 @@ func TestUpdatePinned_emptyPinIsError(t *testing.T) {
 		return nil
 	}
 
-	p := pinnedTestPkg("v1.0.0", "")
+	p := pinnedTestPkg(testVersionOne, "")
 	res := updatePinned(deps, t.Context(), p, false)
 	if res.err == nil {
 		t.Fatal("expected an error for a pin with no recorded version, never a silent @latest")

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -557,7 +557,7 @@ func mockStdin(t *testing.T, dummyInput string) (funcDefer func(), err error) {
 //
 //nolint:paralleltest // relies on process-wide filesystem state
 func TestRemoveLoop_removeFailure(t *testing.T) {
-	skipIfRoot(t)
+	skipIfDirWriteFaultUnsupported(t)
 	gobin := t.TempDir()
 	bin := filepath.Join(gobin, testBinTool)
 	if err := os.WriteFile(bin, []byte("x"), 0o600); err != nil {

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -496,7 +496,7 @@ func Test_hasSuffixFold(t *testing.T) {
 		{name: "no suffix match", s: "tool.bin", suffix: dotExe, want: false},
 		{name: "s shorter than suffix", s: "ex", suffix: dotExe, want: false},
 		{name: "s one char shorter than suffix", s: ".ex", suffix: dotExe, want: false},
-		{name: "empty suffix matches anything", s: "tool", suffix: "", want: true},
+		{name: "empty suffix matches anything", s: testBinTool, suffix: "", want: true},
 		{name: "empty suffix and empty s", s: "", suffix: "", want: true},
 		{name: "empty s nonempty suffix", s: "", suffix: dotExe, want: false},
 		{name: "equal length match", s: abcLiteral, suffix: abcLiteral, want: true},
@@ -549,4 +549,30 @@ func mockStdin(t *testing.T, dummyInput string) (funcDefer func(), err error) {
 		os.Stdin = oldOsStdin
 		os.Remove(tmpFile.Name())
 	}, nil
+}
+
+// TestRemoveLoop_removeFailure covers the branch that reports an os.Remove
+// failure: the target exists but its parent directory is read-only, so the
+// unlink is denied.
+//
+//nolint:paralleltest // relies on process-wide filesystem state
+func TestRemoveLoop_removeFailure(t *testing.T) {
+	skipIfRoot(t)
+	gobin := t.TempDir()
+	bin := filepath.Join(gobin, testBinTool)
+	if err := os.WriteFile(bin, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(gobin, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(gobin, 0o700) })
+
+	p, buf := newTestPrinter()
+	if got := removeLoop(p, gobin, true, []string{testBinTool}); got != 1 {
+		t.Fatalf("removeLoop() = %d, want 1 on remove failure", got)
+	}
+	if buf.Len() == 0 {
+		t.Error("removeLoop() expected an error message")
+	}
 }

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -1385,7 +1385,10 @@ func TestUpdateWithChannels_modulePathRenameRetry(t *testing.T) {
 	if len(succeeded) != 1 {
 		t.Fatalf("succeeded = %d, want 1", len(succeeded))
 	}
-	if renamed["old"] != "new" {
-		t.Fatalf("renamed = %v, want old->new", renamed)
+	// On Windows the reinstalled binary carries the .exe suffix, so derive the
+	// expected new name the same way the command does instead of hardcoding it.
+	wantNew := binaryNameFromImportPath("example.com/new")
+	if renamed[testNameOld] != wantNew {
+		t.Fatalf("renamed = %v, want %s->%s", renamed, testNameOld, wantNew)
 	}
 }

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -669,7 +669,7 @@ func Test_installWithSelectedVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		called = ""
-		if err := installWithSelectedVersion(deps, context.Background(), "example.com/tool", tt.channel); err != nil {
+		if err := installWithSelectedVersion(deps, context.Background(), testImportExampleTool, tt.channel); err != nil {
 			t.Errorf("channel=%q: unexpected error: %v", tt.channel, err)
 		}
 		if called != tt.want {
@@ -683,13 +683,13 @@ func Test_installWithSelectedVersion_contextCanceled(t *testing.T) {
 	deps := testDeps()
 	deps.installLatest = func(ctx context.Context, _ string) error {
 		<-ctx.Done()
-		return fmt.Errorf("can't install %s:\n%w", "example.com/tool", ctx.Err())
+		return fmt.Errorf("can't install %s:\n%w", testImportExampleTool, ctx.Err())
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := installWithSelectedVersion(deps, ctx, "example.com/tool", goutil.UpdateChannelLatest)
+	err := installWithSelectedVersion(deps, ctx, testImportExampleTool, goutil.UpdateChannelLatest)
 	if !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), context.Canceled.Error()) {
 		t.Fatalf("installWithSelectedVersion() error = %v, want cancellation to be surfaced", err)
 	}
@@ -1310,7 +1310,82 @@ func Test_update_ambiguousConfigFailsFast(t *testing.T) {
 		t.Errorf("update() = %d, want 1", got)
 	}
 	out := buf.String()
-	if !strings.Contains(out, "multiple gup.json") || !strings.Contains(out, "--file") {
+	if !strings.Contains(out, "multiple gup.json") || !strings.Contains(out, testFlagFile) {
 		t.Errorf("expected ambiguity error mentioning --file, got: %s", out)
+	}
+}
+
+// TestRemoveOldBinaryIfRenamed_removesOldBinary covers the success path that
+// deletes the pre-rename binary from GOBIN.
+//
+//nolint:paralleltest // mutates the GOBIN environment variable
+func TestRemoveOldBinaryIfRenamed_removesOldBinary(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GOBIN", dir)
+	oldPath := filepath.Join(dir, "oldname")
+	if err := os.WriteFile(oldPath, []byte("bin"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := removeOldBinaryIfRenamed("oldname", "newname"); err != nil {
+		t.Fatalf("removeOldBinaryIfRenamed() err = %v", err)
+	}
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Fatalf("old binary still present, stat err = %v", err)
+	}
+}
+
+// TestRemoveOldBinaryIfRenamed_missingOldBinaryIsNoError covers the branch that
+// treats an already-absent old binary as success.
+//
+//nolint:paralleltest // mutates the GOBIN environment variable
+func TestRemoveOldBinaryIfRenamed_missingOldBinaryIsNoError(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GOBIN", dir)
+	if err := removeOldBinaryIfRenamed("absent", "newname"); err != nil {
+		t.Fatalf("removeOldBinaryIfRenamed() err = %v, want nil", err)
+	}
+}
+
+// TestUpdateWithChannels_modulePathRenameRetry covers the update path where the
+// first install fails because the module was renamed: gup rewrites the import
+// path, retries the install, and records the binary rename.
+//
+//nolint:paralleltest // mutates the GOBIN environment variable
+func TestUpdateWithChannels_modulePathRenameRetry(t *testing.T) {
+	t.Setenv("GOBIN", t.TempDir())
+	deps := testDeps()
+	deps.getLatestVer = func(context.Context, string) (string, error) { return "v1.1.0", nil }
+	calls := 0
+	deps.installLatest = func(context.Context, string) error {
+		calls++
+		if calls == 1 {
+			return errors.New("module declares its path as: example.com/new\n\tbut was required as: example.com/old")
+		}
+		return nil
+	}
+
+	pkgs := []goutil.Package{{
+		Name:          testNameOld,
+		ImportPath:    testImportExampleOld,
+		ModulePath:    testImportExampleOld,
+		Version:       &goutil.Version{Current: testVersionOne},
+		UpdateChannel: goutil.UpdateChannelLatest,
+	}}
+	channelMap := map[string]goutil.UpdateChannel{"old": goutil.UpdateChannelLatest}
+
+	// jsonOut=true keeps output machine-readable and avoids the human renderer,
+	// which would dereference the (test-omitted) GoVersion for display.
+	code, succeeded, renamed := updateWithChannels(deps, discardPrinter(), pkgs, false, false, 1, true, channelMap, nil, 0, true, false)
+	if code != 0 {
+		t.Fatalf("updateWithChannels() exit = %d, want 0", code)
+	}
+	if calls != 2 {
+		t.Fatalf("install attempts = %d, want 2 (initial + retry)", calls)
+	}
+	if len(succeeded) != 1 {
+		t.Fatalf("succeeded = %d, want 1", len(succeeded))
+	}
+	if renamed["old"] != "new" {
+		t.Fatalf("renamed = %v, want old->new", renamed)
 	}
 }

--- a/e2e/atago/bug_report.atago.yaml
+++ b/e2e/atago/bug_report.atago.yaml
@@ -1,0 +1,39 @@
+# Exercises 'gup bug-report' against the real binary. bug_report.go was excluded
+# from coverage because it opens a web browser; atago drives it with PATH pointed
+# at an empty directory so the browser launcher (xdg-open) is never found, gup
+# falls back to printing the issue template to STDOUT, and the whole command runs
+# deterministically with no browser window and no network. Run with: make e2e
+version: "1"
+
+suite:
+  name: gup bug-report (offline)
+
+scenarios:
+  - name: prints the pre-filled issue template when no browser can be opened
+    env:
+      HOME: "${workdir}/home"
+      XDG_CONFIG_HOME: "${workdir}/home/.config"
+      GOBIN: "${workdir}/gobin"
+      GOPATH: "${workdir}/gopath"
+      # An empty PATH for the gup child process: its exec("xdg-open") lookup fails,
+      # openBrowser() returns false, and the STDOUT fallback fires. atago resolves
+      # the 'gup'/'mkdir' commands via the launcher environment, so overriding the
+      # child PATH here does not stop the scenario from running the built binary.
+      PATH: "${workdir}/emptybin"
+    steps:
+      - run:
+          shell: true
+          command: mkdir -p ${workdir}/emptybin
+      - run:
+          command: gup bug-report
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - "Please file a new issue"
+              - "## gup version"
+              - "## OS"
+      # The injected e2e version is embedded in the template body.
+      - assert:
+          stdout:
+            contains: "v0.0.0-e2e"

--- a/e2e/atago/check.atago.yaml
+++ b/e2e/atago/check.atago.yaml
@@ -63,3 +63,36 @@ scenarios:
       - assert:
           stderr:
             not_contains: "not found 'junk'"
+
+  - name: human-readable check lists an outdated binary and suggests gup update
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      # No --json: exercises the human-readable renderer, the per-binary check
+      # line, and the "run the following command" update hint.
+      - run:
+          command: gup check
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - "check binary under"
+              - outdated
+              - "gup update"
+
+  - name: --quiet check hides up-to-date binaries but prints the summary
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/uptodate@v1.0.0
+      - run:
+          command: gup check --quiet
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "gup: 0 update available"
+      # In quiet mode the up-to-date binary's per-line output is suppressed.
+      - assert:
+          stdout:
+            not_contains: "check binary under"

--- a/e2e/atago/cli.atago.yaml
+++ b/e2e/atago/cli.atago.yaml
@@ -1,0 +1,113 @@
+# Top-level CLI contracts that exercise the process entrypoint (main.go), the
+# root command wiring (root.go) and the dynamic shell-completion callback
+# (completePathBinaries). These paths only run when the real binary is launched,
+# so they were unmeasured until the atago suite drove them. Run with: make e2e
+version: "1"
+
+suite:
+  name: gup cli entrypoint (offline)
+
+scenarios:
+  - name: an unknown subcommand fails via the process error path and names it
+    env: &iso
+      HOME: "${workdir}/home"
+      XDG_CONFIG_HOME: "${workdir}/home/.config"
+      GOBIN: "${workdir}/gobin"
+      GOPATH: "${workdir}/gopath"
+    steps:
+      # cmd.Execute() returns an error, so main() prints it and exits non-zero -
+      # the only path that reaches main.go's error branch.
+      - run:
+          command: gup no-such-subcommand
+      - assert:
+          exit_code: 1
+          stderr:
+            contains: "unknown command"
+
+  - name: an unknown flag fails via the process error path
+    env: *iso
+    steps:
+      - run:
+          command: gup --no-such-flag
+      - assert:
+          exit_code: 1
+          stderr:
+            contains: "unknown flag"
+
+  - name: top-level --version prints the injected banner
+    env: *iso
+    steps:
+      - run:
+          command: gup --version
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "v0.0.0-e2e"
+
+  - name: the -V short flag matches --version
+    env: *iso
+    steps:
+      - run:
+          command: gup -V
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "v0.0.0-e2e"
+
+  - name: --help lists the subcommands
+    env: *iso
+    steps:
+      - run:
+          command: gup --help
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - "Available Commands"
+              - "update"
+              - "bug-report"
+
+  - name: --no-color runs the persistent pre-run without error
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      # PersistentPreRunE reads --no-color and applies the color preference before
+      # the subcommand runs; a plain list confirms the wired-up flow succeeds.
+      - run:
+          command: gup --no-color list
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: outdated
+
+  - name: dynamic completion lists installed binaries by prefix
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: go install gup.test/uptodate@v1.0.0
+      # cobra's hidden __complete drives completePathBinaries with the typed
+      # prefix; "up" must match uptodate but filter out outdated.
+      - run:
+          command: gup __complete update up
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: uptodate
+      - assert:
+          stdout:
+            not_contains: outdated
+
+  - name: dynamic completion with an empty prefix lists every binary
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: gup __complete update ""
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: outdated

--- a/e2e/atago/completion.atago.yaml
+++ b/e2e/atago/completion.atago.yaml
@@ -1,0 +1,107 @@
+# Exercises 'gup completion' for every shell plus --install against the real
+# binary. The per-shell switch in completion.go and the file-deploying install
+# path (internal/completion) were previously only unit-tested; driving the CLI
+# here measures the code an end user actually runs. Run with: make e2e
+version: "1"
+
+suite:
+  name: gup completion (offline)
+
+scenarios:
+  - name: prints bash completion to STDOUT
+    env: &iso
+      HOME: "${workdir}/home"
+      XDG_CONFIG_HOME: "${workdir}/home/.config"
+      GOBIN: "${workdir}/gobin"
+      GOPATH: "${workdir}/gopath"
+    steps:
+      - run:
+          command: gup completion bash
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "# bash completion V2 for gup"
+
+  - name: prints fish completion to STDOUT
+    env: *iso
+    steps:
+      - run:
+          command: gup completion fish
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "fish completion for gup"
+
+  - name: prints zsh completion to STDOUT
+    env: *iso
+    steps:
+      - run:
+          command: gup completion zsh
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "#compdef gup"
+
+  - name: prints powershell completion to STDOUT
+    env: *iso
+    steps:
+      - run:
+          command: gup completion powershell
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "Register-ArgumentCompleter"
+
+  - name: rejects an unknown shell name
+    env: *iso
+    steps:
+      - run:
+          command: gup completion tcsh
+      - assert:
+          exit_code: 1
+          stderr:
+            contains: "invalid argument"
+
+  - name: guidance is printed when neither a shell nor --install is given
+    env: *iso
+    steps:
+      - run:
+          command: gup completion
+      - assert:
+          exit_code: 1
+          stderr:
+            contains:
+              - "requires a shell name"
+              - "--install"
+
+  - name: --install writes shell completion files under the user config paths
+    env: *iso
+    steps:
+      - run:
+          command: gup completion --install
+      - assert:
+          exit_code: 0
+      # bash goes under $HOME/.local/share (XDG_DATA_HOME unset), fish under
+      # $XDG_CONFIG_HOME, zsh under $HOME/.zsh - proving all three were deployed.
+      - assert:
+          file:
+            path: home/.local/share/bash-completion/completions/gup
+            exists: true
+      - assert:
+          file:
+            path: home/.config/fish/completions/gup.fish
+            exists: true
+      - assert:
+          file:
+            path: home/.zsh/completion/_gup
+            exists: true
+
+  - name: --install rejects a shell argument
+    env: *iso
+    steps:
+      - run:
+          command: gup completion --install bash
+      - assert:
+          exit_code: 1
+          stderr:
+            contains: "cannot be used with shell argument"

--- a/e2e/atago/list_remove.atago.yaml
+++ b/e2e/atago/list_remove.atago.yaml
@@ -59,3 +59,48 @@ scenarios:
           file:
             path: gobin/outdated
             exists: true
+
+  - name: list --json annotates an installed binary as installed
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: gup list --json
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              path: "$[0].name"
+              equals: outdated
+      - assert:
+          stdout:
+            json:
+              path: "$[0].status"
+              equals: installed
+
+  - name: list --json on an empty GOBIN emits a valid empty JSON array
+    env: *iso
+    steps:
+      - run:
+          shell: true
+          command: mkdir -p ${workdir}/gobin
+      - run:
+          command: gup list --json
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "[]"
+
+  - name: remove rejects an unsafe binary name that escapes GOBIN
+    env: *iso
+    steps:
+      - run:
+          shell: true
+          command: mkdir -p ${workdir}/gobin
+      - run:
+          command: gup remove --force "../evil"
+      - assert:
+          exit_code: 1
+          stderr:
+            contains: "invalid command name"

--- a/e2e/atago/man.atago.yaml
+++ b/e2e/atago/man.atago.yaml
@@ -1,0 +1,52 @@
+# Exercises 'gup man' against the real binary. Historically man.go was excluded
+# from coverage because generating man-pages needs a writable MANPATH and root
+# privilege for the default /usr/share/man; atago drives the CLI with a private
+# MANPATH under ${workdir}, so the whole generate/copy/gzip/atomic-write path is
+# now measured. Run with: make e2e
+version: "1"
+
+suite:
+  name: gup man (offline)
+
+scenarios:
+  - name: generates gzipped man-pages under a writable MANPATH
+    env: &iso
+      HOME: "${workdir}/home"
+      XDG_CONFIG_HOME: "${workdir}/home/.config"
+      GOBIN: "${workdir}/gobin"
+      GOPATH: "${workdir}/gopath"
+      # A custom MANPATH whose man1 directory does not exist yet: gup must create
+      # it and write the pages there instead of touching the system /usr/share/man.
+      MANPATH: "${workdir}/man"
+    steps:
+      - run:
+          command: gup man
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "Generate"
+          file:
+            path: man/man1/gup.1.gz
+            exists: true
+      # The subcommand pages are generated too, proving the whole doc tree copied.
+      - assert:
+          file:
+            path: man/man1/gup-update.1.gz
+            exists: true
+
+  - name: reports a clear error when the man directory can not be created
+    env: *iso
+    steps:
+      # MANPATH points under a regular file, so MkdirAll for the man1 dir fails
+      # and gup surfaces the "can not generate man-pages" error instead of panicking.
+      - fixture:
+          file: blocker
+          content: "not a directory"
+      - run:
+          command: gup man
+          env:
+            MANPATH: "${workdir}/blocker"
+      - assert:
+          exit_code: 1
+          stderr:
+            contains: "can not generate man-pages"

--- a/e2e/atago/migrate_export_import.atago.yaml
+++ b/e2e/atago/migrate_export_import.atago.yaml
@@ -59,3 +59,149 @@ scenarios:
             exists: true
           stdout:
             contains: gup.test/uptodate
+
+  - name: import --dry-run reports the plan without installing anything
+    env: *iso
+    steps:
+      - fixture:
+          file: import.json
+          content: |
+            {"schema_version":1,"packages":[{"name":"uptodate","import_path":"gup.test/uptodate","version":"v1.0.0","channel":"latest"}]}
+      - run:
+          command: gup import --dry-run --file "${workdir}/import.json"
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: gup.test/uptodate
+      # Dry-run must not write into the real $GOBIN.
+      - assert:
+          file:
+            path: gobin/uptodate
+            exists: false
+
+  - name: import rejects a config with an invalid package entry
+    env: *iso
+    steps:
+      - fixture:
+          file: bad.json
+          content: |
+            {"schema_version":1,"packages":[{"name":"uptodate","import_path":"gup.test/uptodate","version":"","channel":"latest"}]}
+      - run:
+          command: gup import --file "${workdir}/bad.json"
+      - assert:
+          exit_code: 1
+          stderr:
+            contains: "invalid package entry"
+
+  - name: migrate reports a clear error when BEFORE_PATH does not exist
+    env: *iso
+    steps:
+      - run:
+          command: gup migrate "${workdir}/missing-before" "${workdir}/after"
+      - assert:
+          exit_code: 1
+          stderr:
+            contains: "BEFORE_PATH does not exist"
+
+  - name: migrate rejects the same directory for BEFORE_PATH and AFTER_PATH
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+          env:
+            GOBIN: "${workdir}/before"
+      - run:
+          command: gup migrate "${workdir}/before" "${workdir}/before"
+      - assert:
+          exit_code: 1
+          stderr:
+            contains: "same directory"
+
+  - name: migrate rejects an AFTER_PATH that is an existing regular file
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+          env:
+            GOBIN: "${workdir}/before"
+      - fixture:
+          file: after-file
+          content: "i am a file"
+      - run:
+          command: gup migrate "${workdir}/before" "${workdir}/after-file"
+      - assert:
+          exit_code: 1
+          stderr:
+            contains: "AFTER_PATH is not a directory"
+
+  - name: migrate --dry-run plans the migration without installing into AFTER_PATH
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+          env:
+            GOBIN: "${workdir}/before"
+      - run:
+          command: gup migrate --dry-run "${workdir}/before" "${workdir}/after"
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: gup.test/outdated
+      # Dry-run must neither create AFTER_PATH nor install the binary there.
+      - assert:
+          file:
+            path: after/outdated
+            exists: false
+
+  - name: migrate warns about a requested binary missing from BEFORE_PATH
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+          env:
+            GOBIN: "${workdir}/before"
+      - run:
+          command: gup migrate "${workdir}/before" "${workdir}/after" no-such-tool
+      - assert:
+          stderr:
+            contains: "not found 'no-such-tool'"
+
+  - name: migrate skips a binary that already exists in AFTER_PATH without --force
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+          env:
+            GOBIN: "${workdir}/before"
+      # Pre-populate AFTER_PATH with the same binary so migrate skips it.
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+          env:
+            GOBIN: "${workdir}/after"
+      - run:
+          command: gup migrate "${workdir}/before" "${workdir}/after"
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "already exists in AFTER_PATH"
+
+  - name: migrate --force reinstalls over an existing binary in AFTER_PATH
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+          env:
+            GOBIN: "${workdir}/before"
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+          env:
+            GOBIN: "${workdir}/after"
+      - run:
+          command: gup migrate --force "${workdir}/before" "${workdir}/after"
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: gup.test/outdated
+      - assert:
+          stdout:
+            not_contains: "already exists in AFTER_PATH"

--- a/e2e/atago/migrate_export_import.atago.yaml
+++ b/e2e/atago/migrate_export_import.atago.yaml
@@ -162,7 +162,10 @@ scenarios:
             GOBIN: "${workdir}/before"
       - run:
           command: gup migrate "${workdir}/before" "${workdir}/after" no-such-tool
+      # Only the missing name is requested, so nothing matches and migrate fails
+      # after warning about it (consistent with the other negative-path cases).
       - assert:
+          exit_code: 1
           stderr:
             contains: "not found 'no-such-tool'"
 

--- a/e2e/atago/pin.atago.yaml
+++ b/e2e/atago/pin.atago.yaml
@@ -333,10 +333,14 @@ scenarios:
           command: go install gup.test/outdated@v1.0.0
       - run:
           command: gup pin outdated latest
+      # "Pinned" is a success message written to STDOUT, so the rejection is
+      # asserted on STDOUT (absence) plus the concrete error on STDERR.
       - assert:
           exit_code: 1
-          stderr:
+          stdout:
             not_contains: "Pinned"
+          stderr:
+            contains: "channel keyword"
 
   - name: rejects specifying the version twice
     env: *iso
@@ -365,6 +369,8 @@ scenarios:
           exit_code: 1
           stdout:
             not_contains: "Pinned"
+          stderr:
+            contains: "is not valid JSON"
 
   - name: unpin reports a clear error for an empty tool name
     env: *iso
@@ -387,3 +393,5 @@ scenarios:
           command: gup unpin outdated --file "${workdir}/broken.json"
       - assert:
           exit_code: 1
+          stderr:
+            contains: "is not valid JSON"

--- a/e2e/atago/pin.atago.yaml
+++ b/e2e/atago/pin.atago.yaml
@@ -325,3 +325,65 @@ scenarios:
             contains:
               - '"channel": "pinned"'
               - '"name": "outdated"'
+
+  - name: rejects pinning to a channel keyword such as latest
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: gup pin outdated latest
+      - assert:
+          exit_code: 1
+          stderr:
+            not_contains: "Pinned"
+
+  - name: rejects specifying the version twice
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: gup pin outdated@v1.0.0 v2.0.0
+      - assert:
+          exit_code: 1
+          stderr:
+            contains: "specify the version once"
+
+  - name: pin fails fast on a malformed channel-source config
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - fixture:
+          file: broken.json
+          content: |
+            {this is not valid json
+      - run:
+          command: gup pin outdated v1.0.0 --file "${workdir}/broken.json"
+      - assert:
+          exit_code: 1
+          stdout:
+            not_contains: "Pinned"
+
+  - name: unpin reports a clear error for an empty tool name
+    env: *iso
+    steps:
+      - run:
+          command: gup unpin "@"
+      - assert:
+          exit_code: 1
+          stderr:
+            contains: "missing tool name"
+
+  - name: unpin fails fast on a malformed channel-source config
+    env: *iso
+    steps:
+      - fixture:
+          file: broken.json
+          content: |
+            {this is not valid json
+      - run:
+          command: gup unpin outdated --file "${workdir}/broken.json"
+      - assert:
+          exit_code: 1

--- a/e2e/atago/update.atago.yaml
+++ b/e2e/atago/update.atago.yaml
@@ -244,8 +244,12 @@ scenarios:
           command: gup pin outdated v9.9.9
       - run:
           command: gup update
+      # The failure names the pinned tool, confirming this is the pinned-install
+      # failure path and not some unrelated exit-1 error.
       - assert:
           exit_code: 1
+          stderr:
+            contains: outdated
       # The originally installed version is left in place after the failed reinstall.
       - run:
           command: go version -m gobin/outdated

--- a/e2e/atago/update.atago.yaml
+++ b/e2e/atago/update.atago.yaml
@@ -181,3 +181,74 @@ scenarios:
             contains:
               - "replace directive"
               - "go install"
+
+  - name: --dry-run reports the update but leaves the installed binary untouched
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: gup update --dry-run
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: outdated
+      # Dry-run must not touch $GOBIN: the binary stays at the original version.
+      - run:
+          command: go version -m gobin/outdated
+      - assert:
+          stdout:
+            contains: v1.0.0
+      - assert:
+          stdout:
+            not_contains: v1.1.0
+
+  - name: --quiet prints a summary line and still updates
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: gup update --quiet
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "gup: 1 updated"
+      - run:
+          command: go version -m gobin/outdated
+      - assert:
+          stdout:
+            contains: v1.1.0
+
+  - name: rejects a binary named in two conflicting channel flags
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: gup update --main outdated --master outdated
+      - assert:
+          exit_code: 1
+          stderr:
+            contains:
+              - "specified in both"
+              - "--main"
+              - "--master"
+
+  - name: a pin to a nonexistent version fails the update at install time
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: gup pin outdated v9.9.9
+      - run:
+          command: gup update
+      - assert:
+          exit_code: 1
+      # The originally installed version is left in place after the failed reinstall.
+      - run:
+          command: go version -m gobin/outdated
+      - assert:
+          stdout:
+            contains: v1.0.0

--- a/internal/completion/completion_more_test.go
+++ b/internal/completion/completion_more_test.go
@@ -982,3 +982,24 @@ func TestCompletionFilePaths(t *testing.T) {
 		}
 	}
 }
+
+// TestAtomicWriteFile_createTempFailure covers the temp-file creation error
+// branch when the destination directory is not writable. It is skipped as root,
+// where the read-only bit is ignored; gup's CI runs as a non-root user.
+//
+//nolint:paralleltest // relies on process-wide filesystem state
+func TestAtomicWriteFile_createTempFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("skipping: read-only permissions are bypassed when running as root")
+	}
+	dir := t.TempDir()
+	roDir := filepath.Join(dir, "readonly")
+	if err := os.Mkdir(roDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(roDir, 0o700) }) //nolint:gosec // restore dir perms so t.TempDir cleanup can remove it
+
+	if err := atomicWriteFile(filepath.Join(roDir, "completion"), []byte("data"), "completion file"); err == nil {
+		t.Fatal("atomicWriteFile() err = nil, want temp-create failure in a read-only dir")
+	}
+}

--- a/internal/completion/completion_more_test.go
+++ b/internal/completion/completion_more_test.go
@@ -992,6 +992,9 @@ func TestAtomicWriteFile_createTempFailure(t *testing.T) {
 	if os.Geteuid() == 0 {
 		t.Skip("skipping: read-only permissions are bypassed when running as root")
 	}
+	if IsWindows() {
+		t.Skip("skipping: Windows does not enforce read-only dir permissions for writes")
+	}
 	dir := t.TempDir()
 	roDir := filepath.Join(dir, "readonly")
 	if err := os.Mkdir(roDir, 0o500); err != nil {

--- a/internal/configstate/configstate_test.go
+++ b/internal/configstate/configstate_test.go
@@ -25,11 +25,12 @@ const (
 	testVer100   = "v1.0.0"
 	testVer200   = "v2.0.0"
 
-	testOldName  = "old-name"
-	testNewName  = "new-name"
-	testFooPath  = "example.com/foo/cmd/foo"
-	testToolName = "tool"
-	testToolPath = "example.com/tool/cmd/tool"
+	testOldName    = "old-name"
+	testNewName    = "new-name"
+	testFooPath    = "example.com/foo/cmd/foo"
+	testToolName   = "tool"
+	testVersion123 = "v1.2.3"
+	testToolPath   = "example.com/tool/cmd/tool"
 
 	testFoo       = "foo"
 	testBar       = "bar"
@@ -474,9 +475,9 @@ func TestSanitizePackage(t *testing.T) {
 		pkg     goutil.Package
 		wantVer string
 	}{
-		{name: "nil version -> latest", pkg: goutil.Package{Name: "tool", ImportPath: "github.com/example/tool"}, wantVer: latestKeyword},
-		{name: "blank version -> latest", pkg: goutil.Package{Name: "tool", ImportPath: "github.com/example/tool", Version: &goutil.Version{Current: "  "}}, wantVer: latestKeyword},
-		{name: "valid version preserved + trimmed", pkg: goutil.Package{Name: " tool ", ImportPath: " github.com/example/tool ", Version: &goutil.Version{Current: " v1.2.3 "}}, wantVer: "v1.2.3"},
+		{name: "nil version -> latest", pkg: goutil.Package{Name: testToolName, ImportPath: "github.com/example/tool"}, wantVer: latestKeyword},
+		{name: "blank version -> latest", pkg: goutil.Package{Name: testToolName, ImportPath: "github.com/example/tool", Version: &goutil.Version{Current: "  "}}, wantVer: latestKeyword},
+		{name: "valid version preserved + trimmed", pkg: goutil.Package{Name: " tool ", ImportPath: " github.com/example/tool ", Version: &goutil.Version{Current: " v1.2.3 "}}, wantVer: testVersion123},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -875,5 +876,44 @@ func TestMergePackages_keepsRenameWithUnchangedImportPath(t *testing.T) {
 	}
 	if got[0].Name != testBar {
 		t.Errorf("kept entry = %q, want %q", got[0].Name, testBar)
+	}
+}
+
+// TestSavedPinnedVersion_fallsBackToRecordedVersion covers the branch that, for
+// a pinned package with no dedicated PinnedVersion, falls back to the recorded
+// current version.
+func TestSavedPinnedVersion_fallsBackToRecordedVersion(t *testing.T) {
+	t.Parallel()
+	got := savedPinnedVersion(goutil.Package{
+		UpdateChannel: goutil.UpdateChannelPinned,
+		Version:       &goutil.Version{Current: testVersion123},
+	})
+	if got != testVersion123 {
+		t.Fatalf("savedPinnedVersion() = %q, want v1.2.3", got)
+	}
+}
+
+// TestSavedPinnedVersion_noVersionInfo covers the branch that returns an empty
+// string for a pinned package with neither a PinnedVersion nor a recorded
+// version.
+func TestSavedPinnedVersion_noVersionInfo(t *testing.T) {
+	t.Parallel()
+	got := savedPinnedVersion(goutil.Package{
+		UpdateChannel: goutil.UpdateChannelPinned,
+		Version:       nil,
+	})
+	if got != "" {
+		t.Fatalf("savedPinnedVersion() = %q, want empty", got)
+	}
+}
+
+// TestResolveChannels_mainAndLatestConflict covers the branch that rejects a
+// binary named in both --main and --latest.
+func TestResolveChannels_mainAndLatestConflict(t *testing.T) {
+	t.Parallel()
+	pkgs := []goutil.Package{{Name: testToolName, ImportPath: "example.com/tool"}}
+	_, _, err := ResolveChannels(pkgs, nil, []string{"tool"}, nil, []string{"tool"}, nil, func(string) {})
+	if err == nil {
+		t.Fatal("ResolveChannels() err = nil, want conflict error for --main and --latest")
 	}
 }

--- a/internal/configstate/pinned_test.go
+++ b/internal/configstate/pinned_test.go
@@ -130,7 +130,7 @@ func TestSetPin_addsAndReplaces(t *testing.T) {
 	}
 	target := goutil.Package{Name: testToolName, ImportPath: pinTestImport}
 
-	got, err := SetPin(conf, target, "v1.2.3")
+	got, err := SetPin(conf, target, testVersion123)
 	if err != nil {
 		t.Fatalf("SetPin() error: %v", err)
 	}
@@ -143,7 +143,7 @@ func TestSetPin_addsAndReplaces(t *testing.T) {
 			tool = &got[i]
 		}
 	}
-	if tool == nil || tool.UpdateChannel != goutil.UpdateChannelPinned || tool.PinnedVersion != "v1.2.3" {
+	if tool == nil || tool.UpdateChannel != goutil.UpdateChannelPinned || tool.PinnedVersion != testVersion123 {
 		t.Fatalf("SetPin did not pin tool: %+v", tool)
 	}
 

--- a/internal/fileutil/fileutil_test.go
+++ b/internal/fileutil/fileutil_test.go
@@ -206,3 +206,29 @@ func TestResolveSymlinkTarget(t *testing.T) {
 func isWindows() bool {
 	return os.PathSeparator == '\\'
 }
+
+// TestResolveSymlinkTarget_relativeLink covers the branch that resolves a
+// relative symlink target against the link's own directory, so the returned
+// path is the absolute file the link points at.
+//
+//nolint:paralleltest // creates symlinks under a temp dir
+func TestResolveSymlinkTarget_relativeLink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real.json")
+	if err := os.WriteFile(target, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link.json")
+	// A RELATIVE target ("real.json") must be joined with the link's directory.
+	if err := os.Symlink("real.json", link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	got, err := ResolveSymlinkTarget(link)
+	if err != nil {
+		t.Fatalf("ResolveSymlinkTarget() err = %v", err)
+	}
+	if got != filepath.Clean(target) {
+		t.Fatalf("ResolveSymlinkTarget() = %q, want %q", got, target)
+	}
+}

--- a/internal/pkgselect/pkgselect_test.go
+++ b/internal/pkgselect/pkgselect_test.go
@@ -20,6 +20,7 @@ const (
 	pkg3        = "pkg3"
 	nameTest2   = "test2"
 	nameMissing = "missing"
+	blankTarget = "   "
 )
 
 // excludeNotice builds the notice Exclude emits for a dropped binary, matching
@@ -56,7 +57,7 @@ func TestFilterBinaryPaths(t *testing.T) {
 
 	t.Run("returns an empty list when every target is blank", func(t *testing.T) {
 		t.Parallel()
-		got := FilterBinaryPaths(binList, []string{"   ", ""})
+		got := FilterBinaryPaths(binList, []string{blankTarget, ""})
 		if diff := cmp.Diff([]string{}, got); diff != "" {
 			t.Fatalf("value is mismatch (-want +got):\n%s", diff)
 		}
@@ -313,5 +314,31 @@ func TestPackageInfoByTargets_presentButUnreadableIsNotMissing(t *testing.T) {
 	}
 	if len(missing) != 0 {
 		t.Fatalf("PackageInfoByTargets() missing = %v, want none (dummy exists on disk)", missing)
+	}
+}
+
+// TestMissingTargets_skipsBlankTarget covers the branch that ignores a target
+// whose normalized name is empty (whitespace only), so it is never reported as
+// missing.
+func TestMissingTargets_skipsBlankTarget(t *testing.T) {
+	t.Parallel()
+	got := MissingTargets([]string{"/gobin/foo"}, []string{blankTarget})
+	if len(got) != 0 {
+		t.Fatalf("MissingTargets() = %v, want empty (blank target skipped)", got)
+	}
+}
+
+// TestExclude_skipsBlankName covers the branch that ignores a blank exclude
+// name, so a whitespace-only entry excludes nothing.
+func TestExclude_skipsBlankName(t *testing.T) {
+	t.Parallel()
+	pkgs := []goutil.Package{{Name: "foo"}, {Name: "bar"}}
+	notified := 0
+	got := Exclude(pkgs, []string{blankTarget}, func(string) { notified++ })
+	if len(got) != len(pkgs) {
+		t.Fatalf("Exclude() dropped packages for a blank name: got %d, want %d", len(got), len(pkgs))
+	}
+	if notified != 0 {
+		t.Fatalf("Exclude() notified %d times for a blank name, want 0", notified)
 	}
 }

--- a/internal/vercache/vercache_test.go
+++ b/internal/vercache/vercache_test.go
@@ -328,3 +328,35 @@ func TestChannelResolver(t *testing.T) {
 		}
 	})
 }
+
+// TestChannelResolver_pinnedNotResolvable covers the guard that refuses to
+// resolve a pinned channel against the proxy: pinned packages must be installed
+// at their exact recorded version, never resolved to @latest.
+func TestChannelResolver_pinnedNotResolvable(t *testing.T) {
+	t.Parallel()
+	resolve := ChannelResolver(
+		func(context.Context, string) (string, error) { return "v1.0.0", nil },
+		func(context.Context, string, string) (string, error) { return "v1.0.0", nil },
+	)
+	if _, err := resolve(context.Background(), "example.com/tool", goutil.UpdateChannelPinned); err == nil {
+		t.Fatal("ChannelResolver() err = nil, want error for pinned channel")
+	}
+}
+
+// TestChannelResolver_masterRoutesToRef covers the @master branch, which
+// resolves directly against the master ref.
+func TestChannelResolver_masterRoutesToRef(t *testing.T) {
+	t.Parallel()
+	var ref string
+	resolve := ChannelResolver(
+		func(context.Context, string) (string, error) { return "", nil },
+		func(_ context.Context, _, r string) (string, error) { ref = r; return "v2.0.0", nil },
+	)
+	got, err := resolve(context.Background(), "example.com/tool", goutil.UpdateChannelMaster)
+	if err != nil {
+		t.Fatalf("ChannelResolver() err = %v", err)
+	}
+	if got != "v2.0.0" || ref != "master" {
+		t.Fatalf("ChannelResolver() = %q via ref %q, want v2.0.0 via master", got, ref)
+	}
+}


### PR DESCRIPTION
## Summary

This PR pushes combined (unit + self-hosted E2E) coverage from ~90.3% to ~94.2% and raises `.octocov.yml`'s acceptable threshold from 80% to 90%. The gains come from driving code paths the atago E2E suite can now exercise on the real CLI (man-page generation, bug-report, the process entrypoint, shell completion) plus targeted unit tests for the error branches E2E can not reach without fault injection.

## Changes

- New atago E2E scenarios: `gup man` (writes gzipped pages under a private MANPATH), `gup bug-report` (deterministic STDOUT fallback with the browser launcher removed from PATH), `gup completion` for every shell + `--install`, and top-level CLI contracts (unknown command/flag, `--version`/`-V`, `--help`, `--no-color`, dynamic `__complete`).
- Extended existing scenarios: `update --dry-run`/`--quiet`/conflicting channel flags/pin-to-missing-version, human-readable and `--quiet` `check`, `list --json`, `remove` unsafe-name rejection, and many `migrate`/`import` failure and dry-run paths.
- Unit tests for branches unreachable from the CLI: per-flag parse errors across every command, `updatePinned`/`installWithSelectedVersion`/`checkPinned` edge cases, the module-path rename+retry path in `update`/`migrate`, `writeConfigFile`/`writeManpageAtomically`/completion atomic-write I/O failures, `pin`/`unpin` config-write failures, and small helpers in `pkgselect`/`vercache`/`fileutil`/`configstate`.
- `.octocov.yml`: `acceptable` 80% -> 90%, and the exclude list trimmed to only `e2e/testproxy/main.go`. `main.go`, `cmd/root.go`, `cmd/man.go` and `cmd/bug_report.go` are now measured because the E2E suite exercises them on the real binary.

## Design Decisions

- Every shipped source file is now measured. The only remaining exclude is the offline module proxy under `e2e/testproxy`, which is E2E test infrastructure rather than part of the gup binary.
- `bug-report` is made deterministic by pointing the child process's PATH at an empty directory, so its `xdg-open` lookup fails and the STDOUT template fallback fires with no browser window and no network. atago resolves the `gup` command through the launcher environment, so overriding the child PATH does not stop the built binary from running.
- Filesystem-permission fault injection (read-only dirs to force `os.CreateTemp` failures) is guarded with a root check via a shared `skipIfRoot` helper, since root bypasses the read-only bit; gup's coverage CI runs as the non-root runner user, so those branches are still exercised there.

## Limitations

- Coverage lands at ~94.2%, short of a full 95%. The remaining uncovered statements are defensive I/O-failure branches in the atomic-write helpers (`Sync`/`Close`/`Chmod`/rename failures on an already-open file) and a few Windows-only paths, none of which are reachable from the CLI or via portable fault injection without adding more test seams to production code. The 90% acceptable threshold keeps a comfortable margin above the achieved number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Testing & Quality**
  * Expanded end-to-end coverage for CLI behaviors (help/version, unknown commands/flags), shell completion across bash/fish/zsh/powershell, and offline scenarios for bug-report, check, manpage generation, list/remove, pin/unpin, import/migrate, and update.
  * Added/strengthened unit tests for additional failure and edge cases, including invalid arguments, missing/incorrect version data, malformed configs, unsafe paths, and filesystem write/copy/rename/atomic temp-file error handling.

* **Chores**
  * Tightened CI coverage by raising the acceptable threshold to 90% and adjusting offline exclusion rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->