### PR TITLE
fix(completion): complete migrate BINARY from BEFORE_PATH instead of $GOBIN

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -74,9 +74,9 @@ const timeoutFlagName = "timeout"
 func addTimeoutFlag(cmd *cobra.Command) {
 	cmd.Flags().Duration(timeoutFlagName, defaultGoOpTimeout,
 		"per-package timeout for go operations (e.g. 90s, 5m); default 0 means no timeout, so a slow go install is never killed")
-	if err := cmd.RegisterFlagCompletionFunc(timeoutFlagName, cobra.NoFileCompletions); err != nil {
-		panic(err)
-	}
+	// A duration is not a path, so never fall back to cobra's default file
+	// completion for its value.
+	mustRegisterFlagCompletion(cmd, timeoutFlagName, cobra.NoFileCompletions)
 }
 
 // getTimeoutFlag reads the shared --timeout flag.

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -262,3 +262,37 @@ func TestMustMarkFileFlagAsJSON_panicsOnMissingFileFlag(t *testing.T) {
 	}()
 	mustMarkFileFlagAsJSON(&cobra.Command{})
 }
+
+// TestAddTimeoutFlag_completion covers every command that carries the shared
+// --timeout flag. A duration is not a path, so cobra's default file completion
+// must be suppressed for its value.
+func TestAddTimeoutFlag_completion(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name string
+		cmd  *cobra.Command
+	}{
+		{name: "update", cmd: newUpdateCmd()},
+		{name: "check", cmd: newCheckCmd()},
+		{name: "import", cmd: newImportCmd()},
+		{name: "migrate", cmd: newMigrateCmd()},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if tt.cmd.Flags().Lookup(timeoutFlagName) == nil {
+				t.Fatalf("%s has no --%s flag", tt.name, timeoutFlagName)
+			}
+			completion, ok := tt.cmd.GetFlagCompletionFunc(timeoutFlagName)
+			if !ok {
+				t.Fatalf("--%s has no completion function, so shells fall back to file completion", timeoutFlagName)
+			}
+			got, directive := completion(tt.cmd, nil, "")
+			if directive != cobra.ShellCompDirectiveNoFileComp {
+				t.Errorf("directive = %v, want NoFileComp", directive)
+			}
+			if len(got) != 0 {
+				t.Errorf("completions = %v, want none", got)
+			}
+		})
+	}
+}

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -60,12 +60,7 @@ If BINARY arguments are given, only those binaries are migrated.`,
 		Args: requireMinArgs(migrateMinArgs,
 			"requires BEFORE_PATH and AFTER_PATH",
 			"gup migrate /old/gobin /new/gobin"),
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if len(args) < migrateMinArgs {
-				return nil, cobra.ShellCompDirectiveFilterDirs
-			}
-			return completePathBinaries(cmd, args, toComplete)
-		},
+		ValidArgsFunction: completeMigrateArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			OsExit(runMigrate(printerFor(cmd), cmd, args))
 		},
@@ -79,6 +74,18 @@ If BINARY arguments are given, only those binaries are migrated.`,
 	addTimeoutFlag(cmd)
 
 	return cmd
