### PR TITLE
Feat/completion improvements

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -74,6 +74,9 @@ const timeoutFlagName = "timeout"
 func addTimeoutFlag(cmd *cobra.Command) {
 	cmd.Flags().Duration(timeoutFlagName, defaultGoOpTimeout,
 		"per-package timeout for go operations (e.g. 90s, 5m); default 0 means no timeout, so a slow go install is never killed")
+	if err := cmd.RegisterFlagCompletionFunc(timeoutFlagName, cobra.NoFileCompletions); err != nil {
+		panic(err)
+	}
 }
 
 // getTimeoutFlag reads the shared --timeout flag.

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -60,7 +60,12 @@ If BINARY arguments are given, only those binaries are migrated.`,
 		Args: requireMinArgs(migrateMinArgs,
 			"requires BEFORE_PATH and AFTER_PATH",
 			"gup migrate /old/gobin /new/gobin"),
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) < migrateMinArgs {
+				return nil, cobra.ShellCompDirectiveFilterDirs
+			}
+			return completePathBinaries(cmd, args, toComplete)
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			OsExit(runMigrate(printerFor(cmd), cmd, args))
 		},

--- a/cmd/pin.go
+++ b/cmd/pin.go
@@ -65,7 +65,12 @@ The binary's gup.json entry is reset to the @latest channel, so the next
 nothing and succeeds.`,
 		Example:           `  gup unpin golangci-lint`,
 		Args:              cobra.ExactArgs(1),
-		ValidArgsFunction: completePathBinaries,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) == 0 {
+				return completePathBinaries(cmd, args, toComplete)
+			}
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			OsExit(runUnpin(printerFor(cmd), cmd, args))
 		},

--- a/cmd/pin.go
+++ b/cmd/pin.go
@@ -38,7 +38,7 @@ stays on the version you rely on (for example to match CI or a team-wide
 development environment). Run 'gup unpin' to allow the tool to update again.`,
 		Example: `  gup pin golangci-lint v1.62.0
   gup pin golangci-lint@v1.62.0`,
-		Args:              cobra.RangeArgs(pinMinArgs, pinMaxArgs),
+		Args: cobra.RangeArgs(pinMinArgs, pinMaxArgs),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) == 0 {
 				return completePathBinaries(cmd, args, toComplete)

--- a/cmd/pin.go
+++ b/cmd/pin.go
@@ -63,8 +63,8 @@ func newUnpinCmd() *cobra.Command {
 The binary's gup.json entry is reset to the @latest channel, so the next
 'gup update' updates it normally. Unpinning a tool that is not pinned does
 nothing and succeeds.`,
-		Example:           `  gup unpin golangci-lint`,
-		Args:              cobra.ExactArgs(1),
+		Example: `  gup unpin golangci-lint`,
+		Args:    cobra.ExactArgs(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) == 0 {
 				return completePathBinaries(cmd, args, toComplete)

--- a/cmd/pin.go
+++ b/cmd/pin.go
@@ -39,7 +39,12 @@ development environment). Run 'gup unpin' to allow the tool to update again.`,
 		Example: `  gup pin golangci-lint v1.62.0
   gup pin golangci-lint@v1.62.0`,
 		Args:              cobra.RangeArgs(pinMinArgs, pinMaxArgs),
-		ValidArgsFunction: completePathBinaries,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) == 0 {
+				return completePathBinaries(cmd, args, toComplete)
+			}
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			OsExit(runPin(printerFor(cmd), cmd, args))
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to gup! Please fill in the sections below. -->

## Summary

<!-- What does this PR change and why? -->

SSIA.

## Related issue

<!-- e.g. Closes #123 -->
N/A

## Checklist

- [ ] Added or updated unit tests for the change
- [x] `make test` / `make vet` / `make fmt` pass locally
- [ ] If I changed `README.md`, I updated the translated READMEs under
      `doc/<lang>/README.md` for the affected sections, or confirmed the
      "translation may lag behind English" banner is present
      (see [CONTRIBUTING.md](../CONTRIBUTING.md#documentation-and-translations))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved shell completion for migration commands by suggesting directories while entering required paths, then offering available binaries.
  - Added smarter completion for pin and unpin commands, including binary suggestions before arguments are entered.
  - Refined timeout option completion to prevent irrelevant file suggestions.
  - Existing command validation and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->