### PR TITLE
feat(website): add GitHub Pages documentation

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -36,6 +36,8 @@ jobs:
       - name: Configure Pages
         id: pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Build site
         run: hugo --gc --minify --cleanDestinationDir --baseURL "${{ steps.pages.outputs.base_url }}/"

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -50,7 +50,7 @@ jobs:
 
   deploy:
     name: Deploy GitHub Pages
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,0 +1,63 @@
+name: Website
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build GitHub Pages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: "0.164.0"
+          extended: true
+
+      - name: Configure Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Build site
+        run: hugo --gc --minify --cleanDestinationDir --baseURL "${{ steps.pages.outputs.base_url }}/"
+        working-directory: website
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: website/public
+
+  deploy:
+    name: Deploy GitHub Pages
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@ cmd/testdata/gobin_tmp
 # `make coverage` scratch: raw covdata (unit + e2e) and the merged dir. The
 # final cover.out / cover.html are the only kept artifacts.
 .coverage/
+
+# Hugo build output and cache for the documentation website (built by
+# `make website`, published from CI).
+/website/public/
+/website/resources/
+/website/.hugo_build.lock

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test e2e coverage clean vet fmt chkfmt changelog update-tools help coverage-tree
+.PHONY: build test e2e coverage clean vet fmt chkfmt changelog update-tools help coverage-tree website website-serve
 
 APP         = gup
 VERSION     = $(shell git describe --tags --abbrev=0)
@@ -34,6 +34,12 @@ e2e: ## Run offline end-to-end tests against the real CLI (requires atago)
 
 coverage: ## Combine unit + self-hosted E2E coverage into cover.out / cover.html (uses a `go build -cover` gup; scratch under .coverage/)
 	bash ./scripts/coverage.sh
+
+website: ## Build the documentation website into website/public (requires hugo)
+	cd website && hugo --gc --minify --cleanDestinationDir
+
+website-serve: ## Serve the documentation website locally with live reload (requires hugo)
+	cd website && hugo server
 
 vet: ## Start go vet
 	$(GO_VET) $(GO_PACKAGES)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Documentation: [GitHub Pages](https://nao1215.github.io/gup/)
+
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-32-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->

--- a/cmd/docs_drift_test.go
+++ b/cmd/docs_drift_test.go
@@ -219,6 +219,7 @@ func TestCookbook_EveryRecipeSectionIsExercised(t *testing.T) {
 	scenarioPattern := regexp.MustCompile(`^  - name: "([^"]+)"$`)
 	sections := make(map[string]bool)
 	for _, line := range strings.Split(cookbook, "\n") {
+		line = strings.TrimSuffix(line, "\r")
 		match := sectionPattern.FindStringSubmatch(line)
 		if len(match) == 2 && match[1] != "Find a recipe by task" {
 			sections[match[1]] = true
@@ -227,6 +228,7 @@ func TestCookbook_EveryRecipeSectionIsExercised(t *testing.T) {
 
 	covered := make(map[string]bool)
 	for _, line := range strings.Split(spec, "\n") {
+		line = strings.TrimSuffix(line, "\r")
 		match := scenarioPattern.FindStringSubmatch(line)
 		if len(match) != 2 {
 			continue

--- a/cmd/docs_drift_test.go
+++ b/cmd/docs_drift_test.go
@@ -1,0 +1,336 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// The website is intentionally assembled from small, copyable examples and a
+// cookbook. Keep those examples tied to the Cobra command tree: a renamed flag
+// or command must fail this test while the documentation change is still in
+// review.
+type documentedInvocation struct {
+	source string
+	line   int
+	args   []string
+}
+
+func repositoryRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), ".."))
+}
+
+func readRepositoryFile(t *testing.T, root, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(root, name)) //nolint:gosec // test paths are fixed below
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(b)
+}
+
+func shellWords(line string) []string {
+	var words []string
+	var word strings.Builder
+	var quote rune
+	escaped := false
+	flush := func() {
+		if word.Len() == 0 {
+			return
+		}
+		words = append(words, word.String())
+		word.Reset()
+	}
+
+	for _, r := range line {
+		if escaped {
+			word.WriteRune(r)
+			escaped = false
+			continue
+		}
+		if r == '\\' && quote != '\'' {
+			escaped = true
+			continue
+		}
+		if quote != 0 {
+			if r == quote {
+				quote = 0
+			} else {
+				word.WriteRune(r)
+			}
+			continue
+		}
+		switch r {
+		case '\'', '"':
+			quote = r
+		case ' ', '\t':
+			flush()
+		case '#', '|', ';', '&', '>':
+			flush()
+			words = append(words, string(r))
+		default:
+			word.WriteRune(r)
+		}
+	}
+	if escaped {
+		word.WriteRune('\\')
+	}
+	flush()
+	return words
+}
+
+func documentedCommands(source, markdown string) []documentedInvocation {
+	var invocations []documentedInvocation
+	lines := strings.Split(markdown, "\n")
+	inFence := false
+	for lineNumber, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+			inFence = !inFence
+			continue
+		}
+		if !inFence {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "$ ") {
+			trimmed = strings.TrimPrefix(trimmed, "$ ")
+		}
+		words := shellWords(trimmed)
+		for i, word := range words {
+			if word == "#" || word == "|" || word == ";" || word == "&" || word == ">" {
+				break
+			}
+			if strings.HasPrefix(word, "gup:") {
+				continue
+			}
+			if word == "gup" || word == "\\gup" {
+				args := words[i+1:]
+				for j, arg := range args {
+					if arg == "#" || arg == "|" || arg == ";" || arg == "&" || arg == ">" {
+						args = args[:j]
+						break
+					}
+				}
+				invocations = append(invocations, documentedInvocation{
+					source: source,
+					line:   lineNumber + 1,
+					args:   append([]string(nil), args...),
+				})
+				break
+			}
+			if word == "sudo" || strings.HasPrefix(word, "NO_COLOR=") {
+				continue
+			}
+			if word == "go" && i+2 < len(words) && words[i+1] == "run" &&
+				strings.HasPrefix(words[i+2], "github.com/nao1215/gup@") {
+				args := words[i+3:]
+				for j, arg := range args {
+					if arg == "#" || arg == "|" || arg == ";" || arg == "&" || arg == ">" {
+						args = args[:j]
+						break
+					}
+				}
+				invocations = append(invocations, documentedInvocation{
+					source: source,
+					line:   lineNumber + 1,
+					args:   append([]string(nil), args...),
+				})
+				break
+			}
+		}
+	}
+	return invocations
+}
+
+func websiteMarkdownSources(t *testing.T, root string) []string {
+	t.Helper()
+	paths, err := filepath.Glob(filepath.Join(root, "website", "content", "*.md"))
+	if err != nil {
+		t.Fatalf("glob website Markdown: %v", err)
+	}
+	if len(paths) == 0 {
+		t.Fatal("website/content contains no Markdown pages")
+	}
+	sources := make([]string, 0, len(paths))
+	for _, path := range paths {
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			t.Fatalf("make website path relative: %v", err)
+		}
+		sources = append(sources, filepath.ToSlash(rel))
+	}
+	sort.Strings(sources)
+	return sources
+}
+
+func validateDocumentedInvocation(invocation documentedInvocation) error {
+	// man is intentionally not registered on Windows, while the cookbook
+	// documents it for Linux and macOS.
+	if runtime.GOOS == "windows" && len(invocation.args) > 0 && invocation.args[0] == "man" {
+		return nil
+	}
+	root := newRootCmd()
+	command, args, err := root.Find(invocation.args)
+	if err != nil {
+		return err
+	}
+	if err := command.ParseFlags(args); err != nil {
+		return err
+	}
+	return nil
+}
+
+func TestDocs_EveryDocumentedInvocationParses(t *testing.T) {
+	root := repositoryRoot(t)
+	sources := append([]string{"README.md", "doc/cookbook.md"}, websiteMarkdownSources(t, root)...)
+	var invocations []documentedInvocation
+	for _, source := range sources {
+		invocations = append(invocations, documentedCommands(source, readRepositoryFile(t, root, source))...)
+	}
+	if len(invocations) < 50 {
+		t.Fatalf("found only %d documented gup invocations; the extractor or the docs probably regressed", len(invocations))
+	}
+	for _, invocation := range invocations {
+		invocation := invocation
+		t.Run(fmt.Sprintf("%s:%d %s", invocation.source, invocation.line, strings.Join(invocation.args, " ")), func(t *testing.T) {
+			if err := validateDocumentedInvocation(invocation); err != nil {
+				t.Fatalf("%s:%d documents a command the parser rejects: gup %s: %v", invocation.source, invocation.line, strings.Join(invocation.args, " "), err)
+			}
+		})
+	}
+}
+
+func TestCookbook_EveryRecipeSectionIsExercised(t *testing.T) {
+	root := repositoryRoot(t)
+	cookbook := readRepositoryFile(t, root, "doc/cookbook.md")
+	spec := readRepositoryFile(t, root, "e2e/atago/cookbook.atago.yaml")
+
+	sectionPattern := regexp.MustCompile(`^## (.+)$`)
+	scenarioPattern := regexp.MustCompile(`^  - name: "([^"]+)"$`)
+	sections := make(map[string]bool)
+	for _, line := range strings.Split(cookbook, "\n") {
+		match := sectionPattern.FindStringSubmatch(line)
+		if len(match) == 2 && match[1] != "Find a recipe by task" {
+			sections[match[1]] = true
+		}
+	}
+
+	covered := make(map[string]bool)
+	for _, line := range strings.Split(spec, "\n") {
+		match := scenarioPattern.FindStringSubmatch(line)
+		if len(match) != 2 {
+			continue
+		}
+		name := match[1]
+		section, _, ok := strings.Cut(name, ": ")
+		if !ok {
+			t.Errorf("scenario %q does not identify its cookbook section", name)
+			continue
+		}
+		if !sections[section] {
+			t.Errorf("scenario %q names a cookbook section that does not exist", name)
+		}
+		covered[section] = true
+	}
+
+	var missing []string
+	for section := range sections {
+		if !covered[section] {
+			missing = append(missing, section)
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Fatalf("cookbook sections have no executable atago scenario: %s", strings.Join(missing, ", "))
+	}
+}
+
+func markdownHeadingIDs(markdown string) map[string]bool {
+	ids := make(map[string]bool)
+	for _, line := range strings.Split(markdown, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "#") {
+			continue
+		}
+		text := strings.TrimSpace(strings.TrimLeft(line, "#"))
+		text = strings.ToLower(text)
+		text = regexp.MustCompile(`[^a-z0-9]+`).ReplaceAllString(text, "-")
+		ids[strings.Trim(text, "-")] = true
+	}
+	return ids
+}
+
+func TestSite_InternalLinksAndImagesResolve(t *testing.T) {
+	root := repositoryRoot(t)
+	documents := []struct {
+		path string
+	}{
+		{path: "doc/cookbook.md"},
+	}
+	routes := map[string]bool{"/": true, "/cookbook/": true}
+	for _, source := range websiteMarkdownSources(t, root) {
+		name := strings.TrimSuffix(filepath.Base(source), filepath.Ext(source))
+		route := "/"
+		if name != "_index" {
+			route = "/" + name + "/"
+		}
+		routes[route] = true
+		documents = append(documents, struct {
+			path string
+		}{path: source})
+	}
+	linkPattern := regexp.MustCompile(`\]\(([^)\s]+)`) // Markdown destinations cannot contain an unescaped space here.
+
+	for _, document := range documents {
+		markdown := readRepositoryFile(t, root, document.path)
+		headingIDs := markdownHeadingIDs(markdown)
+		for _, match := range linkPattern.FindAllStringSubmatch(markdown, -1) {
+			destination := match[1]
+			if strings.HasPrefix(destination, "http://") || strings.HasPrefix(destination, "https://") ||
+				strings.HasPrefix(destination, "mailto:") || strings.HasPrefix(destination, "//") {
+				continue
+			}
+			path, fragment, _ := strings.Cut(destination, "#")
+			if path == "" {
+				if !headingIDs[fragment] {
+					t.Errorf("%s links to missing heading #%s", document.path, fragment)
+				}
+				continue
+			}
+			if strings.HasPrefix(path, "/img/") {
+				if _, err := os.Stat(filepath.Join(root, "doc", strings.TrimPrefix(path, "/"))); err != nil {
+					t.Errorf("%s references missing image %s: %v", document.path, path, err)
+				}
+				continue
+			}
+			if !strings.HasSuffix(path, "/") {
+				path += "/"
+			}
+			if !routes[path] {
+				t.Errorf("%s links to %s, which is not a page of the site", document.path, destination)
+			}
+		}
+	}
+}
+
+func TestSite_CookbookUsesCommittedSource(t *testing.T) {
+	root := repositoryRoot(t)
+	template := readRepositoryFile(t, root, "website/content/_content.gotmpl")
+	config := readRepositoryFile(t, root, "website/hugo.toml")
+	if !strings.Contains(template, `resources.Get "doc/cookbook.md"`) {
+		t.Error("cookbook page is not generated from doc/cookbook.md")
+	}
+	if !strings.Contains(config, `source = "../doc/cookbook.md"`) {
+		t.Error("doc/cookbook.md is not mounted into the Hugo site")
+	}
+}

