### PR TITLE
test(e2e): adopt atago v0.3.4 with pty and snapshot specs, bump CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.1.0
+          version: v0.3.4
 
       # Combines unit-test coverage with self-hosted E2E coverage, then merges
       # both into cover.out. The E2E suite is fully offline (it starts its own

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.1.0
+          version: v0.3.4
 
       - name: Run offline end-to-end tests
         run: make e2e

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,12 +33,19 @@ temp tree. It never touches your real `$HOME`, `~/.config/gup`, or `$GOBIN`, and
 needs no network access. The tests are plain-YAML specs run by
 [atago](https://github.com/nao1215/atago).
 
+The suite uses atago **v0.3.4+** features (a real-PTY step for the interactive
+`gup remove` prompt, and golden-output snapshots), so an older atago will fail to
+parse those specs. CI pins the same version via setup-atago.
+
 ```shell
-# Install atago once
+# Install atago once (v0.3.4 or newer)
 go install github.com/nao1215/atago@latest
 
 # Run the whole offline suite
 make e2e
+
+# Refresh golden snapshots after an intentional output change
+atago run --update-snapshots e2e/atago
 ```
 
 The harness lives under `e2e/`: `e2e/run.sh` builds gup, starts the offline

--- a/e2e/atago/export-pinned-outdated
+++ b/e2e/atago/export-pinned-outdated
@@ -1,0 +1,11 @@
+{
+  "schema_version": 2,
+  "packages": [
+    {
+      "name": "outdated",
+      "import_path": "gup.test/outdated",
+      "version": "v1.0.0",
+      "channel": "pinned"
+    }
+  ]
+}

--- a/e2e/atago/remove_interactive.atago.yaml
+++ b/e2e/atago/remove_interactive.atago.yaml
@@ -1,0 +1,85 @@
+# Drives 'gup remove' through a REAL pseudo-terminal (atago v0.3.x pty step), so
+# the interactive confirmation prompt that only appears when stdin is a TTY is
+# exercised end-to-end. The non-TTY behavior (refusal without --force) is covered
+# in list_remove.atago.yaml; this file covers the confirm/cancel/default-yes
+# branches that a piped stdin can never reach. The pty runtime is POSIX-only, so
+# these scenarios are skipped on Windows. Run with: make e2e
+version: "1"
+
+suite:
+  name: gup remove (interactive, pty)
+
+scenarios:
+  - name: answering y at the confirmation prompt deletes the binary
+    skip:
+      os: windows
+    env: &iso
+      HOME: "${workdir}/home"
+      XDG_CONFIG_HOME: "${workdir}/home/.config"
+      GOBIN: "${workdir}/gobin"
+      GOPATH: "${workdir}/gopath"
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - pty:
+          command: gup remove outdated
+          env: *iso
+          timeout: 30s
+          session:
+            - expect: "Y/n"
+            - send: "y"
+            - send: { key: enter }
+      - assert:
+          exit_code: 0
+          screen:
+            contains: removed
+      - assert:
+          file:
+            path: gobin/outdated
+            exists: false
+
+  - name: answering n at the confirmation prompt keeps the binary
+    skip:
+      os: windows
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - pty:
+          command: gup remove outdated
+          env: *iso
+          timeout: 30s
+          session:
+            - expect: "Y/n"
+            - send: "n"
+            - send: { key: enter }
+      - assert:
+          screen:
+            contains: "cancel removal"
+      - assert:
+          file:
+            path: gobin/outdated
+            exists: true
+
+  - name: pressing enter takes the [Y/n] default and deletes the binary (#146)
+    skip:
+      os: windows
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - pty:
+          command: gup remove outdated
+          env: *iso
+          timeout: 30s
+          session:
+            - expect: "Y/n"
+            - send: { key: enter }
+      - assert:
+          exit_code: 0
+          screen:
+            contains: removed
+      - assert:
+          file:
+            path: gobin/outdated
+            exists: false

--- a/e2e/atago/snapshot.atago.yaml
+++ b/e2e/atago/snapshot.atago.yaml
@@ -1,0 +1,32 @@
+# Golden-output (snapshot) checks (atago v0.3.x). Unlike `contains`, a snapshot
+# pins the EXACT bytes gup emits for a deterministic, offline input, so any
+# unintended change to a machine-readable format is caught. Only fully
+# deterministic outputs are snapshotted here (no version banner, OS/arch, or
+# absolute paths). Refresh intentionally-changed goldens with:
+#   atago run --update-snapshots e2e/atago
+# Run with: make e2e
+version: "1"
+
+suite:
+  name: gup golden output (offline)
+
+scenarios:
+  - name: export --output emits the canonical gup.json for a pinned tool
+    env: &iso
+      HOME: "${workdir}/home"
+      XDG_CONFIG_HOME: "${workdir}/home/.config"
+      GOBIN: "${workdir}/gobin"
+      GOPATH: "${workdir}/gopath"
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: gup pin outdated v1.0.0
+      # The exported JSON (schema_version, import path, pinned version/channel)
+      # is fully determined by the offline fixture, so it is a stable golden.
+      - run:
+          command: gup export --output
+      - assert:
+          exit_code: 0
+          stdout:
+            snapshot: export-pinned-outdated


### PR DESCRIPTION
## Summary

The E2E CI was pinned to atago v0.1.0. This PR upgrades CI to atago v0.3.4 and adds E2E specs that use two v0.3.4 capabilities the older suite could not: a real-PTY step (for the interactive `gup remove` prompt that only appears on a TTY) and golden-output snapshots. All 89 offline scenarios pass; combined unit+E2E coverage stays at ~94.2% (octocov gate 90%).

## Changes

- `.github/workflows/e2e.yml`, `.github/workflows/coverage.yml`: bump setup-atago's installed atago from `v0.1.0` to `v0.3.4`.
- `e2e/atago/remove_interactive.atago.yaml` (new): drives `gup remove` through a real pseudo-terminal via the `pty` step and covers the three interactive-confirmation branches that a piped stdin can never reach — answering `y` (deletes), answering `n` (cancels, binary kept), and pressing Enter to take the `[Y/n]` default (deletes, issue #146). Skipped on Windows because the pty runtime is POSIX-only.
- `e2e/atago/snapshot.atago.yaml` + `e2e/atago/export-pinned-outdated` (new): a golden-output snapshot of `gup export --output` for a pinned tool, pinning the exact canonical `gup.json` bytes rather than a loose substring.
- `CONTRIBUTING.md`: note the atago v0.3.4+ requirement and how to refresh snapshots.

## Design Decisions

- The existing non-TTY `gup remove` refusal (`#323`) is still covered in `list_remove.atago.yaml`; this file deliberately covers the complementary TTY path, which was previously unreachable from an offline spec. The pty session asserts against the vt100-rendered `screen` and the resulting filesystem state, so it verifies both what the user sees and what actually happened.
- Only fully deterministic output is snapshotted. `gup export --output` for an offline fixture yields a fixed JSON (schema_version, import path, pinned version/channel) with no version banner, OS/arch, or absolute paths, so the golden is stable across platforms. The version banner and anything path- or arch-dependent is intentionally left to `contains`/`matches` assertions elsewhere.
- CI E2E runs on ubuntu only, and the pty scenarios carry `skip: { os: windows }`, so a developer running `make e2e` on Windows skips the POSIX-only pty scenarios rather than hitting a hard error.

## Limitations

- The pty scenarios strengthen integration coverage (the interactive confirm/cancel/default flow is now exercised end-to-end through the real binary and a real terminal) but do not raise the coverage percentage, since those branches were already reached by unit tests. Their value is regression protection for the TTY path and the demonstration of the v0.3.4 pty capability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new end-to-end coverage for interactive removal flows, including confirm/cancel behavior and default prompt handling.
  * Added snapshot-based end-to-end coverage for exporting pinned packages.

* **Bug Fixes**
  * Updated end-to-end tooling requirements to a newer version, ensuring offline test specs run reliably.

* **Documentation**
  * Clarified local testing instructions and snapshot refresh steps in the contributor guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->