### PR TITLE
feat(release): publish Windows builds to winget from the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+          # Fork-scoped token so the winget manifests can be pushed to
+          # nao1215/winget-pkgs and the pull request opened upstream.
+          WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
       - name: Attest build provenance
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -108,6 +108,66 @@ nfpms:
         dst: /usr/share/zsh/vendor-completions/_gup
         file_info:
           mode: 0644
+# winget distribution for Windows. `nao1215.gup` already exists in the community
+# repository, but nothing here put it there: a third-party bot watches the
+# releases and submits manifests when it gets around to it, which is why v1.5.1,
+# v1.6.0, and v1.7.0 never reached winget at all and v1.8.0 arrived five days
+# late carrying v1.7.1's release notes. Publishing from the release takes that
+# over — the identifier is unchanged, so the next tag simply supersedes the
+# bot's last submission, and the bot skips a version that is already there.
+#
+# The Windows archives are zips, which winget installs as a portable package, so
+# no installer is built or signed. The manifests go to a branch on
+# nao1215/winget-pkgs, a fork of the community repository, and the pull request
+# is opened against microsoft/winget-pkgs. The publisher and description fields
+# match what the package page already shows, so the takeover is not a visible
+# change to anyone who has gup installed.
+winget:
+  - name: gup
+    package_identifier: nao1215.gup
+    publisher: Chikamatsu Naohiro
+    publisher_url: "https://github.com/nao1215"
+    publisher_support_url: "https://github.com/nao1215/gup/issues"
+    author: Chikamatsu Naohiro
+    homepage: "https://github.com/nao1215/gup"
+    short_description: 'gup - Update binaries installed by "go install" with goroutines'
+    description: |
+      gup updates and manages the global Go command-line tools in $GOBIN.
+      `go install` places each program there but never updates it again, keeps no
+      manifest of what it installed, and offers no way to hold a tool at a
+      version you depend on. gup brings the whole set up to date in parallel,
+      pins selected tools to exact versions, and adds the management commands
+      `go install` lacks: list and check what is installed, remove binaries,
+      export and import the set to reproduce it on another machine, and migrate
+      it to a new $GOBIN.
+    license: Apache-2.0
+    license_url: "https://github.com/nao1215/gup/blob/main/LICENSE"
+    copyright: "Copyright (c) Chikamatsu Naohiro"
+    copyright_url: "https://github.com/nao1215/gup/blob/main/LICENSE"
+    release_notes_url: "https://github.com/nao1215/gup/releases/tag/{{ .Tag }}"
+    tags:
+      - cli-app
+      - command-line-tool
+      - cross-platform
+      - go
+      - golang
+      - golang-tools
+      - update
+      - updater
+      - user-friendly
+    skip_upload: auto
+    repository:
+      owner: nao1215
+      name: winget-pkgs
+      branch: "gup-{{ .Version }}"
+      token: "{{ .Env.WINGET_GITHUB_TOKEN }}"
+      pull_request:
+        enabled: true
+        draft: false
+        base:
+          owner: microsoft
+          name: winget-pkgs
+          branch: master
 brews:
   - name: gup
     description: 'Fast manager for Go-installed binaries in $GOBIN: update, export/import, and migrate toolsets across machines'

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -33,12 +33,19 @@ The release workflow then:
 - publishes archives, `deb`/`rpm`/`apk` packages, and `checksums.txt`;
 - signs the checksums with cosign (keyless) and attaches an SBOM;
 - attests build provenance via GitHub OIDC;
-- updates the Homebrew tap (`nao1215/homebrew-tap`).
+- updates the Homebrew tap (`nao1215/homebrew-tap`);
+- pushes the winget manifests to `nao1215/winget-pkgs` and opens the pull request against [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs).
 
 ## Required secrets
 - `GITHUB_TOKEN`: provided automatically; used to create the GitHub Release.
 - `TAP_GITHUB_TOKEN`: a token with write access to `nao1215/homebrew-tap`,
   used to push the updated formula.