--- a/cmd/docs_drift_test.go
+++ b/cmd/docs_drift_test.go
@@ -102,18 +102,16 @@ func documentedCommands(source, markdown string) []documentedInvocation {
 		if !inFence {
 			continue
 		}
-		if strings.HasPrefix(trimmed, "$ ") {
-			trimmed = strings.TrimPrefix(trimmed, "$ ")
-		}
+		trimmed = strings.TrimPrefix(trimmed, "$ ")
 		words := shellWords(trimmed)
 		for i, word := range words {
 			if word == "#" || word == "|" || word == ";" || word == "&" || word == ">" {
 				break
 			}
-			if strings.HasPrefix(word, "gup:") {
+			if strings.HasPrefix(word, testCmdGup+":") {
 				continue
 			}
-			if word == "gup" || word == "\\gup" {
+			if word == testCmdGup || word == "\\"+testCmdGup {
 				args := words[i+1:]
 				for j, arg := range args {
 					if arg == "#" || arg == "|" || arg == ";" || arg == "&" || arg == ">" {
@@ -191,9 +189,10 @@ func validateDocumentedInvocation(invocation documentedInvocation) error {
 }
 
 func TestDocs_EveryDocumentedInvocationParses(t *testing.T) {
+	t.Parallel()
 	root := repositoryRoot(t)
 	sources := append([]string{"README.md", "doc/cookbook.md"}, websiteMarkdownSources(t, root)...)
-	var invocations []documentedInvocation
+	invocations := make([]documentedInvocation, 0, 128)
 	for _, source := range sources {
 		invocations = append(invocations, documentedCommands(source, readRepositoryFile(t, root, source))...)
 	}
@@ -201,8 +200,8 @@ func TestDocs_EveryDocumentedInvocationParses(t *testing.T) {
 		t.Fatalf("found only %d documented gup invocations; the extractor or the docs probably regressed", len(invocations))
 	}
 	for _, invocation := range invocations {
-		invocation := invocation
 		t.Run(fmt.Sprintf("%s:%d %s", invocation.source, invocation.line, strings.Join(invocation.args, " ")), func(t *testing.T) {
+			t.Parallel()
 			if err := validateDocumentedInvocation(invocation); err != nil {
 				t.Fatalf("%s:%d documents a command the parser rejects: gup %s: %v", invocation.source, invocation.line, strings.Join(invocation.args, " "), err)
 			}
@@ -211,6 +210,7 @@ func TestDocs_EveryDocumentedInvocationParses(t *testing.T) {
 }
 
 func TestCookbook_EveryRecipeSectionIsExercised(t *testing.T) {
+	t.Parallel()
 	root := repositoryRoot(t)
 	cookbook := readRepositoryFile(t, root, "doc/cookbook.md")
 	spec := readRepositoryFile(t, root, "e2e/atago/cookbook.atago.yaml")
@@ -271,14 +271,13 @@ func markdownHeadingIDs(markdown string) map[string]bool {
 }
 
 func TestSite_InternalLinksAndImagesResolve(t *testing.T) {
+	t.Parallel()
 	root := repositoryRoot(t)
-	documents := []struct {
-		path string
-	}{
-		{path: "doc/cookbook.md"},
-	}
+	websiteSources := websiteMarkdownSources(t, root)
+	documents := make([]struct{ path string }, 0, len(websiteSources)+1)
+	documents = append(documents, struct{ path string }{path: "doc/cookbook.md"})
 	routes := map[string]bool{"/": true, "/cookbook/": true}
-	for _, source := range websiteMarkdownSources(t, root) {
+	for _, source := range websiteSources {
 		name := strings.TrimSuffix(filepath.Base(source), filepath.Ext(source))
 		route := "/"
 		if name != "_index" {
@@ -324,6 +323,7 @@ func TestSite_InternalLinksAndImagesResolve(t *testing.T) {
 }
 
 func TestSite_CookbookUsesCommittedSource(t *testing.T) {
+	t.Parallel()
 	root := repositoryRoot(t)
 	template := readRepositoryFile(t, root, "website/content/_content.gotmpl")
 	config := readRepositoryFile(t, root, "website/hugo.toml")

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -106,7 +106,7 @@ func removeLoop(p *print.Printer, gobin string, force bool, target []string) int
 				// A failed confirmation read (EOF, closed pipe, ...) is not a
 				// cancellation: report it and fail so the caller does not mistake a
 				// never-confirmed removal for a successful one.
-				p.Err(err)
+				p.Err(fmt.Errorf("confirmation could not be read: %w\nUse --force to skip confirmation", err))
 				result = 1
 				continue
 			}

--- a/doc/cookbook.md
+++ b/doc/cookbook.md
@@ -1,0 +1,394 @@
+# Cookbook
+
+Copyable one-liners for the Go tools in your `$GOBIN`. Every recipe runs as
+shown; swap the tool names for yours.
+
+`go install` drops a binary in `$GOBIN` and then forgets it. gup reads the build
+info stamped into each binary — import path, version, Go toolchain — so the set
+you already installed is the manifest, and there is nothing to declare first.
+
+## Find a recipe by task
+
+| I want to | Go to |
+|:--|:--|
+| See what `go install` left in my `$GOBIN` | [See what you have](#see-what-you-have) |
+| Find out what is out of date | [Find what is out of date](#find-what-is-out-of-date) |
+| Update the whole set at once | [Update everything](#update-everything) |
+| Update some tools and skip others | [Update only some tools](#update-only-some-tools) |
+| Keep one tool on an exact version | [Hold a tool at a version](#hold-a-tool-at-a-version) |
+| Track `@main` instead of a release | [Follow a branch](#follow-a-branch) |
+| Install the same tools on another machine | [Reproduce the set elsewhere](#reproduce-the-set-elsewhere) |
+| Move my tools after a Go upgrade | [Move to a new $GOBIN](#move-to-a-new-gobin) |
+| Delete a tool I no longer use | [Remove a tool](#remove-a-tool) |
+| Drive gup from a script or from CI | [Script it](#script-it) |
+| Work out why an update failed | [When an update fails](#when-an-update-fails) |
+| Get tab completion and man pages | [Completion and man pages](#completion-and-man-pages) |
+
+## See what you have
+
+Every binary under `$GOBIN`, with the import path and version it was built from:
+
+```shell
+gup list
+```
+
+![list](/img/list.gif)
+
+The same as JSON, one object per tool:
+
+```shell
+gup list --json
+```
+
+```json
+[
+  {
+    "name": "gup",
+    "import_path": "github.com/nao1215/gup",
+    "module_path": "github.com/nao1215/gup",
+    "channel": "latest",
+    "current_version": "v1.0.0",
+    "current_go_version": "go1.26.4",
+    "installed_go_version": "go1.26.4",
+    "status": "installed"
+  }
+]
+```
+
+Just the names, for the next command in the pipe:
+
+```shell
+gup list --json | jq -r '.[].name'
+```
+
+A binary that was not installed by `go install` is reported, not hidden — it
+simply has no import path to reinstall from.
+
+## Find what is out of date
+
+`check` compares each tool against its module and against the Go toolchain you
+are running now. It never installs anything:
+
+```shell
+gup check
+```
+
+Only the tools that need something, plus a one-line summary:
+
+```shell
+gup check --quiet
+```
+
+```text
+github.com/nao1215/gup (current: v0.7.0, latest: v0.7.1 / go1.26.4)
+
+If you want to update binaries, run the following command.
+           $ gup update gup
+gup: 1 update available, 8 up-to-date, 0 failed
+```
+
+Check two tools instead of the whole set:
+
+```shell
+gup check gopls staticcheck
+```
+
+The names of everything with an update waiting:
+
+```shell
+gup check --json | jq -r '.[] | select(.status == "update-available") | .name'
+```
+
+A tool built with an older Go toolchain counts as out of date, because it is.
+To ignore that and compare versions only:
+
+```shell
+gup check --ignore-go-update
+```
+
+`check` exits `0` even when it finds updates — finding them is the job, not a
+failure.
+
+## Update everything
+
+```shell
+gup update
+```
+
+![update](/img/update.gif)
+
+gup runs the updates in parallel, so the whole set finishes in about the time
+the slowest build takes.
+
+See what would happen first:
+
+```shell
+gup update --dry-run
+```
+
+Version updates only, leaving Go-toolchain rebuilds alone:
+
+```shell
+gup update --ignore-go-update
+```
+
+Fewer parallel builds, and a ceiling on any single one:
+
+```shell
+gup update --jobs 4 --timeout 5m
+```
+
+Tell me when the long run is done:
+
+```shell
+gup update --notify
+```
+
+## Update only some tools
+
+Name them:
+
+```shell
+gup update gopls staticcheck
+```
+
+Or update everything except the ones you name:
+
+```shell
+gup update --exclude gopls,golangci-lint
+```
+
+`--exclude` combines with `--dry-run`, so you can confirm the skip list before
+anything is built:
+
+```shell
+gup update --exclude gopls --dry-run
+```
+
+## Hold a tool at a version
+
+Pin the tool your CI is pinned to, then keep updating everything else:
+
+```shell
+gup pin golangci-lint v1.62.0
+gup update
+```
+
+The `tool@version` form works too:
+
+```shell
+gup pin golangci-lint@v1.62.0
+```
+
+A pinned tool is installed as `go install <import_path>@<version>` and is never
+resolved to `@latest`. The pin lives in `gup.json` under `channel: "pinned"`, so
+it survives `export`/`import`.
+
+Which tools are pinned, and to what:
+
+```shell
+gup check --json | jq -r '.[] | select(.channel == "pinned") | "\(.name) \(.pinned_version)"'
+```
+
+`gup check` reports a pinned tool as `pinned` when it sits at its version, and
+`pin-mismatch` when something moved it. Let it float again with:
+
+```shell
+gup unpin golangci-lint
+```
+
+## Follow a branch
+
+Some tools ship from a branch, not a tag:
+
+```shell
+gup update --main gup
+gup update --master sqly
+gup update --latest air
+```
+
+`--main` falls back to `@master` only when the repository has no `main` branch.
+A build failure on `@main` is reported as a build failure; it never silently
+installs `@master` instead.
+
+The channel is written to `gup.json` and reused by later runs, so you set it
+once:
+
+```shell
+gup update --main gup,lazygit --master sqly --latest air
+```
+
+After that, a plain `gup update` keeps each tool on the channel you chose.
+
+## Reproduce the set elsewhere
+
+On the machine that has the tools:
+
+```shell
+gup export
+```
+
+On the machine that wants them:
+
+```shell
+gup import
+```
+
+`export` writes `$XDG_CONFIG_HOME/gup/gup.json`; `import` reads it (or `./gup.json`),
+and installs the exact version recorded for each tool. Pinned tools stay pinned.
+
+Keep the file in your dotfiles instead:
+
+```shell
+gup export --output > gup.json
+gup import --file gup.json
+```
+
+Check what an import would install before it installs it:
+
+```shell
+gup import --file gup.json --dry-run
+```
+
+## Move to a new $GOBIN
+
+When a Go upgrade changes where `$GOBIN` points — this happens with
+[mise](https://mise.jdx.dev/) on every Go version — the old tools are still on
+disk, just invisible to the new toolchain. Reinstall them into the new
+directory, at the versions they already had:
+
+```shell
+gup migrate ~/.local/share/mise/installs/go/1.24.0/bin ~/.local/share/mise/installs/go/1.25.0/bin
+```
+
+Only some of them:
+
+```shell
+gup migrate /old/gobin /new/gobin gopls air
+```
+
+`migrate` is add-only: it never deletes anything in the destination, and it
+skips a binary that is already there. Look before you leap, then overwrite on
+purpose:
+
+```shell
+gup migrate /old/gobin /new/gobin --dry-run
+gup migrate /old/gobin /new/gobin --force
+```
+
+Local `devel` builds and binaries with no resolvable version are skipped rather
+than upgraded, so nothing you built by hand is quietly replaced.
+
+## Remove a tool
+
+`remove` asks before each deletion:
+
+```shell
+gup remove subaru ubume
+```
+
+```text
+gup:CHECK: remove /home/nao/.go/bin/subaru? [Y/n] Y
+removed /home/nao/.go/bin/subaru
+```
+
+Do not ask:
+
+```shell
+gup remove --force gal
+```
+
+With no terminal to ask on — a pipe, a CI job — `remove` fails fast instead of
+blocking forever on a prompt nobody can answer. Pass `--force` there.
+
+## Script it
+
+`list`, `check`, and `update` all take `--json`, and the array stays valid JSON
+even when some packages fail (those get `"status": "error"`):
+
+```shell
+gup check --json > check.json
+```
+
+Report only the failures, with their message:
+
+```shell
+gup update --json | jq -r '.[] | select(.status == "error") | "\(.name): \(.error)"'
+```
+
+Fail a CI job when anything is behind:
+
+```shell
+test -z "$(gup check --json | jq -r '.[] | select(.status == "update-available") | .name')"
+```
+
+Errors always go to STDERR, so STDOUT stays pure JSON and can be piped straight
+into `jq`.
+
+For human-readable logs, drop the noise and the escape codes:
+
+```shell
+gup update --quiet --no-color
+```
+
+```shell
+NO_COLOR=1 gup update
+```
+
+An empty `$GOBIN` is a normal first run, not an error: `list`, `check`, and
+`update` exit `0` (and print `[]` with `--json`).
+
+## When an update fails
+
+gup turns the Go toolchain's output into one next step, printed on STDERR after
+the error:
+
+```text
+gup:ERROR: [1/1] tool: can't install gup.test/moved/cmd/tool:
+go: gup.test/moved/cmd/tool@latest: module gup.test/moved@latest found (v1.1.0), but does not contain package gup.test/moved/cmd/tool
+gup:HINT : The module no longer provides this command at its import path. The project likely moved to a new major version (e.g. a `/v2` module path) or relocated the command; check its current install instructions and reinstall with the new path.
+```
+
+The same text is the `hint` field under `--json`, so a script can collect them:
+
+```shell
+gup update --json | jq -r '.[] | select(.hint) | "\(.name): \(.hint)"'
+```
+
+Hints cover major-version moves, relocated commands, `replace` directives,
+binaries that never came from `go install`, missing branches and tags,
+unreachable or private repositories, permission and network errors, and a Go
+toolchain that is too old. When gup has nothing reliable to add, it says
+nothing.
+
+A failure is per-package: the other tools in the run still update, and the
+process exits non-zero so CI notices.
+
+## Completion and man pages
+
+Install completion for the shell you are in:
+
+```shell
+gup completion --install
+```
+
+Or print it and place it yourself:
+
+```shell
+gup completion bash > gup.bash
+gup completion zsh > _gup
+gup completion fish > gup.fish
+gup completion powershell > gup.ps1
+```
+
+Completion is not just subcommands: `gup update`, `gup remove`, and `gup pin`
+complete the binary names actually present in your `$GOBIN`.
+
+Man pages, on Linux and macOS:
+
+```shell
+sudo gup man
+```
+
+`man` honors `MANPATH` when it is set, and fails with a clear error instead of a
+stack trace when the target directory is not writable.

--- a/e2e/atago/cookbook.atago.yaml
+++ b/e2e/atago/cookbook.atago.yaml
@@ -1,0 +1,768 @@
+# The recipes published on https://nao1215.github.io/gup/cookbook/ (the
+# committed doc/cookbook.md), run against the real binary so a command a reader
+# copies off the site cannot silently stop working.
+#
+# Every scenario name starts with the "## " section title it comes from,
+# followed by ": ". TestCookbook_EverySectionIsExercised (cmd/docs_drift_test.go)
+# reads both files and fails when a section has no scenario here, or a scenario
+# names a section the cookbook no longer has - so the mapping cannot rot and no
+# hand-maintained list has to be kept in step.
+#
+# The recipes name real-world tools (gopls, golangci-lint); offline, the fixture
+# modules served by e2e/testproxy stand in for them. The command SHAPE is what is
+# under test: the flags, their combinations, the exit codes, and the output a
+# reader is told to pipe into jq. Run with: make e2e
+version: "1"
+
+suite:
+  name: gup cookbook recipes (offline)
+
+scenarios:
+  # ---------------------------------------------------------------- See what you have
+  - name: "See what you have: gup list names the import path and version"
+    env: &iso
+      HOME: "${workdir}/home"
+      XDG_CONFIG_HOME: "${workdir}/home/.config"
+      GOBIN: "${workdir}/gobin"
+      GOPATH: "${workdir}/gopath"
+    steps:
+      - run:
+          command: go install gup.test/uptodate@v1.0.0
+      - run:
+          command: gup list
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - uptodate
+              - gup.test/uptodate
+              - v1.0.0
+
+  - name: "See what you have: gup list --json carries the fields the recipe pipes into jq"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/uptodate@v1.0.0
+      - run:
+          command: gup list --json
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              path: "$[0].name"
+              equals: uptodate
+      - assert:
+          stdout:
+            json:
+              path: "$[0].import_path"
+              equals: gup.test/uptodate
+      - assert:
+          stdout:
+            json:
+              path: "$[0].channel"
+              equals: latest
+      - assert:
+          stdout:
+            json:
+              path: "$[0].status"
+              equals: installed
+
+  # ------------------------------------------------------- Find what is out of date
+  # The front page of the site quotes this run: the header line, a per-binary
+  # line, and the closing suggestion. All three are pinned here.
+  - name: "Find what is out of date: gup check reports without installing anything"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: gup check
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - "check binary under $GOPATH/bin or $GOBIN"
+              - "gup.test/outdated"
+              - "If you want to update binaries, run the following command."
+              - "$ gup update outdated"
+      # check installs nothing: the binary is still the version it was.
+      - run:
+          command: go version -m gobin/outdated
+      - assert:
+          stdout:
+            contains: v1.0.0
+
+  - name: "Find what is out of date: --quiet drops the up-to-date lines and adds a summary"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: go install gup.test/uptodate@v1.0.0
+      - run:
+          command: gup check --quiet
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - "gup.test/outdated"
+              - "1 update available"
+      - assert:
+          stdout:
+            not_contains: "gup.test/uptodate"
+
+  - name: "Find what is out of date: naming binaries checks only those"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: go install gup.test/uptodate@v1.0.0
+      - run:
+          command: gup check uptodate
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "gup.test/uptodate"
+      - assert:
+          stdout:
+            not_contains: "gup.test/outdated"
+
+  - name: "Find what is out of date: --json selects the update-available names"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: gup check --json
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              path: "$[0].status"
+              equals: update-available
+      - assert:
+          stdout:
+            json:
+              path: "$[0].latest_version"
+              equals: v1.1.0
+
+  - name: "Find what is out of date: --ignore-go-update compares versions only"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/uptodate@v1.0.0
+      - run:
+          command: gup check --ignore-go-update
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "gup.test/uptodate"
+
+  # ------------------------------------------------------------- Update everything
+  - name: "Update everything: gup update brings the whole set up to date"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: gup update
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "update binary under $GOPATH/bin or $GOBIN"
+      - run:
+          command: go version -m gobin/outdated
+      - assert:
+          stdout:
+            contains: v1.1.0
+
+  - name: "Update everything: --dry-run changes nothing on disk"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: gup update --dry-run
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: outdated
+      - run:
+          command: go version -m gobin/outdated
+      - assert:
+          stdout:
+            contains: v1.0.0
+
+  - name: "Update everything: --jobs and --timeout are accepted together"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: gup update --jobs 4 --timeout 5m
+      - assert:
+          exit_code: 0
+      - run:
+          command: go version -m gobin/outdated
+      - assert:
+          stdout:
+            contains: v1.1.0
+
+  - name: "Update everything: --ignore-go-update still installs a newer version"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: gup update --ignore-go-update
+      - assert:
+          exit_code: 0
+      - run:
+          command: go version -m gobin/outdated
+      - assert:
+          stdout:
+            contains: v1.1.0
+
+  # -------------------------------------------------------- Update only some tools
+  - name: "Update only some tools: naming a binary leaves the others alone"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: go install gup.test/pinnable@v1.0.0
+      - run:
+          command: gup update outdated
+      - assert:
+          exit_code: 0
+      - run:
+          command: go version -m gobin/pinnable
+      - assert:
+          stdout:
+            contains: v1.0.0
+
+  - name: "Update only some tools: --exclude skips the named binary"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: go install gup.test/pinnable@v1.0.0
+      - run:
+          command: gup update --exclude outdated
+      - assert:
+          exit_code: 0
+      - run:
+          command: go version -m gobin/outdated
+      - assert:
+          stdout:
+            contains: v1.0.0
+      - run:
+          command: go version -m gobin/pinnable
+      - assert:
+          stdout:
+            contains: v1.1.0
+
+  - name: "Update only some tools: --exclude combines with --dry-run"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: go install gup.test/uptodate@v1.0.0
+      - run:
+          command: gup update --exclude outdated --dry-run
+      - assert:
+          exit_code: 0
+      - run:
+          command: go version -m gobin/outdated
+      - assert:
+          stdout:
+            contains: v1.0.0
+
+  # ------------------------------------------------------ Hold a tool at a version
+  - name: "Hold a tool at a version: a pinned tool stays put while the rest update"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/pinnable@v1.0.0
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: gup pin pinnable v1.0.0
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "Pinned pinnable to v1.0.0"
+      - run:
+          command: gup update
+      - assert:
+          exit_code: 0
+      - run:
+          command: go version -m gobin/pinnable
+      - assert:
+          stdout:
+            contains: v1.0.0
+      # The unpinned tool in the same run still moved.
+      - run:
+          command: go version -m gobin/outdated
+      - assert:
+          stdout:
+            contains: v1.1.0
+
+  - name: "Hold a tool at a version: the tool@version form records the same pin"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/pinnable@v1.0.0
+      - run:
+          command: gup pin pinnable@v1.0.0
+      - assert:
+          exit_code: 0
+          file:
+            path: home/.config/gup/gup.json
+            contains: '"channel": "pinned"'
+
+  - name: "Hold a tool at a version: --json reports the pin the recipe greps for"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/pinnable@v1.0.0
+      - run:
+          command: gup pin pinnable v1.0.0
+      - run:
+          command: gup check --json
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              path: "$[0].channel"
+              equals: pinned
+      - assert:
+          stdout:
+            json:
+              path: "$[0].pinned_version"
+              equals: v1.0.0
+      - assert:
+          stdout:
+            json:
+              path: "$[0].status"
+              equals: pinned
+
+  - name: "Hold a tool at a version: unpin lets it move again"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/pinnable@v1.0.0
+      - run:
+          command: gup pin pinnable v1.0.0
+      - run:
+          command: gup unpin pinnable
+      - assert:
+          exit_code: 0
+      - run:
+          command: gup update pinnable
+      - assert:
+          exit_code: 0
+      - run:
+          command: go version -m gobin/pinnable
+      - assert:
+          stdout:
+            contains: v1.1.0
+
+  # ---------------------------------------------------------------- Follow a branch
+  - name: "Follow a branch: --main, --master and --latest pick the source per tool"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/maintool@main
+      - run:
+          command: go install gup.test/mastertool@master
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: gup update --main maintool --master mastertool --latest outdated
+      - assert:
+          exit_code: 0
+          file:
+            path: gobin/maintool
+            exists: true
+      - assert:
+          file:
+            path: gobin/mastertool
+            exists: true
+      - run:
+          command: go version -m gobin/outdated
+      - assert:
+          stdout:
+            contains: v1.1.0
+
+  - name: "Follow a branch: the channel is saved, so a later plain update reuses it"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/maintool@main
+      - run:
+          command: gup update --main maintool
+      - assert:
+          exit_code: 0
+          file:
+            path: home/.config/gup/gup.json
+            contains: '"channel": "main"'
+      # No --main this time: the saved channel is what drives the run.
+      - run:
+          command: gup update
+      - assert:
+          exit_code: 0
+          file:
+            path: home/.config/gup/gup.json
+            contains: '"channel": "main"'
+
+  # ------------------------------------------------------- Reproduce the set elsewhere
+  - name: "Reproduce the set elsewhere: export writes the set and import installs it"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/uptodate@v1.0.0
+      - run:
+          command: gup export
+      - assert:
+          exit_code: 0
+          file:
+            path: home/.config/gup/gup.json
+            contains: gup.test/uptodate
+      # A second machine: a fresh GOBIN reading the same config.
+      - run:
+          command: gup import
+          env:
+            GOBIN: "${workdir}/gobin2"
+      - assert:
+          exit_code: 0
+          file:
+            path: gobin2/uptodate
+            exists: true
+
+  - name: "Reproduce the set elsewhere: --output prints the config for your dotfiles"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/uptodate@v1.0.0
+      - run:
+          command: gup export --output
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - '"schema_version"'
+              - gup.test/uptodate
+
+  - name: "Reproduce the set elsewhere: import --dry-run installs nothing"
+    env: *iso
+    steps:
+      - fixture:
+          file: gup.json
+          content: |
+            {"schema_version":1,"packages":[{"name":"uptodate","import_path":"gup.test/uptodate","version":"v1.0.0","channel":"latest"}]}
+      - run:
+          command: gup import --file "${workdir}/gup.json" --dry-run
+      - assert:
+          exit_code: 0
+          file:
+            path: gobin/uptodate
+            exists: false
+
+  # --------------------------------------------------------------- Move to a new $GOBIN
+  - name: "Move to a new $GOBIN: migrate reinstalls at the recorded versions"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+          env:
+            GOBIN: "${workdir}/old"
+      - run:
+          command: gup migrate "${workdir}/old" "${workdir}/new"
+      - assert:
+          exit_code: 0
+          file:
+            path: new/outdated
+            exists: true
+      # The recorded version, not @latest: v1.1.0 exists and was NOT taken.
+      - run:
+          command: go version -m new/outdated
+      - assert:
+          stdout:
+            contains: v1.0.0
+      # Add-only: the source directory is left alone.
+      - assert:
+          file:
+            path: old/outdated
+            exists: true
+
+  - name: "Move to a new $GOBIN: naming binaries migrates only those"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+          env:
+            GOBIN: "${workdir}/old"
+      - run:
+          command: go install gup.test/uptodate@v1.0.0
+          env:
+            GOBIN: "${workdir}/old"
+      - run:
+          command: gup migrate "${workdir}/old" "${workdir}/new" outdated
+      - assert:
+          exit_code: 0
+          file:
+            path: new/outdated
+            exists: true
+      - assert:
+          file:
+            path: new/uptodate
+            exists: false
+
+  - name: "Move to a new $GOBIN: --dry-run plans it, --force overwrites on purpose"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+          env:
+            GOBIN: "${workdir}/old"
+      - run:
+          command: gup migrate "${workdir}/old" "${workdir}/new" --dry-run
+      - assert:
+          exit_code: 0
+          file:
+            path: new/outdated
+            exists: false
+      - run:
+          command: gup migrate "${workdir}/old" "${workdir}/new"
+      - assert:
+          exit_code: 0
+      - run:
+          command: gup migrate "${workdir}/old" "${workdir}/new" --force
+      - assert:
+          exit_code: 0
+          file:
+            path: new/outdated
+            exists: true
+
+  # ------------------------------------------------------------------- Remove a tool
+  - name: "Remove a tool: --force deletes it without asking"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: gup remove --force outdated
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: removed
+          file:
+            path: gobin/outdated
+            exists: false
+
+  - name: "Remove a tool: without a terminal it fails fast instead of blocking"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      # No PTY here, so stdin is not a terminal: the recipe's warning about CI.
+      - run:
+          command: gup remove outdated
+      - assert:
+          exit_code: 1
+          stderr:
+            contains: "--force"
+      - assert:
+          file:
+            path: gobin/outdated
+            exists: true
+
+  # ------------------------------------------------------------------------ Script it
+  - name: "Script it: --json stays parseable while a package fails"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: go install gup.test/moved/cmd/tool@v1.0.0
+      - run:
+          command: gup update --json
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - '"status": "error"'
+              - '"status": "updated"'
+
+  - name: "Script it: --quiet --no-color emits neither noise nor escape codes"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/uptodate@v1.0.0
+      - run:
+          command: gup update --quiet --no-color
+      - assert:
+          exit_code: 0
+          stdout:
+            not_matches: "\\["
+      - assert:
+          stdout:
+            contains: "up-to-date"
+
+  - name: "Script it: NO_COLOR is honored like the flag"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/uptodate@v1.0.0
+      - run:
+          command: gup update
+          env:
+            NO_COLOR: "1"
+      - assert:
+          exit_code: 0
+          stdout:
+            not_matches: "\\["
+
+  - name: "Script it: an empty GOBIN is a first run, not an error"
+    env: *iso
+    steps:
+      - run:
+          shell: true
+          command: mkdir -p ${workdir}/gobin
+      - run:
+          command: gup check --json
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "[]"
+      - run:
+          command: gup update
+      - assert:
+          exit_code: 0
+
+  # ------------------------------------------------------------- When an update fails
+  - name: "When an update fails: the hint names the next step on stderr"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/moved/cmd/tool@v1.0.0
+      - run:
+          command: gup update tool
+      - assert:
+          exit_code: 1
+          stderr:
+            contains:
+              - "gup:ERROR"
+              - "does not contain package"
+              - "gup:HINT"
+              - "major version"
+
+  - name: "When an update fails: the same text is the --json hint field"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/moved/cmd/tool@v1.0.0
+      - run:
+          command: gup update --json
+      - assert:
+          exit_code: 1
+          stdout:
+            json:
+              path: "$[0].status"
+              equals: error
+      - assert:
+          stdout:
+            contains: '"hint"'
+
+  - name: "When an update fails: the other tools in the run still update"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: go install gup.test/moved/cmd/tool@v1.0.0
+      - run:
+          command: gup update
+      - assert:
+          exit_code: 1
+      - run:
+          command: go version -m gobin/outdated
+      - assert:
+          stdout:
+            contains: v1.1.0
+
+  # ------------------------------------------------------- Completion and man pages
+  - name: "Completion and man pages: --install writes the files the shells read"
+    env: *iso
+    steps:
+      - run:
+          shell: true
+          command: mkdir -p ${workdir}/home
+      - run:
+          command: gup completion --install
+          env:
+            SHELL: /bin/bash
+      - assert:
+          exit_code: 0
+          file:
+            path: home/.local/share/bash-completion/completions/gup
+            exists: true
+
+  - name: "Completion and man pages: each shell script is printed to STDOUT"
+    env: *iso
+    steps:
+      - run:
+          command: gup completion bash
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "# bash completion V2 for gup"
+      - run:
+          command: gup completion zsh
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "#compdef gup"
+      - run:
+          command: gup completion fish
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "fish completion for gup"
+      - run:
+          command: gup completion powershell
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "Register-ArgumentCompleter"
+
+  - name: "Completion and man pages: completion offers the binaries in this GOBIN"
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+      - run:
+          command: gup __complete update ""
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: outdated
+
+  - name: "Completion and man pages: man writes gzipped pages under MANPATH"
+    env: *iso
+    steps:
+      - run:
+          command: gup man
+          env:
+            MANPATH: "${workdir}/man"
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: Generate
+          file:
+            path: man/man1/gup.1.gz
+            exists: true

--- a/website/assets/css/chroma.css
+++ b/website/assets/css/chroma.css
@@ -1,0 +1,159 @@
+/* Generated using: hugo gen chromastyles --style=github */
+
+/* Background */ .bg { background-color:#f7f7f7; }
+/* PreWrapper */ .chroma { background-color:#f7f7f7;-webkit-text-size-adjust:none; }
+/* Error */ .chroma .err { color:#f6f8fa;background-color:#82071e }
+/* LineLink */ .chroma .lnlinks { outline:none;text-decoration:none;color:inherit }
+/* LineTableTD */ .chroma .lntd { vertical-align:top;padding:0;margin:0;border:0; }
+/* LineTable */ .chroma .lntable { border-spacing:0;padding:0;margin:0;border:0; }
+/* LineHighlight */ .chroma .hl { background-color:#dedede }
+/* LineNumbersTable */ .chroma .lnt { white-space:pre;-webkit-user-select:none;user-select:none;margin-right:0.4em;padding:0 0.4em 0 0.4em;color:#7f7f7f }
+/* LineNumbers */ .chroma .ln { white-space:pre;-webkit-user-select:none;user-select:none;margin-right:0.4em;padding:0 0.4em 0 0.4em;color:#7f7f7f }
+/* Line */ .chroma .line { display:flex; }
+/* Keyword */ .chroma .k { color:#cf222e }
+/* KeywordConstant */ .chroma .kc { color:#cf222e }
+/* KeywordDeclaration */ .chroma .kd { color:#cf222e }
+/* KeywordNamespace */ .chroma .kn { color:#cf222e }
+/* KeywordPseudo */ .chroma .kp { color:#cf222e }
+/* KeywordReserved */ .chroma .kr { color:#cf222e }
+/* KeywordType */ .chroma .kt { color:#cf222e }
+/* NameAttribute */ .chroma .na { color:#1f2328 }
+/* NameClass */ .chroma .nc { color:#1f2328 }
+/* NameConstant */ .chroma .no { color:#0550ae }
+/* NameDecorator */ .chroma .nd { color:#0550ae }
+/* NameEntity */ .chroma .ni { color:#6639ba }
+/* NameLabel */ .chroma .nl { color:#900;font-weight:bold }
+/* NameNamespace */ .chroma .nn { color:#24292e }
+/* NameOther */ .chroma .nx { color:#1f2328 }
+/* NameTag */ .chroma .nt { color:#0550ae }
+/* NameBuiltin */ .chroma .nb { color:#6639ba }
+/* NameBuiltinPseudo */ .chroma .bp { color:#6a737d }
+/* NameVariable */ .chroma .nv { color:#953800 }
+/* NameVariableClass */ .chroma .vc { color:#953800 }
+/* NameVariableGlobal */ .chroma .vg { color:#953800 }
+/* NameVariableInstance */ .chroma .vi { color:#953800 }
+/* NameVariableMagic */ .chroma .vm { color:#953800 }
+/* NameFunction */ .chroma .nf { color:#6639ba }
+/* NameFunctionMagic */ .chroma .fm { color:#6639ba }
+/* LiteralString */ .chroma .s { color:#0a3069 }
+/* LiteralStringAffix */ .chroma .sa { color:#0a3069 }
+/* LiteralStringBacktick */ .chroma .sb { color:#0a3069 }
+/* LiteralStringChar */ .chroma .sc { color:#0a3069 }
+/* LiteralStringDelimiter */ .chroma .dl { color:#0a3069 }
+/* LiteralStringDoc */ .chroma .sd { color:#0a3069 }
+/* LiteralStringDouble */ .chroma .s2 { color:#0a3069 }
+/* LiteralStringEscape */ .chroma .se { color:#0a3069 }
+/* LiteralStringHeredoc */ .chroma .sh { color:#0a3069 }
+/* LiteralStringInterpol */ .chroma .si { color:#0a3069 }
+/* LiteralStringOther */ .chroma .sx { color:#0a3069 }
+/* LiteralStringRegex */ .chroma .sr { color:#0a3069 }
+/* LiteralStringSingle */ .chroma .s1 { color:#0a3069 }
+/* LiteralStringSymbol */ .chroma .ss { color:#032f62 }
+/* LiteralNumber */ .chroma .m { color:#0550ae }
+/* LiteralNumberBin */ .chroma .mb { color:#0550ae }
+/* LiteralNumberFloat */ .chroma .mf { color:#0550ae }
+/* LiteralNumberHex */ .chroma .mh { color:#0550ae }
+/* LiteralNumberInteger */ .chroma .mi { color:#0550ae }
+/* LiteralNumberIntegerLong */ .chroma .il { color:#0550ae }
+/* LiteralNumberOct */ .chroma .mo { color:#0550ae }
+/* Operator */ .chroma .o { color:#0550ae }
+/* OperatorWord */ .chroma .ow { color:#0550ae }
+/* OperatorReserved */ .chroma .or { color:#0550ae }
+/* Punctuation */ .chroma .p { color:#1f2328 }
+/* Comment */ .chroma .c { color:#57606a }
+/* CommentHashbang */ .chroma .ch { color:#57606a }
+/* CommentMultiline */ .chroma .cm { color:#57606a }
+/* CommentSingle */ .chroma .c1 { color:#57606a }
+/* CommentSpecial */ .chroma .cs { color:#57606a }
+/* CommentPreproc */ .chroma .cp { color:#57606a }
+/* CommentPreprocFile */ .chroma .cpf { color:#57606a }
+/* GenericDeleted */ .chroma .gd { color:#82071e;background-color:#ffebe9 }
+/* GenericEmph */ .chroma .ge { color:#1f2328 }
+/* GenericInserted */ .chroma .gi { color:#116329;background-color:#dafbe1 }
+/* GenericOutput */ .chroma .go { color:#1f2328 }
+/* GenericUnderline */ .chroma .gl { text-decoration:underline }
+/* TextWhitespace */ .chroma .w { color:#fff }
+
+@media (prefers-color-scheme: dark) {
+  /* Generated using: hugo gen chromastyles --style=github-dark */
+
+  /* Background */ .bg { color:#e6edf3;background-color:#0d1117; }
+  /* PreWrapper */ .chroma { color:#e6edf3;background-color:#0d1117;-webkit-text-size-adjust:none; }
+  /* Error */ .chroma .err { color:#f85149 }
+  /* LineLink */ .chroma .lnlinks { outline:none;text-decoration:none;color:inherit }
+  /* LineTableTD */ .chroma .lntd { vertical-align:top;padding:0;margin:0;border:0; }
+  /* LineTable */ .chroma .lntable { border-spacing:0;padding:0;margin:0;border:0; }
+  /* LineHighlight */ .chroma .hl { background-color:#6e7681 }
+  /* LineNumbersTable */ .chroma .lnt { white-space:pre;-webkit-user-select:none;user-select:none;margin-right:0.4em;padding:0 0.4em 0 0.4em;color:#737679 }
+  /* LineNumbers */ .chroma .ln { white-space:pre;-webkit-user-select:none;user-select:none;margin-right:0.4em;padding:0 0.4em 0 0.4em;color:#6e7681 }
+  /* Line */ .chroma .line { display:flex; }
+  /* Keyword */ .chroma .k { color:#ff7b72 }
+  /* KeywordConstant */ .chroma .kc { color:#79c0ff }
+  /* KeywordDeclaration */ .chroma .kd { color:#ff7b72 }
+  /* KeywordNamespace */ .chroma .kn { color:#ff7b72 }
+  /* KeywordPseudo */ .chroma .kp { color:#79c0ff }
+  /* KeywordReserved */ .chroma .kr { color:#ff7b72 }
+  /* KeywordType */ .chroma .kt { color:#ff7b72 }
+  /* NameClass */ .chroma .nc { color:#f0883e;font-weight:bold }
+  /* NameConstant */ .chroma .no { color:#79c0ff;font-weight:bold }
+  /* NameDecorator */ .chroma .nd { color:#d2a8ff;font-weight:bold }
+  /* NameEntity */ .chroma .ni { color:#ffa657 }
+  /* NameException */ .chroma .ne { color:#f0883e;font-weight:bold }
+  /* NameLabel */ .chroma .nl { color:#79c0ff;font-weight:bold }
+  /* NameNamespace */ .chroma .nn { color:#ff7b72 }
+  /* NameOther */ .chroma .nx { color:#e6edf3 }
+  /* NameProperty */ .chroma .py { color:#79c0ff }
+  /* NameTag */ .chroma .nt { color:#7ee787 }
+  /* NameVariable */ .chroma .nv { color:#79c0ff }
+  /* NameVariableClass */ .chroma .vc { color:#79c0ff }
+  /* NameVariableGlobal */ .chroma .vg { color:#79c0ff }
+  /* NameVariableInstance */ .chroma .vi { color:#79c0ff }
+  /* NameVariableMagic */ .chroma .vm { color:#79c0ff }
+  /* NameFunction */ .chroma .nf { color:#d2a8ff;font-weight:bold }
+  /* NameFunctionMagic */ .chroma .fm { color:#d2a8ff;font-weight:bold }
+  /* Literal */ .chroma .l { color:#a5d6ff }
+  /* LiteralDate */ .chroma .ld { color:#79c0ff }
+  /* LiteralString */ .chroma .s { color:#a5d6ff }
+  /* LiteralStringAffix */ .chroma .sa { color:#79c0ff }
+  /* LiteralStringBacktick */ .chroma .sb { color:#a5d6ff }
+  /* LiteralStringChar */ .chroma .sc { color:#a5d6ff }
+  /* LiteralStringDelimiter */ .chroma .dl { color:#79c0ff }
+  /* LiteralStringDoc */ .chroma .sd { color:#a5d6ff }
+  /* LiteralStringDouble */ .chroma .s2 { color:#a5d6ff }
+  /* LiteralStringEscape */ .chroma .se { color:#79c0ff }
+  /* LiteralStringHeredoc */ .chroma .sh { color:#79c0ff }
+  /* LiteralStringInterpol */ .chroma .si { color:#a5d6ff }
+  /* LiteralStringOther */ .chroma .sx { color:#a5d6ff }
+  /* LiteralStringRegex */ .chroma .sr { color:#79c0ff }
+  /* LiteralStringSingle */ .chroma .s1 { color:#a5d6ff }
+  /* LiteralStringSymbol */ .chroma .ss { color:#a5d6ff }
+  /* LiteralNumber */ .chroma .m { color:#a5d6ff }
+  /* LiteralNumberBin */ .chroma .mb { color:#a5d6ff }
+  /* LiteralNumberFloat */ .chroma .mf { color:#a5d6ff }
+  /* LiteralNumberHex */ .chroma .mh { color:#a5d6ff }
+  /* LiteralNumberInteger */ .chroma .mi { color:#a5d6ff }
+  /* LiteralNumberIntegerLong */ .chroma .il { color:#a5d6ff }
+  /* LiteralNumberOct */ .chroma .mo { color:#a5d6ff }
+  /* Operator */ .chroma .o { color:#ff7b72;font-weight:bold }
+  /* OperatorWord */ .chroma .ow { color:#ff7b72;font-weight:bold }
+  /* OperatorReserved */ .chroma .or { color:#ff7b72;font-weight:bold }
+  /* Comment */ .chroma .c { color:#8b949e;font-style:italic }
+  /* CommentHashbang */ .chroma .ch { color:#8b949e;font-style:italic }
+  /* CommentMultiline */ .chroma .cm { color:#8b949e;font-style:italic }
+  /* CommentSingle */ .chroma .c1 { color:#8b949e;font-style:italic }
+  /* CommentSpecial */ .chroma .cs { color:#8b949e;font-weight:bold;font-style:italic }
+  /* CommentPreproc */ .chroma .cp { color:#8b949e;font-weight:bold;font-style:italic }
+  /* CommentPreprocFile */ .chroma .cpf { color:#8b949e;font-weight:bold;font-style:italic }
+  /* GenericDeleted */ .chroma .gd { color:#ffa198;background-color:#490202 }
+  /* GenericEmph */ .chroma .ge { font-style:italic }
+  /* GenericError */ .chroma .gr { color:#ffa198 }
+  /* GenericHeading */ .chroma .gh { color:#79c0ff;font-weight:bold }
+  /* GenericInserted */ .chroma .gi { color:#56d364;background-color:#0f5323 }
+  /* GenericOutput */ .chroma .go { color:#8b949e }
+  /* GenericPrompt */ .chroma .gp { color:#8b949e }
+  /* GenericStrong */ .chroma .gs { font-weight:bold }
+  /* GenericSubheading */ .chroma .gu { color:#79c0ff }
+  /* GenericTraceback */ .chroma .gt { color:#ff7b72 }
+  /* GenericUnderline */ .chroma .gl { text-decoration:underline }
+  /* TextWhitespace */ .chroma .w { color:#6e7681 }
+}

--- a/website/assets/css/site.css
+++ b/website/assets/css/site.css
@@ -1,0 +1,509 @@
+:root {
+  --bg: #ffffff;
+  --fg: #1f2328;
+  --muted: #59636e;
+  --link: #0757ba;
+  --border: #d1d9e0;
+  --code-bg: #f6f8fa;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0d1117;
+    --fg: #e6edf3;
+    --muted: #9198a1;
+    --link: #58a6ff;
+    --border: #30363d;
+    --code-bg: #161b22;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  font-size: 1.0625rem;
+  line-height: 1.6;
+}
+
+header {
+  border-bottom: 1px solid var(--border);
+}
+
+header nav {
+  max-width: 56rem;
+  margin: 0 auto;
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 1rem;
+  align-items: baseline;
+}
+
+header nav a {
+  color: var(--fg);
+  text-decoration: none;
+}
+
+header nav a:hover {
+  text-decoration: underline;
+}
+
+header nav .brand {
+  font-weight: 700;
+  margin-right: 0.5rem;
+}
+
+header nav .sponsor {
+  color: #bf3989;
+}
+
+@media (prefers-color-scheme: dark) {
+  header nav .sponsor {
+    color: #f778ba;
+  }
+}
+
+/* --- home page logo --- */
+
+.logo {
+  text-align: center;
+}
+
+.logo img {
+  max-width: min(400px, 100%);
+  border-radius: 8px;
+}
+
+/* Landing hero: a smaller logo sitting directly above the tagline h1, so the
+   "what is this" headline is the first text a visitor and a crawler see. */
+.hero {
+  text-align: center;
+  margin: 0.5rem 0 1.5rem;
+}
+
+.hero-logo {
+  max-width: min(360px, 90%);
+  height: auto;
+  border-radius: 8px;
+}
+
+.hero h1 {
+  margin: 0.75rem 0 0;
+  font-size: 1.6rem;
+  line-height: 1.25;
+}
+
+/* Embedded doc images (demo/snapshot GIFs) keep their intrinsic ratio while
+   scaling down, so the reserved width/height box never overflows the column. */
+main img {
+  max-width: 100%;
+  height: auto;
+}
+
+main {
+  max-width: 56rem;
+  margin: 0 auto;
+  padding: 1.5rem 1rem 3rem;
+}
+
+footer {
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.875rem;
+}
+
+footer p {
+  max-width: 56rem;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+footer a {
+  color: var(--muted);
+}
+
+h1, h2, h3, h4 {
+  line-height: 1.25;
+  margin: 1.75em 0 0.5em;
+}
+
+h1 {
+  margin-top: 0.5em;
+  font-size: 1.75rem;
+}
+
+h2 {
+  font-size: 1.35rem;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.25rem;
+}
+
+h3 {
+  font-size: 1.1rem;
+}
+
+a {
+  color: var(--link);
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+code, pre {
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 0.875em;
+}
+
+code {
+  background: var(--code-bg);
+  border-radius: 4px;
+  padding: 0.15em 0.35em;
+}
+
+pre {
+  background: var(--code-bg);
+  border-radius: 6px;
+  padding: 0.9rem 1rem;
+  overflow-x: auto;
+  line-height: 1.5;
+}
+
+pre code {
+  background: none;
+  padding: 0;
+  font-size: 1em;
+}
+
+.highlight pre {
+  background: var(--code-bg) !important;
+}
+
+/* A real <table> (not display:block) so browsers keep announcing it as a table
+   to assistive tech; horizontal scrolling for wide tables lives on the
+   .table-wrap container emitted by the table render hook and the spec-reference
+   shortcode instead. */
+table {
+  display: table;
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1rem 0;
+}
+
+.table-wrap {
+  overflow-x: auto;
+  margin: 1rem 0;
+}
+
+th, td {
+  border: 1px solid var(--border);
+  padding: 0.4rem 0.7rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  background: var(--code-bg);
+}
+
+blockquote {
+  margin: 1rem 0;
+  padding: 0 1rem;
+  color: var(--muted);
+  border-left: 3px solid var(--border);
+}
+
+hr {
+  border: 0;
+  border-top: 1px solid var(--border);
+  margin: 2rem 0;
+}
+
+/* --- navigation state --- */
+
+header nav a.active {
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 0.35em;
+}
+
+/* --- heading anchors: visible on hover --- */
+
+.hlink {
+  text-decoration: none;
+  opacity: 0;
+  font-weight: 400;
+  transition: opacity 0.1s;
+}
+
+h1:hover .hlink, h2:hover .hlink, h3:hover .hlink, h4:hover .hlink {
+  opacity: 0.7;
+}
+
+/* --- "On this page" box --- */
+
+details.toc {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.5rem 1rem;
+  margin: 1rem 0;
+  font-size: 0.95rem;
+}
+
+details.toc summary {
+  cursor: pointer;
+  color: var(--muted);
+}
+
+details.toc ul {
+  margin: 0.5rem 0;
+  padding-left: 1.25rem;
+}
+
+details.toc a {
+  text-decoration: none;
+}
+
+details.toc a:hover {
+  text-decoration: underline;
+}
+
+/* --- copy button on code blocks --- */
+
+pre {
+  position: relative;
+}
+
+pre .copy {
+  position: absolute;
+  top: 0.4rem;
+  right: 0.4rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--muted);
+  font: 0.75rem ui-monospace, monospace;
+  padding: 0.15rem 0.5rem;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.1s;
+}
+
+pre:hover .copy {
+  opacity: 1;
+}
+
+pre .copy:hover {
+  color: var(--fg);
+}
+
+/* --- subtle zebra striping for wide tables --- */
+
+tbody tr:nth-child(even) {
+  background: var(--code-bg);
+}
+
+/* --- landing: "Where to go" as a card grid --- */
+
+#where-to-go + ul {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(21rem, 1fr));
+  gap: 0.75rem;
+}
+
+#where-to-go + ul li {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  margin: 0;
+}
+
+#where-to-go + ul li a:first-child {
+  font-weight: 600;
+}
+
+/* --- performance: skip off-screen layout on the heaviest pages (#237) --- */
+/* content-visibility:auto lets the browser skip layout and paint of off-screen
+   code blocks and tables — the real-world pages reach ~1.7 MB with 1,896 <pre>
+   blocks — while contain-intrinsic-size gives a placeholder box so the scrollbar
+   stays stable and remembered sizes avoid re-layout thrash on scroll. */
+main pre,
+main .table-wrap {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 6rem;
+}
+
+/* --- accessibility: skip-to-content link (#242) --- */
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+  z-index: 10;
+  padding: 0.5rem 0.85rem;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 0 0 6px 0;
+}
+
+.skip-link:focus {
+  left: 0;
+}
+
+/* --- accessibility: copy button reachable by keyboard and touch (#242) --- */
+/* Previously only pre:hover revealed it, so keyboard users tabbed onto an
+   invisible control and touch devices (no hover) never saw it at all. */
+pre:focus-within .copy,
+.copy:focus-visible {
+  opacity: 1;
+}
+
+@media (hover: none) {
+  pre .copy {
+    opacity: 1;
+  }
+}
+
+/* --- accessibility: visible focus outlines (#242) --- */
+header nav a:focus-visible,
+.hlink:focus-visible,
+.copy:focus-visible,
+main a:focus-visible {
+  outline: 2px solid var(--link);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+/* --- cookbook / reference: sticky TOC sidebar on wide viewports (#241) --- */
+/* Anchor jumps land clear of the top edge instead of flush against it. */
+main h2,
+main h3 {
+  scroll-margin-top: 1rem;
+}
+
+/* Narrow (and any non-toc page): keep the collapsible inline TOC, no sidebar. */
+.sidebar {
+  display: none;
+}
+
+.toc-filter {
+  width: 100%;
+  box-sizing: border-box;
+  margin-bottom: 0.75rem;
+  padding: 0.4rem 0.6rem;
+  font: inherit;
+  color: var(--fg);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+@media (min-width: 1200px) {
+  /* Widen the column band for TOC pages so a sidebar fits beside the 56rem
+     article instead of wasting the margin the narrow cap leaves. */
+  main:has(.page.has-toc) {
+    max-width: 76rem;
+  }
+
+  .page.has-toc {
+    display: grid;
+    grid-template-columns: 15rem minmax(0, 1fr);
+    gap: 2.5rem;
+    align-items: start;
+  }
+
+  .page.has-toc article {
+    max-width: 56rem;
+    min-width: 0;
+  }
+
+  .sidebar {
+    display: block;
+  }
+
+  .sidebar-inner {
+    position: sticky;
+    top: 1rem;
+    max-height: calc(100vh - 2rem);
+    overflow-y: auto;
+    font-size: 0.9rem;
+  }
+
+  .toc-nav ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .toc-nav ul ul {
+    padding-left: 0.9rem;
+  }
+
+  .toc-nav li {
+    margin: 0.15rem 0;
+  }
+
+  .toc-nav a {
+    text-decoration: none;
+    color: var(--muted);
+  }
+
+  .toc-nav a:hover {
+    color: var(--fg);
+    text-decoration: underline;
+  }
+
+  /* The inline collapsible TOC is redundant once the sidebar is shown. */
+  .toc-inline {
+    display: none;
+  }
+}
+/* --- client-side search box in the nav (#236) --- */
+.search {
+  position: relative;
+  display: inline-flex;
+}
+
+.search-box {
+  font: inherit;
+  font-size: 0.9rem;
+  padding: 0.2rem 0.55rem;
+  width: 9rem;
+  max-width: 40vw;
+  color: var(--fg);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+/* Pagefind renders its input and results into this dropdown once loaded; the
+   CSS variables theme it to match the site in both light and dark. */
+.search-ui {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 0.4rem;
+  width: min(92vw, 24rem);
+  max-height: 72vh;
+  overflow-y: auto;
+  padding: 0.6rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
+  z-index: 30;
+  --pagefind-ui-primary: var(--link);
+  --pagefind-ui-text: var(--fg);
+  --pagefind-ui-background: var(--bg);
+  --pagefind-ui-border: var(--border);
+  --pagefind-ui-tag: var(--code-bg);
+  --pagefind-ui-font: inherit;
+}

--- a/website/content/_content.gotmpl
+++ b/website/content/_content.gotmpl
@@ -1,0 +1,20 @@
+{{/* Build the cookbook page from doc/cookbook.md, committed in this repository
+     and mounted under assets/. The committed file stays the single source of
+     truth; this template only strips the H1 (the layout renders the title) and
+     rewrites repository-relative links to GitHub. */}}
+
+{{ $gh := "https://github.com/nao1215/gup/blob/main/" }}
+
+{{ with resources.Get "doc/cookbook.md" }}
+  {{ $md := .Content }}
+  {{ $md = replaceRE `\A# Cookbook\n` "" $md }}
+  {{ $md = replaceRE `\]\(\.\./` (printf "](%s" $gh) $md }}
+  {{ $.AddPage (dict
+      "path" "cookbook"
+      "title" "Cookbook"
+      "params" (dict
+        "description" "Copyable gup one-liners indexed by task: list and check your $GOBIN, update in parallel, pin a version, follow a branch, export the set to another machine, migrate to a new $GOBIN."
+        "toc" true
+        "filter" true)
+      "content" (dict "mediaType" "text/markdown" "value" $md)) }}
+{{ end }}

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -1,0 +1,61 @@
+---
+title: gup
+---
+
+`go install` puts a binary in `$GOBIN` and never touches it again. gup manages
+that set: it updates every tool in parallel, pins the ones that must stay put,
+and exports the whole set so another machine can reproduce it.
+
+![gup updating the binaries under $GOBIN](/img/sample.gif)
+
+## Try it in 30 seconds
+
+```shell
+go run github.com/nao1215/gup@latest check
+```
+
+```text
+check binary under $GOPATH/bin or $GOBIN
+[1/3] github.com/nao1215/gup (current: v0.7.0, latest: v0.7.1 / go1.26.4)
+[2/3] github.com/x-motemen/ghq (Already up-to-date: v1.6.3 / go1.26.4)
+[3/3] golang.org/x/tools/gopls (Already up-to-date: v0.20.0 / go1.26.4)
+
+If you want to update binaries, run the following command.
+           $ gup update gup
+```
+
+Nothing to configure: the binaries already in `$GOBIN` carry the build info gup
+reads. `check` never installs anything.
+
+## Three things to try next
+
+```shell
+gup update                       # bring the whole set up to date, in parallel
+gup pin golangci-lint v1.62.0    # hold one tool where CI holds it
+gup export                       # write the set to gup.json for another machine
+```
+
+The [cookbook](/cookbook/) has the rest: branch channels, `--json` for scripts,
+migrating to a new `$GOBIN` after a Go upgrade, and reading a failed update.
+
+## Why gup?
+
+Pick the tool that fits the job:
+
+| You want | Use |
+|:--|:--|
+| Tools scoped to one project, recorded in its `go.mod` | [`go tool`](https://go.dev/doc/modules/managing-dependencies#tools) |
+| A declarative, multi-language runtime and tool manager | [mise](https://mise.jdx.dev/), [aqua](https://aquaproj.github.io/) |
+| To update the Go binaries already in your `$GOBIN`, in parallel, with pins | gup |
+
+gup's emphasis is the toolbox you carry between projects: the commands you run
+from any directory and keep alongside your dotfiles.
+
+## Install
+
+```shell
+go install github.com/nao1215/gup@latest
+```
+
+Homebrew, winget, mise, nix, aqua, and prebuilt packages are on the
+[install page](/install/).

--- a/website/content/install.md
+++ b/website/content/install.md
@@ -1,0 +1,81 @@
+---
+title: Install
+description: Install gup with go install, Homebrew, winget, mise, nix, aqua, or a prebuilt .deb/.rpm/.apk package, and verify the release signatures.
+---
+
+gup runs on Linux, macOS, and Windows. It shells out to `go`, so a Go toolchain
+has to be on `PATH` whichever way you install gup itself.
+
+## go install
+
+```shell
+go install github.com/nao1215/gup@latest
+```
+
+Building from source needs Go 1.25 or newer. On an older Go, take a prebuilt
+binary or a package below.
+
+## Package managers
+
+```shell
+brew install nao1215/tap/gup
+```
+
+```shell
+winget install --id nao1215.gup
+```
+
+```shell
+mise use -g gup@latest
+```
+
+```shell
+nix profile install nixpkgs#gogup
+```
+
+gup is in the [aqua](https://aquaproj.github.io/) standard registry:
+
+```shell
+aqua g -i nao1215/gup
+```
+
+## Prebuilt packages and binaries
+
+[The release page](https://github.com/nao1215/gup/releases) carries `.deb`,
+`.rpm`, and `.apk` packages plus archives for every supported platform.
+
+## Verify what you downloaded
+
+Every release ships a cosign-signed `checksums.txt`, an SPDX SBOM per archive,
+and SLSA build provenance attested through GitHub OIDC.
+
+```shell
+cosign verify-blob \
+  --bundle checksums.txt.sigstore.json \
+  --certificate-identity-regexp 'https://github.com/nao1215/gup/\.github/workflows/release\.yml@refs/tags/.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  checksums.txt
+sha256sum --check --ignore-missing checksums.txt
+```
+
+```shell
+gh attestation verify gup_1.0.0_linux_amd64.tar.gz --repo nao1215/gup
+```
+
+## Shell completion
+
+```shell
+gup completion --install
+```
+
+That writes bash, fish, and zsh completion into the paths your shell already
+reads. For PowerShell, redirect a `.ps1` and source it from your profile. See
+[Completion and man pages](/cookbook/#completion-and-man-pages).
+
+## If `gup` runs `git pull --rebase`
+
+oh-my-zsh ships a `gup` alias. Remove or rename it, or bypass it once:
+
+```shell
+\gup update
+```

--- a/website/content/reference.md
+++ b/website/content/reference.md
@@ -1,0 +1,116 @@
+---
+title: Reference
+description: Every gup subcommand and flag, the gup.json schema, the --json output fields, and the exit codes.
+toc: true
+---
+
+Run `gup <command> --help` for the same information in your terminal. Recipes
+that use these live in the [cookbook](/cookbook/).
+
+## Commands
+
+| Command | What it does |
+|:--|:--|
+| `gup update [BINARY...]` | Reinstall binaries at their update channel, in parallel |
+| `gup check [BINARY...]` | Report what is out of date; installs nothing |
+| `gup list` | List every binary under `$GOBIN` with its import path and version |
+| `gup export` | Write the installed set to `gup.json` |
+| `gup import` | Install the set recorded in `gup.json` |
+| `gup pin TOOL[@VERSION] [VERSION]` | Hold a tool at an exact version |
+| `gup unpin TOOL` | Let a pinned tool update again |
+| `gup migrate BEFORE_PATH AFTER_PATH [BINARY...]` | Reinstall binaries from one `$GOBIN` into another |
+| `gup remove BINARY...` | Delete binaries from `$GOBIN` |
+| `gup completion [SHELL]` | Print or install shell completion |
+| `gup man` | Generate man pages (Linux, macOS) |
+| `gup version` | Print the version, same as `gup --version` |
+| `gup bug-report` | Open a pre-filled GitHub issue |
+
+`gup rm` is an alias for `gup remove`. `--no-color` works on every command, as
+does the `NO_COLOR` environment variable.
+
+## Flags
+
+| Flag | Commands | Meaning |
+|:--|:--|:--|
+| `-n`, `--dry-run` | `update`, `import`, `migrate` | Report what would happen, change nothing |
+| `-e`, `--exclude` | `update` | Comma-separated binaries to skip |
+| `-f`, `--file` | `update`, `check`, `list`, `import`, `export`, `pin`, `unpin` | Use this `gup.json` instead of the auto-detected one |
+| `-o`, `--output` | `export` | Print the config to STDOUT instead of writing it |
+| `--json` | `update`, `check`, `list` | Machine-readable output |
+| `-q`, `--quiet` | `update`, `check` | Drop up-to-date lines; keep changes, failures, and a summary |
+| `-j`, `--jobs` | `update`, `check`, `import`, `migrate` | Parallel workers (default: CPU count) |
+| `--timeout` | `update`, `check`, `import`, `migrate` | Per-package limit, e.g. `90s`, `5m`; `0` means none |
+| `--ignore-go-update` | `update`, `check` | Compare versions only, ignore Go-toolchain rebuilds |
+| `-m`, `--main` | `update` | Update these by `@main` (falls back to `@master` only when no `main` branch exists) |
+| `--master` | `update` | Update these by `@master` |
+| `--latest` | `update` | Update these by `@latest` |
+| `-N`, `--notify` | `update`, `import`, `migrate` | Desktop notification when the run finishes |
+| `--force` | `remove` (`-f`), `migrate` | Skip the confirmation / overwrite an existing binary |
+| `--install` | `completion` | Write completion files to the user shell config paths |
+| `--no-color` | all | Disable colorized output |
+| `-V`, `--version` | root | Print the version |
+
+`--json` wins over `--quiet` when both are given: you get the full array.
+
+## gup.json
+
+`export` writes it, `import` reads it, and `update`/`check` read the update
+channel from it. The path is `$XDG_CONFIG_HOME/gup/gup.json`, or `./gup.json`,
+in that order; `--file` overrides both. If both exist and no `--file` is given,
+gup fails and asks you to choose rather than picking one.
+
+```json
+{
+  "schema_version": 2,
+  "packages": [
+    {
+      "name": "gal",
+      "import_path": "github.com/nao1215/gal/cmd/gal",
+      "version": "v1.1.1",
+      "channel": "latest"
+    },
+    {
+      "name": "golangci-lint",
+      "import_path": "github.com/golangci/golangci-lint/cmd/golangci-lint",
+      "version": "v1.62.0",
+      "channel": "pinned"
+    }
+  ]
+}
+```
+
+`schema_version` is `1` while nothing is pinned and `2` once anything is, so an
+environment with no pins keeps writing files older gup releases can read. gup
+reads both. A malformed file, an unknown `channel`, an unsupported
+`schema_version`, or a `pinned` entry with no concrete version is an error, not
+something to ignore — a saved channel is never quietly downgraded to `latest`.
+
+## JSON output fields
+
+| Field | Notes |
+|:--|:--|
+| `name` | Binary name in `$GOBIN` |
+| `import_path` | What `go install` would be given |
+| `module_path` | Module that provides it |
+| `channel` | `latest`, `main`, `master`, or `pinned` |
+| `current_version` | Version of the installed binary |
+| `latest_version` | Empty for `list` and for pinned packages |
+| `pinned_version` | Only for `channel: "pinned"` |
+| `current_go_version` | Go toolchain the binary was built with |
+| `installed_go_version` | Go toolchain on this machine |
+| `status` | `installed`, `up-to-date`, `update-available`, `updated`, `pinned`, `pin-mismatch`, `error` |
+| `error` | Omitted when absent |
+| `hint` | Next step for the error, when gup has one |
+
+The array is valid JSON even on partial failure, and errors are also written to
+STDERR so STDOUT stays parseable.
+
+## Exit codes
+
+| Code | When |
+|:--|:--|
+| `0` | The command did its job — including `check` finding updates, and any command on an empty `$GOBIN` |
+| `1` | A usage error, a config error, or at least one package failed |
+
+Naming a binary that is not installed, or excluding every binary, is a usage
+error.

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -1,0 +1,67 @@
+# Configuration for the hosted documentation website (GitHub Pages).
+# Content comes from the repository itself: doc/cookbook.md is mounted read-only
+# and turned into a page by content/_content.gotmpl, so the committed file stays
+# the single source of truth.
+baseURL = "https://nao1215.github.io/gup/"
+locale = "en"
+title = "gup"
+disableKinds = ["taxonomy", "term", "rss"]
+enableRobotsTXT = true
+timeZone = "UTC"
+
+[params]
+tagline = "update and manage the Go tools in your $GOBIN"
+description = "gup updates every binary installed by 'go install' in parallel, pins the ones that must stay put, and exports the whole set so another machine can reproduce it."
+
+[markup.highlight]
+noClasses = false
+
+[markup.tableOfContents]
+startLevel = 2
+endLevel = 3
+
+[[menus.main]]
+name = "Install"
+pageRef = "/install"
+weight = 10
+
+[[menus.main]]
+name = "Cookbook"
+pageRef = "/cookbook"
+weight = 20
+
+[[menus.main]]
+name = "Reference"
+pageRef = "/reference"
+weight = 30
+
+[module]
+[[module.mounts]]
+source = "content"
+target = "content"
+
+[[module.mounts]]
+source = "layouts"
+target = "layouts"
+
+[[module.mounts]]
+source = "assets"
+target = "assets"
+
+# Repository docs, mounted so pages can be generated from the committed files.
+[[module.mounts]]
+source = "../doc/cookbook.md"
+target = "assets/doc/cookbook.md"
+
+# Images served as-is.
+[[module.mounts]]
+source = "../doc/img"
+target = "static/img"
+
+# The same images, mounted again as processable assets so the layouts can derive
+# sized variants at build time (a right-ratio social card, a square favicon) and
+# emit intrinsic width/height for embedded images, without committing any extra
+# binary — everything still comes from doc/img.
+[[module.mounts]]
+source = "../doc/img"
+target = "assets/imgsrc"

--- a/website/layouts/404.html
+++ b/website/layouts/404.html
@@ -1,0 +1,6 @@
+{{ define "main" }}
+<article>
+<h1>Page not found</h1>
+<p>No page lives at this address. Start from the <a href="{{ site.Home.RelPermalink }}">front page</a>.</p>
+</article>
+{{ end }}

--- a/website/layouts/_markup/render-heading.html
+++ b/website/layouts/_markup/render-heading.html
@@ -1,0 +1,1 @@
+<h{{ .Level }} id="{{ .Anchor | safeURL }}">{{ .Text }}{{ if ge .Level 2 }} <a class="hlink" href="#{{ .Anchor | safeURL }}" aria-label="Link to this section">#</a>{{ end }}</h{{ .Level }}>

--- a/website/layouts/_markup/render-image.html
+++ b/website/layouts/_markup/render-image.html
@@ -1,0 +1,19 @@
+{{- $u := .Destination -}}
+{{- /* Images committed under doc/img are mounted as processable assets too, so
+       resolve one to a resource and emit its intrinsic width/height — the
+       browser then reserves the box before the (often large GIF) loads, so the
+       page does not shift as each image arrives. The resource is published
+       as-is (no re-encoding), so animated GIFs keep animating. */ -}}
+{{- $img := "" -}}
+{{- if hasPrefix $u "/img/" -}}
+  {{- $img = resources.Get (printf "imgsrc/%s" (strings.TrimPrefix "/img/" $u)) -}}
+{{- end -}}
+{{- if $img -}}
+<img src="{{ $img.RelPermalink }}" alt="{{ .Text }}"{{ with .Title }} title="{{ . }}"{{ end }} width="{{ $img.Width }}" height="{{ $img.Height }}" loading="lazy">
+{{- else -}}
+  {{- if and (hasPrefix $u "/") (not (hasPrefix $u "//")) -}}
+    {{- $u = relURL (strings.TrimPrefix "/" $u) -}}
+  {{- end -}}
+<img src="{{ $u }}" alt="{{ .Text }}"{{ with .Title }} title="{{ . }}"{{ end }} loading="lazy">
+{{- end -}}
+{{- /* chomp trailing newline */ -}}

--- a/website/layouts/_markup/render-link.html
+++ b/website/layouts/_markup/render-link.html
@@ -1,0 +1,9 @@
+{{- /* Site-absolute destinations ("/cookbook/") are prefixed with the base
+     path so pages work under https://<host>/gup/. Everything else —
+     external URLs, fragments, page-relative paths — passes through. */ -}}
+{{- $u := .Destination -}}
+{{- if and (hasPrefix $u "/") (not (hasPrefix $u "//")) -}}
+  {{- $u = relURL (strings.TrimPrefix "/" $u) -}}
+{{- end -}}
+<a href="{{ $u }}"{{ with .Title }} title="{{ . }}"{{ end }}>{{ .Text }}</a>
+{{- /* chomp trailing newline */ -}}

--- a/website/layouts/_markup/render-table.html
+++ b/website/layouts/_markup/render-table.html
@@ -1,0 +1,26 @@
+{{- /* Wrap markdown tables in a horizontally-scrollable container instead of
+     making the <table> itself display:block (which strips the implicit ARIA
+     table role, so screen readers stop announcing it as a table). The table
+     stays a real table; only the wrapper scrolls. */ -}}
+<div class="table-wrap">
+<table>
+<thead>
+{{- range .THead }}
+<tr>
+{{- range . }}
+<th{{ with .Alignment }} style="text-align: {{ . }}"{{ end }}>{{ .Text }}</th>
+{{- end }}
+</tr>
+{{- end }}
+</thead>
+<tbody>
+{{- range .TBody }}
+<tr>
+{{- range . }}
+<td{{ with .Alignment }} style="text-align: {{ . }}"{{ end }}>{{ .Text }}</td>
+{{- end }}
+</tr>
+{{- end }}
+</tbody>
+</table>
+</div>

--- a/website/layouts/baseof.html
+++ b/website/layouts/baseof.html
@@ -1,0 +1,193 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+{{- $title := printf "%s · %s" .Title site.Title }}
+{{- with .Params.seoTitle }}{{ $title = . }}{{ end }}
+{{- if .IsHome }}{{ $title = printf "%s — %s" site.Title site.Params.tagline }}{{ end }}
+<title>{{ $title }}</title>
+{{- $desc := or .Params.description site.Params.description }}
+<meta name="description" content="{{ $desc }}">
+<link rel="canonical" href="{{ .Permalink }}">
+{{- /* A right-ratio (1.91:1) social card and a square favicon, both derived at
+       build time from a committed screenshot: it is fit to 1000px wide and
+       padded onto a 1200x630 dark canvas so X/Slack/Discord render a full card
+       instead of cropping the source. Falls back to the raw file if the
+       processable asset is ever unavailable. */ -}}
+{{- $ogImage := absURL "img/overview.png" }}{{ $ogW := "1100" }}{{ $ogH := "600" }}{{ $favicon := relURL "img/overview.png" }}{{ $faviconType := "image/png" }}
+{{- with resources.Get "imgsrc/overview.png" }}
+  {{- $fit := .Resize "1000x q90" }}
+  {{- $padY := div (sub 630 $fit.Height) 2 }}
+  {{- $card := $fit.Filter (images.Padding $padY 100 (sub 630 (add $fit.Height $padY)) 100 "#0d1117") }}
+  {{- $ogImage = $card.Permalink }}{{ $ogW = string $card.Width }}{{ $ogH = string $card.Height }}
+  {{- $icon := (.Fill "64x64 Center png") }}
+  {{- $favicon = $icon.RelPermalink }}{{ $faviconType = "image/png" }}
+{{- end }}
+<meta property="og:title" content="{{ $title }}">
+<meta property="og:description" content="{{ $desc }}">
+<meta property="og:type" content="website">
+<meta property="og:url" content="{{ .Permalink }}">
+<meta property="og:image" content="{{ $ogImage }}">
+<meta property="og:image:width" content="{{ $ogW }}">
+<meta property="og:image:height" content="{{ $ogH }}">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{{ $title }}">
+<meta name="twitter:description" content="{{ $desc }}">
+<meta name="twitter:image" content="{{ $ogImage }}">
+<link rel="icon" href="{{ $favicon }}" type="{{ $faviconType }}"{{ if eq $faviconType "image/png" }} sizes="64x64"{{ end }}>
+{{- $css := slice (resources.Get "css/site.css") (resources.Get "css/chroma.css") | resources.Concat "css/bundle.css" | minify | fingerprint }}
+<link rel="stylesheet" href="{{ $css.RelPermalink }}">
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to content</a>
+<header>
+<nav>
+<a class="brand" href="{{ site.Home.RelPermalink }}">gup</a>
+{{- range site.Menus.main }}
+<a{{ if or ($.IsMenuCurrent "main" .) ($.HasMenuCurrent "main" .) }} class="active"{{ end }} href="{{ .URL }}">{{ .Name }}</a>
+{{- end }}
+<a href="https://github.com/nao1215/gup">GitHub</a>
+<a class="sponsor" href="https://github.com/sponsors/nao1215">&#9825; Sponsor</a>
+<div class="search">
+<input type="search" id="search-box" class="search-box" placeholder="Search…" aria-label="Search the documentation" autocomplete="off" data-pagefind-base="{{ relURL "" }}">
+<div id="search-ui" class="search-ui" hidden></div>
+</div>
+</nav>
+</header>
+<main id="main" data-pagefind-body>
+{{ block "main" . }}{{ end }}
+</main>
+<footer>
+<p>MIT licensed · <a href="https://github.com/nao1215/gup">nao1215/gup</a> · every page on this site is generated from files committed in the repository.</p>
+</footer>
+<script>
+// Lazy copy buttons: building a button for every <pre> at load is ~1,896
+// synchronous DOM insertions on the heaviest real-world page, before first
+// paint. Create each button only when its block scrolls near the viewport, via
+// IntersectionObserver — off-screen blocks stay button-free, and a block a
+// finger can reach on a touch device is one that has scrolled into view. CSS
+// reveals the button on hover, keyboard focus, and always on hover-less pointers.
+(function () {
+  if (!(navigator.clipboard && window.isSecureContext)) return;
+  var main = document.getElementById("main");
+  if (!main) return;
+  function addButton(pre) {
+    if (pre.querySelector(".copy")) return;
+    var b = document.createElement("button");
+    b.type = "button";
+    b.className = "copy";
+    b.textContent = "copy";
+    b.setAttribute("aria-label", "Copy code to clipboard");
+    b.addEventListener("click", function () {
+      var code = pre.querySelector("code");
+      navigator.clipboard.writeText(code ? code.innerText : pre.innerText).then(function () {
+        b.textContent = "copied";
+      }, function () {
+        b.textContent = "failed";
+      }).then(function () {
+        setTimeout(function () { b.textContent = "copy"; }, 1200);
+      });
+    });
+    pre.appendChild(b);
+  }
+  var pres = main.querySelectorAll("pre");
+  if ("IntersectionObserver" in window) {
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (en) {
+        if (en.isIntersecting) { addButton(en.target); io.unobserve(en.target); }
+      });
+    }, { rootMargin: "300px" });
+    pres.forEach(function (pre) { io.observe(pre); });
+  } else {
+    pres.forEach(addButton);
+  }
+})();
+</script>
+<script>
+// Live recipe filter for the cookbook: type "pty" or "snapshot" and only the
+// matching h2 sections (and their TOC entries) stay visible. Sections are
+// contiguous sibling runs between h2 headings, so group the article's children
+// by heading and toggle each group. No-op on pages without a .toc-filter input.
+(function () {
+  var input = document.querySelector(".toc-filter");
+  if (!input) return;
+  var main = document.getElementById("main");
+  var article = main && main.querySelector("article");
+  if (!article) return;
+  var groups = [];
+  var cur = null;
+  Array.prototype.forEach.call(article.children, function (node) {
+    if (node.tagName === "H2") {
+      cur = { heading: node, nodes: [node], text: node.textContent.toLowerCase() };
+      groups.push(cur);
+    } else if (cur) {
+      cur.nodes.push(node);
+      cur.text += " " + node.textContent.toLowerCase();
+    }
+  });
+  var tocLinks = {};
+  document.querySelectorAll(".toc-nav a, .toc-inline a").forEach(function (a) {
+    var href = a.getAttribute("href");
+    if (href && href.charAt(0) === "#") {
+      var id = href.slice(1);
+      (tocLinks[id] = tocLinks[id] || []).push(a);
+    }
+  });
+  function apply() {
+    var q = input.value.trim().toLowerCase();
+    groups.forEach(function (g) {
+      var show = !q || g.text.indexOf(q) !== -1;
+      g.nodes.forEach(function (n) { n.hidden = !show; });
+      (tocLinks[g.heading.id] || []).forEach(function (a) {
+        var li = a.closest("li");
+        if (li) li.hidden = !show;
+      });
+    });
+  }
+  input.addEventListener("input", apply);
+})();
+</script>
+<script>
+// Client-side search, lazy: the Pagefind UI (script, stylesheet, and the WASM
+// index chunks) is self-hosted under /pagefind/ and fetched only when the user
+// first focuses the search box, so it adds nothing to a normal page load. The
+// index is built in CI by the Pagefind pass in .github/workflows/website.yml;
+// on a local `make website` (no Pagefind) the assets are absent and the box
+// simply does nothing.
+(function () {
+  var box = document.getElementById("search-box");
+  var ui = document.getElementById("search-ui");
+  if (!box || !ui) return;
+  var base = box.getAttribute("data-pagefind-base") || "/";
+  var loaded = false;
+  function load() {
+    if (loaded) return;
+    loaded = true;
+    var css = document.createElement("link");
+    css.rel = "stylesheet";
+    css.href = base + "pagefind/pagefind-ui.css";
+    document.head.appendChild(css);
+    var s = document.createElement("script");
+    s.src = base + "pagefind/pagefind-ui.js";
+    s.onload = function () {
+      if (typeof PagefindUI === "undefined") return;
+      /* global PagefindUI */
+      new PagefindUI({ element: "#search-ui", showImages: false, showSubResults: true });
+      ui.hidden = false;
+      var real = ui.querySelector("input");
+      if (real) {
+        real.value = box.value;
+        real.focus();
+        real.dispatchEvent(new Event("input", { bubbles: true }));
+      }
+      box.hidden = true;
+    };
+    s.onerror = function () { loaded = false; }; // let a later focus retry
+    document.body.appendChild(s);
+  }
+  box.addEventListener("focus", load);
+})();
+</script>
+</body>
+</html>

--- a/website/layouts/home.html
+++ b/website/layouts/home.html
@@ -1,0 +1,6 @@
+{{ define "main" }}
+<div class="hero">
+<h1>{{ site.Params.tagline }}</h1>
+</div>
+{{ .Content }}
+{{ end }}

--- a/website/layouts/page.html
+++ b/website/layouts/page.html
@@ -1,0 +1,22 @@
+{{ define "main" }}
+<div class="page{{ if .Params.toc }} has-toc{{ end }}">
+{{ if .Params.toc }}
+<aside class="sidebar" aria-label="On this page">
+<div class="sidebar-inner">
+{{ if .Params.filter }}<input type="search" class="toc-filter" placeholder="Filter recipes…" aria-label="Filter recipes by keyword" autocomplete="off">{{ end }}
+<nav class="toc-nav">{{ .TableOfContents }}</nav>
+</div>
+</aside>
+{{ end }}
+<article>
+<h1>{{ .Title }}</h1>
+{{ if .Params.toc }}
+<details class="toc toc-inline">
+<summary>On this page</summary>
+{{ .TableOfContents }}
+</details>
+{{ end }}
+{{ .Content }}
+</article>
+</div>
+{{ end }}

--- a/website/layouts/robots.txt
+++ b/website/layouts/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: {{ "sitemap.xml" | absURL }}

--- a/website/layouts/section.html
+++ b/website/layouts/section.html
@@ -1,0 +1,6 @@
+{{ define "main" }}
+<article>
+<h1>{{ .Title }}</h1>
+{{ .Content }}
+</article>
+{{ end }}

--- a/website/layouts/sitemap.xml
+++ b/website/layouts/sitemap.xml
@@ -1,0 +1,15 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{- /* Deliberately omit <priority>: Hugo defaults programmatically-added
+         pages (the cookbook and every real-world page, created via AddPage in
+         content/_content.gotmpl) to priority 0, which told crawlers the site's
+         richest content was the least important. With no priority element the
+         crawler weights every URL equally. */ -}}
+  {{ range .Pages }}
+  <url>
+    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <lastmod>{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
+    <changefreq>{{ . }}</changefreq>{{ end }}
+  </url>
+  {{ end }}
+</urlset>


### PR DESCRIPTION
## Summary

Add a concise Hugo documentation site for gup and publish it through GitHub Pages. The site leads with runnable examples and a task-oriented cookbook rather than duplicating the full README.

## Changes

- Add the Hugo site with install, reference, and cookbook pages, generated from the committed cookbook source.
- Add the GitHub Pages build and deployment workflow, Makefile targets, and the README/repository Website links.
- Add docs drift tests for documented invocations, site links, images, and cookbook source wiring.
- Add 128 offline atago scenarios covering the cookbook recipes and make non-interactive remove errors point to --force.

## Design Decisions

- Keep doc/cookbook.md as the source of truth and render it into the site so the copyable recipes cannot diverge from the repository document.
- Validate command syntax with the real Cobra command tree, then exercise each cookbook section with the real gup binary through the offline E2E suite.

## Limitations

- The site deploys after the GitHub Pages workflow runs on main; pull requests only build and validate the artifact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Published an updated hosted documentation site (install guide, cookbook, CLI reference) with search, responsive navigation, dark mode, and accessible pages.
  * Added a prominent README link to the hosted site and automated website publishing.
* **Documentation**
  * Expanded guidance on verification, JSON output/schema, exit codes, and reproducible workflows.
* **Bug Fixes**
  * Improved interactive removal failure messaging with clearer instructions to use `--force`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->