### PR TITLE
docs(changelog): prepare v1.8.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v1.8.1](https://github.com/nao1215/gup/compare/v1.8.0...v1.8.1) (2026-08-15)
+
+### Features
+
+* Windows installs are published to winget from the release. `nao1215.gup` already existed in the community repository, but a third-party bot submitted the manifests on its own schedule and missed v1.5.1, v1.6.0, and v1.7.0 outright; v1.8.0 arrived five days after the tag carrying v1.7.1's release notes. A tagged release now generates the manifests and opens the pull request against microsoft/winget-pkgs itself, so `winget install --id nao1215.gup` tracks the release page. The identifier is unchanged, so nothing changes for anyone who already installed gup that way. (#445)
+
 ## [v1.8.0](https://github.com/nao1215/gup/compare/v1.7.1...v1.8.0) (2026-08-09)
 
 ### Features


### PR DESCRIPTION
## Summary

Prepare v1.8.1. The only change since v1.8.0 that reaches users is the winget wiring, and the tag is what activates it: the pipe runs on a release, so this is the first version whose manifest gup submits itself rather than waiting for the third-party bot that missed three of the last six releases.

## Related issue

## Checklist

- [ ] Added or updated unit tests for the change
- [x] `make test` / `make vet` / `make fmt` pass locally
- [x] If I changed `README.md`, I updated the translated READMEs under
      `doc/<lang>/README.md` for the affected sections, or confirmed the
      "translation may lag behind English" banner is present
      (see [CONTRIBUTING.md](../CONTRIBUTING.md#documentation-and-translations))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 1.8.1.
  * Documented automated Windows winget manifest generation and pull-request submission for tagged releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->