+}
+
+// completeMigrateArgs completes migrate's positional arguments. BEFORE_PATH and
+// AFTER_PATH are directories, so only directories are offered until both are
+// given; the optional BINARY arguments are then completed from the binaries that
+// actually live under the BEFORE_PATH the user typed, which is what runMigrate
+// scans - not the current $GOBIN.
+func completeMigrateArgs(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) < migrateMinArgs {
+		return nil, cobra.ShellCompDirectiveFilterDirs
+	}
+	return completeBinariesInDir(args[0], toComplete)
 }
 
 func runMigrate(p *print.Printer, cmd *cobra.Command, args []string) int {

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -11,8 +11,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/nao1215/gup/internal/goutil"
 	"github.com/nao1215/gup/internal/print"
+	"github.com/spf13/cobra"
 )
 
 func Test_migrate_missingArgs(t *testing.T) {
@@ -89,6 +92,13 @@ const (
 	testNameTest2         = "test2"
 	testUnknown           = "unknown"
 	testBinDummy          = "dummy"
+	testBinGal            = "gal"
+	testBinSubaru         = "subaru"
+	testBinGobinOnly      = "gobin-only"
+	testCmdMigrate        = "migrate"
+	testCmdPin            = "pin"
+	testFlagTimeout       = "--timeout"
+	testBinBeforeOnly     = "before-only"
 )
 
 // captureMigrateOutput runs fn with a buffer-backed printer and returns the
@@ -788,5 +798,70 @@ func TestValidateMigratePaths_symlinkedSameDir(t *testing.T) {
 	}
 	if err := validateMigratePaths(before, after, false); err == nil {
 		t.Fatal("validateMigratePaths() err = nil, want same-directory rejection")
+	}
+}
+
+// Test_completeMigrateArgs pins migrate's staged argument completion: BEFORE_PATH
+// and AFTER_PATH complete as directories, and the optional BINARY arguments come
+// from the BEFORE_PATH the user typed - not from $GOBIN, which migrate never
+// reads.
+func Test_completeMigrateArgs(t *testing.T) {
+	gobin := helper_makeBinaries(t, testBinGobinOnly)
+	t.Setenv("GOBIN", gobin)
+	before := helper_makeBinaries(t, testBinGal, testBinSubaru)
+	after := t.TempDir()
+
+	tests := []struct {
+		name          string
+		args          []string
+		toComplete    string
+		want          []string
+		wantDirective cobra.ShellCompDirective
+	}{
+		{
+			name:          "BEFORE_PATH completes directories",
+			args:          []string{},
+			wantDirective: cobra.ShellCompDirectiveFilterDirs,
+		},
+		{
+			name:          "AFTER_PATH completes directories",
+			args:          []string{before},
+			wantDirective: cobra.ShellCompDirectiveFilterDirs,
+		},
+		{
+			name:          "BINARY completes the binaries under BEFORE_PATH",
+			args:          []string{before, after},
+			want:          []string{testBinGal, testBinSubaru},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "BINARY honors the typed prefix",
+			args:          []string{before, after},
+			toComplete:    "g",
+			want:          []string{testBinGal},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "further BINARY arguments keep completing BEFORE_PATH",
+			args:          []string{before, after, testBinGal},
+			want:          []string{testBinGal, testBinSubaru},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, directive := completeMigrateArgs(nil, tt.args, tt.toComplete)
+			if directive != tt.wantDirective {
+				t.Errorf("directive = %v, want %v", directive, tt.wantDirective)
+			}
+			if diff := cmp.Diff(tt.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("completions mismatch (-want +got):\n%s", diff)
+			}
+			for _, name := range got {
+				if name == testBinGobinOnly {
+					t.Error("completion offered a $GOBIN binary that is absent from BEFORE_PATH")
+				}
+			}
+		})
 	}
 }

--- a/cmd/pin.go
+++ b/cmd/pin.go
@@ -38,13 +38,8 @@ stays on the version you rely on (for example to match CI or a team-wide
 development environment). Run 'gup unpin' to allow the tool to update again.`,
 		Example: `  gup pin golangci-lint v1.62.0
   gup pin golangci-lint@v1.62.0`,
-		Args: cobra.RangeArgs(pinMinArgs, pinMaxArgs),
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if len(args) == 0 {
-				return completePathBinaries(cmd, args, toComplete)
-			}
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		},
+		Args:              cobra.RangeArgs(pinMinArgs, pinMaxArgs),
+		ValidArgsFunction: completeFirstArgPathBinaries,
 		Run: func(cmd *cobra.Command, args []string) {
 			OsExit(runPin(printerFor(cmd), cmd, args))
 		},
@@ -63,14 +58,9 @@ func newUnpinCmd() *cobra.Command {
 The binary's gup.json entry is reset to the @latest channel, so the next
 'gup update' updates it normally. Unpinning a tool that is not pinned does
 nothing and succeeds.`,
