### PR TITLE
docs(cli): add project links to help

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-Documentation: [GitHub Pages](https://nao1215.github.io/gup/)
-
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-32-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
@@ -16,6 +14,8 @@ Documentation: [GitHub Pages](https://nao1215.github.io/gup/)
 ![sample](./doc/img/sample.gif)
 
 gup updates and manages the global Go command-line tools in your `$GOBIN`. `go install` places each program in `$GOBIN` (`$GOPATH/bin`) but never updates it again, keeps no manifest of what it installed, and offers no way to hold a tool at a version you depend on. gup manages that tool set: it brings the whole set up to date in parallel, can `pin` selected tools to exact versions, and adds the management commands `go install` lacks: `list`/`check` what is installed, `remove` binaries, `export`/`import` the set to reproduce it on another machine, and `migrate` it to a new `$GOBIN`. Runs on Windows, macOS, and Linux.
+
+Documentation: **https://nao1215.github.io/gup/**
 
 ## Supported OS (unit testing with GitHub Actions)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,12 +35,13 @@ gup updates all binaries in parallel, so it is very fast. It also provides
 subcommands for manipulating binaries under $GOPATH/bin ($GOBIN).
 gup is cross-platform software that runs on Windows, Mac and Linux.
 
+Documentation: https://nao1215.github.io/gup/
+
 If you are using oh-my-zsh, then gup has an alias set up. The alias
 is gup - git pull --rebase. Therefore, please make sure that the
 oh-my-zsh alias is disabled (e.g. $ \gup update).
 
-If you find gup useful, please consider sponsoring the project:
-  https://github.com/sponsors/nao1215
+GitHub Sponsors: https://github.com/sponsors/nao1215
 `,
 		Example: `  gup update
   gup update --dry-run

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -316,6 +316,21 @@ func TestExecute_RootVersionFlag(t *testing.T) {
 	}
 }
 
+func TestExecute_RootHelpIncludesProjectLinks(t *testing.T) {
+	got, err := helper_runGupCaptureAllOutput(t, []string{testCmdGup, "--help"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"Documentation: https://nao1215.github.io/gup/",
+		"GitHub Sponsors: https://github.com/sponsors/nao1215",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("gup --help output does not contain %q:\n%s", want, got)
+		}
+	}
+}
+
 // TestSubcommandExamples verifies the root command and every subcommand ship
 // copy-paste-friendly Example help mentioning the command (issue #326).
 func TestSubcommandExamples(t *testing.T) {


### PR DESCRIPTION
## Summary
Show the documentation site and GitHub Sponsors link in the top-level help. Move the README documentation link next to the project introduction to match sqly and atago.

## Changes
- move the README documentation link below the introductory paragraph
- add Documentation and GitHub Sponsors links to `gup --help`
- test both links in the rendered root help

## Design Decisions
- keep the links as plain URLs so they remain usable in terminal output

## Testing
- `go test ./...`
- `golangci-lint run --config .golangci.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README with a direct documentation URL.
  * Added documentation and sponsorship links to the command-line help output.

* **Tests**
  * Added coverage to verify both links appear in the root help text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->