### PR TITLE
fix(website): correct license in footer

### DIFF
--- a/doc_sync_test.go
+++ b/doc_sync_test.go
@@ -69,6 +69,23 @@ func Test_englishReadme_hasRequiredSections(t *testing.T) {
 	}
 }
 
+func Test_websiteFooter_hasCanonicalLicense(t *testing.T) {
+	t.Parallel()
+
+	raw, err := os.ReadFile("website/layouts/baseof.html")
+	if err != nil {
+		t.Fatalf("failed to read website footer template: %v", err)
+	}
+	content := string(raw)
+	want := `<a href="https://github.com/nao1215/gup/blob/main/LICENSE">Apache License 2.0</a>`
+	if !strings.Contains(content, want) {
+		t.Errorf("website footer is missing the canonical license link %q", want)
+	}
+	if strings.Contains(strings.ToLower(content), "mit licensed") {
+		t.Error("website footer incorrectly identifies gup as MIT licensed")
+	}
+}
+
 // Test_translatedReadmes_haveRequiredSections asserts that every section the
 // English README carries (issue #306: Benchmark, release integrity, Migrate) is
 // also present in each translation, keyed off language-independent content so a

--- a/website/layouts/baseof.html
+++ b/website/layouts/baseof.html
@@ -59,7 +59,7 @@
 {{ block "main" . }}{{ end }}
 </main>
 <footer>
-<p>MIT licensed · <a href="https://github.com/nao1215/gup">nao1215/gup</a> · every page on this site is generated from files committed in the repository.</p>
+<p><a href="https://github.com/nao1215/gup/blob/main/LICENSE">Apache License 2.0</a> · <a href="https://github.com/nao1215/gup">nao1215/gup</a> · every page on this site is generated from files committed in the repository.</p>
 </footer>
 <script>
 // Lazy copy buttons: building a button for every <pre> at load is ~1,896


### PR DESCRIPTION
## Summary
Correct the license shown in the GitHub Pages footer. gup is licensed under Apache License 2.0, not MIT.

## Changes
- replace the incorrect MIT footer text with an Apache License 2.0 link
- add a regression test that rejects the stale MIT wording

## Design Decisions
- link directly to the repository LICENSE so the footer points to the canonical terms

## Testing
- `go test ./...`
- `golangci-lint run --config .golangci.yml`
- `make website`