-		Example: `  gup unpin golangci-lint`,
-		Args:    cobra.ExactArgs(1),
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if len(args) == 0 {
-				return completePathBinaries(cmd, args, toComplete)
-			}
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		},
+		Example:           `  gup unpin golangci-lint`,
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completeFirstArgPathBinaries,
 		Run: func(cmd *cobra.Command, args []string) {
 			OsExit(runUnpin(printerFor(cmd), cmd, args))
 		},
@@ -78,6 +68,18 @@ nothing and succeeds.`,
 	cmd.Flags().StringP("file", "f", "", "specify gup.json file path to read/write")
 	mustMarkFileFlagAsJSON(cmd)
 	return cmd
+}
+
+// completeFirstArgPathBinaries completes $GOBIN binary names for the first
+// positional argument only. cobra keeps calling ValidArgsFunction even after the
+// Args validator's maximum is reached, so the commands whose later arguments are
+// not binary names (pin's VERSION) or that accept no further argument (unpin)
+// need this guard to stop offering binaries where none can be accepted.
+func completeFirstArgPathBinaries(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) == 0 {
+		return completePathBinaries(cmd, args, toComplete)
+	}
+	return nil, cobra.ShellCompDirectiveNoFileComp
 }
 
 // parsePinArgs splits the pin arguments into a target and a concrete version,

--- a/cmd/pin_test.go
+++ b/cmd/pin_test.go
@@ -4,7 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/nao1215/gup/internal/goutil"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -111,5 +114,68 @@ func TestParsePinArgs_tooManyArgs(t *testing.T) {
 	t.Parallel()
 	if _, _, err := parsePinArgs([]string{"a", "b", "c"}); err == nil {
 		t.Fatal("parsePinArgs() err = nil, want error for three args")
+	}
+}
+
+// Test_completeFirstArgPathBinaries guards the "one binary argument" contract of
+// pin and unpin: cobra keeps calling ValidArgsFunction past the Args validator's
+// maximum, so binaries must only be offered where one can still be accepted.
+//
+//nolint:paralleltest // t.Setenv pins $GOBIN, which forbids parallel subtests
+func Test_completeFirstArgPathBinaries(t *testing.T) {
+	t.Setenv("GOBIN", helper_makeBinaries(t, testBinGal, testBinSubaru))
+
+	tests := []struct {
+		name       string
+		args       []string
+		toComplete string
+		want       []string
+	}{
+		{name: "first argument completes binaries", args: []string{}, want: []string{testBinGal, testBinSubaru}},
+		{name: "first argument honors the typed prefix", args: []string{}, toComplete: "s", want: []string{testBinSubaru}},
+		// pin's second argument is a VERSION, and unpin accepts no second
+		// argument at all: neither takes another binary name.
+		{name: "second argument offers nothing", args: []string{testBinGal}},
+		{name: "argument past the maximum offers nothing", args: []string{testBinGal, testVersionOne}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, directive := completeFirstArgPathBinaries(nil, tt.args, tt.toComplete)
+			if directive != cobra.ShellCompDirectiveNoFileComp {
+				t.Errorf("directive = %v, want NoFileComp", directive)
+			}
+			if diff := cmp.Diff(tt.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("completions mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// Test_pinAndUnpinUseFirstArgCompletion keeps the two commands wired to the
+// shared completion helper, so a future edit cannot silently regress one of them.
+//
+//nolint:paralleltest // t.Setenv pins $GOBIN, which forbids parallel subtests
+func Test_pinAndUnpinUseFirstArgCompletion(t *testing.T) {
+	t.Setenv("GOBIN", helper_makeBinaries(t, testBinGal))
+
+	for _, tt := range []struct {
+		name string
+		cmd  *cobra.Command
+	}{
+		{name: testCmdPin, cmd: newPinCmd()},
+		{name: "unpin", cmd: newUnpinCmd()},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.cmd.ValidArgsFunction == nil {
+				t.Fatal("ValidArgsFunction is not registered")
+			}
+			got, _ := tt.cmd.ValidArgsFunction(tt.cmd, nil, "")
+			if diff := cmp.Diff([]string{testBinGal}, got); diff != "" {
+				t.Errorf("first argument completions mismatch (-want +got):\n%s", diff)
+			}
+			if got, _ := tt.cmd.ValidArgsFunction(tt.cmd, []string{testBinGal}, ""); len(got) != 0 {
+				t.Errorf("second argument completions = %v, want none", got)
+			}
+		})
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -1033,6 +1034,119 @@ func TestExecute_CompletionForShell(t *testing.T) {
 			}
 			if tt.wantHeader != "" && !strings.Contains(got, tt.wantHeader) {
 				t.Errorf("completion output does not include %q", tt.wantHeader)
+			}
+		})
+	}
+}
+
+// helper_shellCompletion drives cobra's hidden "__complete" command through the
+// real root command, the same way a shell does. It returns the candidate names
+// and the directive line so the wiring - not just the helper functions - is
+// covered.
+func helper_shellCompletion(t *testing.T, args ...string) ([]string, cobra.ShellCompDirective) {
+	t.Helper()
+
+	rootCmd := newRootCmd()
+	stdout := &bytes.Buffer{}
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(io.Discard)
+	rootCmd.SetArgs(append([]string{cobra.ShellCompRequestCmd}, args...))
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("__complete %v: %v", args, err)
+	}
+
+	lines := strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n")
+	if len(lines) == 0 {
+		t.Fatalf("__complete %v printed nothing", args)
+	}
+	directiveLine := lines[len(lines)-1]
+	if !strings.HasPrefix(directiveLine, ":") {
+		t.Fatalf("__complete %v: last line %q is not a directive", args, directiveLine)
+	}
+	directive, err := strconv.Atoi(strings.TrimPrefix(directiveLine, ":"))
+	if err != nil {
+		t.Fatalf("__complete %v: can't parse directive %q: %v", args, directiveLine, err)
+	}
+
+	candidates := []string{}
+	for _, line := range lines[:len(lines)-1] {
+		if line == "" {
+			continue
+		}
+		// cobra separates a candidate from its description with a tab.
+		candidates = append(candidates, strings.SplitN(line, "\t", 2)[0])
+	}
+	return candidates, cobra.ShellCompDirective(directive)
+}
+
+// Test_shellCompletion_arguments runs the completions a shell actually requests,
+// through the assembled command tree. It is the regression net for the argument
+// completion contracts: migrate reads its own BEFORE_PATH, pin/unpin only accept
+// one binary, and --timeout never completes file names.
+func Test_shellCompletion_arguments(t *testing.T) {
+	gobin := helper_makeBinaries(t, testBinGobinOnly)
+	t.Setenv("GOBIN", gobin)
+	before := helper_makeBinaries(t, testBinBeforeOnly)
+	after := t.TempDir()
+
+	tests := []struct {
+		name          string
+		args          []string
+		want          []string
+		wantDirective cobra.ShellCompDirective
+	}{
+		{
+			name:          "update completes $GOBIN binaries",
+			args:          []string{testCmdUpdate, ""},
+			want:          []string{testBinGobinOnly},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "migrate completes directories for BEFORE_PATH",
+			args:          []string{testCmdMigrate, ""},
+			want:          []string{},
+			wantDirective: cobra.ShellCompDirectiveFilterDirs,
+		},
+		{
+			name:          "migrate completes BINARY from BEFORE_PATH, not $GOBIN",
+			args:          []string{testCmdMigrate, before, after, ""},
+			want:          []string{testBinBeforeOnly},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "pin completes a binary for its first argument",
+			args:          []string{testCmdPin, ""},
+			want:          []string{testBinGobinOnly},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "pin does not complete a binary for VERSION",
+			args:          []string{testCmdPin, testBinGobinOnly, ""},
+			want:          []string{},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "unpin does not complete past its single argument",
+			args:          []string{"unpin", testBinGobinOnly, ""},
+			want:          []string{},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "--timeout does not complete file names",
+			args:          []string{testCmdUpdate, testFlagTimeout, ""},
+			want:          []string{},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, directive := helper_shellCompletion(t, tt.args...)
+			if directive != tt.wantDirective {
+				t.Errorf("directive = %v, want %v", directive, tt.wantDirective)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("completions mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -584,23 +584,56 @@ func binaryNameFromImportPathWith(importPath, goos, goExe string) string {
 	return binName
 }
 
+// completePathBinaries completes the names of the binaries installed under the
+// current $GOBIN (or $GOPATH/bin). Use it for the commands that act on the
+// binaries gup manages by default (update, check, remove, pin, unpin).
 func completePathBinaries(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	binList, _ := pkgselect.BinaryPaths()
+	binList, err := pkgselect.BinaryPaths()
+	if err != nil {
+		// Completion has no channel to print an error on, so tell the shell the
+		// completion failed instead of pretending no binary is installed.
+		return nil, cobra.ShellCompDirectiveError
+	}
+	return completeBinaryNames(binList, toComplete), cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeBinariesInDir completes the names of the binaries directly under dir.
+// The commands that take an explicit source directory as a positional argument
+// (migrate's BEFORE_PATH) must use this instead of completePathBinaries: they
+// act on the binaries in that directory, which is typically NOT the current
+// $GOBIN - migrating away from an old GOBIN is the whole point of the command.
+func completeBinariesInDir(dir, toComplete string) ([]string, cobra.ShellCompDirective) {
+	binList, err := goutil.BinaryPathList(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// A directory the user has not finished typing yet is an ordinary
+			// state during completion, not a failure: offer nothing.
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		return nil, cobra.ShellCompDirectiveError
+	}
+	return completeBinaryNames(binList, toComplete), cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeBinaryNames returns the base names of binList that start with
+// toComplete. Prefix matching is case-insensitive on Windows, where file names
+// are, so "GO<TAB>" still finds "gopls.exe".
+func completeBinaryNames(binList []string, toComplete string) []string {
 	prefix := toComplete
 	if runtime.GOOS == goosWindows {
 		prefix = strings.ToLower(prefix)
 	}
 	filtered := make([]string, 0, len(binList))
-	for i, b := range binList {
-		binList[i] = filepath.Base(b)
-		candidate := binList[i]
+	for _, b := range binList {
+		name := filepath.Base(b)
+		candidate := name
 		if runtime.GOOS == goosWindows {
 			candidate = strings.ToLower(candidate)
 		}
 		if prefix != "" && !strings.HasPrefix(candidate, prefix) {
 			continue
 		}
-		filtered = append(filtered, binList[i])
+		filtered = append(filtered, name)
 	}
-	return filtered, cobra.ShellCompDirectiveNoFileComp
+	return filtered
 }

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -226,6 +226,13 @@ func Test_completeBinariesInDir_missing(t *testing.T) {
 // Test_completeBinariesInDir_notDirectory verifies that a real read failure is
 // surfaced as a completion error instead of being silently dropped.
 func Test_completeBinariesInDir_notDirectory(t *testing.T) {
+	if runtime.GOOS == goosWindows {
+		// Windows reports a non-directory path as ERROR_PATH_NOT_FOUND, which Go
+		// maps to os.ErrNotExist, so the "path not typed out yet" branch handles
+		// it there and no error reaches the caller. Only POSIX distinguishes the
+		// two with ENOTDIR.
+		t.Skip("a non-directory path is not distinguishable from a missing one on Windows")
+	}
 	t.Parallel()
 
 	file := filepath.Join(helper_makeBinaries(t, testBinGal), testBinGal)

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -126,6 +126,118 @@ func Test_completePathBinaries_prefix(t *testing.T) {
 	}
 }
 
+// helper_makeBinaries creates empty executable files named by names in a fresh
+// directory and returns it. Completion only reads directory entries, so the
+// files need no content.
+func helper_makeBinaries(t *testing.T, names ...string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	for _, name := range names {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte{}, 0o600); err != nil {
+			t.Fatalf("failed to create %s: %v", path, err)
+		}
+	}
+	return dir
+}
+
+func Test_completeBinaryNames(t *testing.T) {
+	t.Parallel()
+
+	binList := []string{
+		filepath.Join("a", testBinGal),
+		filepath.Join("b", testCmdGup),
+		filepath.Join("c", testBinSubaru),
+	}
+	tests := []struct {
+		name       string
+		toComplete string
+		want       []string
+	}{
+		{name: "empty prefix returns every base name", toComplete: "", want: []string{testBinGal, testCmdGup, testBinSubaru}},
+		{name: "prefix filters candidates", toComplete: "g", want: []string{testBinGal, testCmdGup}},
+		{name: "exact prefix keeps one candidate", toComplete: "sub", want: []string{testBinSubaru}},
+		{name: "unmatched prefix returns no candidate", toComplete: "zzz", want: []string{}},
+		// The base name is completed, never the directory it lives in.
+		{name: "directory part is not a prefix match", toComplete: "a", want: []string{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := completeBinaryNames(binList, tt.toComplete)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("completeBinaryNames(_, %q) mismatch (-want +got):\n%s", tt.toComplete, diff)
+			}
+		})
+	}
+}
+
+// Test_completeBinaryNames_windowsCaseInsensitive covers the Windows branch,
+// where file names are case-insensitive so "GA" must still find "gal.exe".
+func Test_completeBinaryNames_windowsCaseInsensitive(t *testing.T) {
+	if runtime.GOOS != goosWindows {
+		t.Skip("case-insensitive matching is a Windows-only behavior")
+	}
+	t.Parallel()
+
+	got := completeBinaryNames([]string{filepath.Join("a", testBinGal+".exe")}, "GA")
+	if diff := cmp.Diff([]string{testBinGal + ".exe"}, got); diff != "" {
+		t.Errorf("completeBinaryNames mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// Test_completeBinariesInDir asserts that completion reads the directory it is
+// handed instead of $GOBIN. 'gup migrate' relies on it: BEFORE_PATH is normally
+// an old GOBIN that is no longer the current one.
+func Test_completeBinariesInDir(t *testing.T) {
+	t.Setenv("GOBIN", helper_makeBinaries(t, testBinGobinOnly))
+	dir := helper_makeBinaries(t, testBinGal, testBinSubaru)
+
+	got, directive := completeBinariesInDir(dir, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("directive = %v, want NoFileComp", directive)
+	}
+	if diff := cmp.Diff([]string{testBinGal, testBinSubaru}, got); diff != "" {
+		t.Errorf("completeBinariesInDir mismatch (-want +got):\n%s", diff)
+	}
+
+	got, _ = completeBinariesInDir(dir, "s")
+	if diff := cmp.Diff([]string{testBinSubaru}, got); diff != "" {
+		t.Errorf("completeBinariesInDir with prefix mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// Test_completeBinariesInDir_missing covers a half-typed path: that is an
+// ordinary state during completion, so it must offer nothing rather than report
+// a completion failure.
+func Test_completeBinariesInDir_missing(t *testing.T) {
+	t.Parallel()
+
+	got, directive := completeBinariesInDir(filepath.Join(t.TempDir(), "no-such-dir"), "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("directive = %v, want NoFileComp", directive)
+	}
+	if len(got) != 0 {
+		t.Errorf("completions = %v, want none", got)
+	}
+}
+
+// Test_completeBinariesInDir_notDirectory verifies that a real read failure is
+// surfaced as a completion error instead of being silently dropped.
+func Test_completeBinariesInDir_notDirectory(t *testing.T) {
+	t.Parallel()
+
+	file := filepath.Join(helper_makeBinaries(t, testBinGal), testBinGal)
+	got, directive := completeBinariesInDir(file, "")
+	if directive != cobra.ShellCompDirectiveError {
+		t.Errorf("directive = %v, want Error", directive)
+	}
+	if got != nil {
+		t.Errorf("completions = %v, want nil", got)
+	}
+}
+
 func Test_catchSignal(t *testing.T) {
 	signals := make(chan os.Signal, 1)
 	done := make(chan struct{})

--- a/e2e/atago/completion.atago.yaml
+++ b/e2e/atago/completion.atago.yaml
@@ -105,3 +105,130 @@ scenarios:
           exit_code: 1
           stderr:
             contains: "cannot be used with shell argument"
+
+  # The scenarios below drive cobra's hidden __complete command - exactly what a
+  # shell runs on <TAB>. gup prints the candidates on STDOUT and the directive
+  # name ("ShellCompDirectiveNoFileComp", ...) on STDERR, so both the offered
+  # names and the file-completion behavior are asserted against the real binary.
+
+  - name: migrate completes directories while BEFORE_PATH and AFTER_PATH are typed
+    env: *iso
+    steps:
+      - run:
+          command: gup __complete migrate ""
+      - assert:
+          exit_code: 0
+          stderr:
+            contains: ShellCompDirectiveFilterDirs
+      # The second positional argument is a directory too.
+      - run:
+          command: gup __complete migrate "${workdir}/before" ""
+      - assert:
+          exit_code: 0
+          stderr:
+            contains: ShellCompDirectiveFilterDirs
+
+  - name: migrate completes BINARY from BEFORE_PATH instead of the current GOBIN
+    env: *iso
+    steps:
+      # outdated lives only under BEFORE_PATH, uptodate only under the current
+      # $GOBIN. migrate reinstalls what BEFORE_PATH holds, so only outdated is a
+      # legal BINARY argument here.
+      - run:
+          command: go install gup.test/outdated@v1.0.0
+          env:
+            GOBIN: "${workdir}/before"
+      - run:
+          command: go install gup.test/uptodate@v1.0.0
+      - run:
+          command: gup __complete migrate "${workdir}/before" "${workdir}/after" ""
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: outdated
+            not_contains: uptodate
+          stderr:
+            contains: ShellCompDirectiveNoFileComp
+      # A typed prefix that only the $GOBIN binary matches must stay empty.
+      - run:
+          command: gup __complete migrate "${workdir}/before" "${workdir}/after" up
+      - assert:
+          exit_code: 0
+          stdout:
+            not_contains: uptodate
+
+  - name: migrate offers no BINARY when BEFORE_PATH does not exist yet
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/uptodate@v1.0.0
+      - run:
+          command: gup __complete migrate "${workdir}/no-such-dir" "${workdir}/after" ""
+      - assert:
+          exit_code: 0
+          stdout:
+            not_contains: uptodate
+          stderr:
+            contains: ShellCompDirectiveNoFileComp
+
+  - name: pin completes a binary for TOOL but not for VERSION
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/pinnable@v1.0.0
+      - run:
+          command: gup __complete pin ""
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: pinnable
+      # The second argument is a VERSION: offering a binary name there would be
+      # wrong, and cobra keeps calling the completion past the argument maximum.
+      - run:
+          command: gup __complete pin pinnable ""
+      - assert:
+          exit_code: 0
+          stdout:
+            not_contains: pinnable
+          stderr:
+            contains: ShellCompDirectiveNoFileComp
+
+  - name: unpin completes one binary and nothing beyond it
+    env: *iso
+    steps:
+      - run:
+          command: go install gup.test/pinnable@v1.0.0
+      - run:
+          command: gup __complete unpin ""
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: pinnable
+      - run:
+          command: gup __complete unpin pinnable ""
+      - assert:
+          exit_code: 0
+          stdout:
+            not_contains: pinnable
+          stderr:
+            contains: ShellCompDirectiveNoFileComp
+
+  - name: --timeout completes no file name
+    env: *iso
+    steps:
+      # A duration is not a path, so the shell must not fall back to file
+      # completion (which is what ShellCompDirectiveDefault would request).
+      - run:
+          command: gup __complete update --timeout ""
+      - assert:
+          exit_code: 0
+          stderr:
+            contains: ShellCompDirectiveNoFileComp
+            not_contains: ShellCompDirectiveDefault
+      - run:
+          command: gup __complete migrate --timeout ""
+      - assert:
+          exit_code: 0
+          stderr:
+            contains: ShellCompDirectiveNoFileComp
+            not_contains: ShellCompDirectiveDefault


### PR DESCRIPTION
## Summary

Follow-up to #438. `gup migrate BEFORE_PATH AFTER_PATH <TAB>` completed the binaries installed under the current `$GOBIN`, but `runMigrate` scans `BEFORE_PATH` — normally an old GOBIN that is no longer the current one, which is the whole reason the command exists. Completion therefore hid every migratable binary and offered names that migrate cannot accept. This scopes that completion to the directory the user actually typed, folds the completion callbacks added in #438 into named helpers, and covers all of it with unit and E2E tests.

## Changes

- `cmd/update.go`: split the name-filtering out of `completePathBinaries` into `completeBinaryNames`, and add `completeBinariesInDir`, which lists the binaries under an explicit directory.
- `cmd/migrate.go`: replace the inline `ValidArgsFunction` with `completeMigrateArgs`, which completes directories until BEFORE_PATH and AFTER_PATH are given and then completes BINARY from `args[0]`.
- `cmd/pin.go`: replace the two identical inline callbacks of `pin` and `unpin` with the shared `completeFirstArgPathBinaries`.
- `cmd/flags.go`: register the `--timeout` completion through the existing `mustRegisterFlagCompletion` helper instead of repeating its panic guard.
- `cmd/update_test.go`, `cmd/migrate_test.go`, `cmd/pin_test.go`, `cmd/flags_test.go`, `cmd/root_test.go`: unit tests for each helper plus `Test_shellCompletion_arguments`, which drives cobra's `__complete` through the assembled command tree exactly as a shell does.
- `e2e/atago/completion.atago.yaml`: six offline E2E scenarios asserting both the offered names (STDOUT) and the completion directive (STDERR) against the real binary.

## Design Decisions

Completion has no channel to report an error on, so the previous `binList, _ :=` dropped failures silently. `completePathBinaries` and `completeBinariesInDir` now return `ShellCompDirectiveError` on a genuine read failure, while a BEFORE_PATH that does not exist yet is treated as an ordinary half-typed path and simply yields no candidate.

`completeBinariesInDir` takes a plain directory string rather than a `cobra.CompletionFunc` signature, because the directory is a positional argument the caller has already parsed; `completeMigrateArgs` owns the argument grammar and stays next to the command it belongs to.

Both the unit tests and the E2E scenarios were verified to fail when the fix is reverted, so they are real regression tests rather than restatements of the current behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved shell completion for update, migrate, pin, and unpin commands.
  * Added context-aware directory and binary suggestions, including binaries from configured paths.
  * Added partial-name filtering and platform-appropriate matching.
  * Limited binary suggestions to valid positional arguments.
  * Improved timeout flag completion to prevent file suggestions.

* **Bug Fixes**
  * Completion errors are now reported instead of silently returning no results.
  * Invalid or unavailable paths are handled consistently during completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->