+- `WINGET_GITHUB_TOKEN`: a classic token with the `public_repo` scope, used to commit the winget manifests to `nao1215/winget-pkgs` and open the upstream pull request. A fine-grained token does not work here: it can only be scoped to repositories you own, and opening the pull request is a write against microsoft/winget-pkgs. A failure is logged without failing the release, so a rejected or delayed pull request never blocks a version.
+
+## The winget pull request
+A **stable** tagged release opens a pull request on microsoft/winget-pkgs; a moderator merges it once their validation pipeline passes, usually within a day. A pre-release tag opens nothing: `skip_upload: auto` skips the winget pipe whenever the tag carries a pre-release suffix, because the community repository takes stable versions only.
+
+Until this was wired up a third-party bot submitted gup's manifests on its own schedule, which is why v1.5.1, v1.6.0, and v1.7.0 never reached winget. The bot skips a version that is already present, so publishing from the release simply takes over.
 
 ## After releasing
 - Check the [Releases page](https://github.com/nao1215/gup/releases) for the
@@ -46,6 +53,8 @@ The release workflow then:
 - Verify a downloaded artifact as described in
   [Verifying release integrity](../README.md#verifying-release-integrity).
 - Confirm `brew upgrade gup` picks up the new version.
+- Confirm the winget pull request was opened, under [pull requests authored by nao1215](https://github.com/microsoft/winget-pkgs/pulls/nao1215). A winget failure is logged without failing the release, so a green release job does not by itself mean the submission happened.
+- If no pull request appears, recover it by hand: the manifests were still generated under `dist/winget/manifests/n/nao1215/gup/<version>/`, and the three files can be committed to a `gup-<version>` branch on `nao1215/winget-pkgs` and submitted against `microsoft/winget-pkgs` `master`. A failure at the push step points at the token's scope; a failure only at the pull-request step points at a fine-grained token being used where a classic one is required.
 
 ## If a release fails
 - Re-run the failed job from the Actions tab once the cause is fixed.


### PR DESCRIPTION
## Summary

`nao1215.gup` already exists in the community repository, but nothing in this repo put it there. A third-party bot watches the releases and submits manifests when it gets around to it, and that schedule has holes:

| release | in winget |
|---|---|
| v1.5.0 | yes |
| v1.5.1 | no |
| v1.6.0 | no |
| v1.7.0 | no |
| v1.7.1 | yes |
| v1.8.0 | yes, five days late, carrying v1.7.1's release notes |

Three of the last six releases never reached winget, so `winget install nao1215.gup` can hand someone a version several releases behind.

This publishes the manifests from the release instead. The Windows archives are already zips, which winget installs as a portable package, so there is no installer to build or sign. GoReleaser writes the three manifests to a branch on nao1215/winget-pkgs, a fork of the community repository, and opens the pull request against microsoft/winget-pkgs. A tag stays the only manual step.

The identifier is unchanged, so the next tag supersedes the bot's last submission rather than competing with it — the bot skips a version that is already present. Publisher, author, description, and tags match what the package page shows today, so nothing visibly changes for anyone who already has gup installed.

The release workflow gains `WINGET_GITHUB_TOKEN`. It has to be a classic token with `public_repo`: a fine-grained token can only be scoped to repositories you own, and opening the pull request is a write against microsoft/winget-pkgs. A winget failure is logged without failing the release, so a rejected or delayed pull request cannot block a version. doc/RELEASE.md documents both points.

Verified with the pinned GoReleaser (v2.16.0): it generates the version, installer, and locale manifests, with x86, x64, and arm64 installers pointing at the release zips, `NestedInstallerType: portable`, and `PortableCommandAlias: gup` — `gup.exe` is found at the archive root despite the bundled `completions/` directory.

The install page already documents `winget install --id nao1215.gup`, so no README or website change is needed. No CHANGELOG entry: this repo stamps the changelog at release time.

## Related issue

## Checklist

- [ ] Added or updated unit tests for the change
- [x] `make test` / `make vet` / `make fmt` pass locally
- [x] If I changed `README.md`, I updated the translated READMEs under `doc/<lang>/README.md` for the affected sections, or confirmed the "translation may lag behind English" banner is present (see [CONTRIBUTING.md](../CONTRIBUTING.md#documentation-and-translations))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated Windows package publishing through Winget.
  * Releases now include Winget metadata, release notes, and automated manifest pull requests.
  * Added support for updating the Homebrew tap during releases.
  * Stable and pre-release versions are handled appropriately across package distribution channels.

* **Documentation**
  * Expanded release documentation with Winget setup, workflow details, verification steps, and failure-recovery guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
