### PR TITLE
fix(goutil): don't compare Go toolchain suffixes

### DIFF
--- a/internal/goutil/goutil_test.go
+++ b/internal/goutil/goutil_test.go
@@ -1042,7 +1042,7 @@ func TestNormalizeGoVersionForCompare(t *testing.T) {
 		want string
 	}{
 		{name: "plain version", in: "go1.26.0", want: "1.26.0"},
-		{name: "rc1", in: "go1.26.0rc1", want: "1.26.0rc1"},
+		{name: "rc1", in: "go1.26rc1", want: "1.26rc1"},
 		{name: "experiment suffix", in: "go1.26.0-X:nodwarf5", want: "1.26.0"},
 		{name: "different experiment", in: "go1.26.0-X:jsonv2", want: "1.26.0"},
 		{name: "custom suffix", in: "go1.26.0-bigcorp", want: "1.26.0"},
@@ -1071,8 +1071,34 @@ func TestPackage_IsGoUpToDate_customBuildTag(t *testing.T) {
 		},
 	}
 
-	if !pkgInfo.IsGoUpToDate() {
-		t.Fatal("custom Go build tag with ':' should be treated as up-to-date when equal")
+	pkgInfo2 := pkgInfo
+	pkgInfo2.GoVersion = &Version{
+		Current: "go1.26.0-X:jsonv2",
+		Latest:  "go1.26.0-X:nodwarf5",
+	}
+
+	tests := []struct {
+		name string
+		in   Package
+		want bool
+	}{
+		{name: "original case", in: pkgInfo, want: true},
+		{name: "different custom build tags", in: pkgInfo2, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.in.IsGoUpToDate()
+			if got != tt.want {
+				t.Fatalf(
+					"IsGoUpToDate(%q, %q) = %v, want %v",
+					tt.in.GoVersion.Current,
+					tt.in.GoVersion.Latest,
+					got,
+					tt.want,
+				)
+			}
+		})
 	}
 }
 

--- a/internal/goutil/goutil_test.go
+++ b/internal/goutil/goutil_test.go
@@ -1041,10 +1041,11 @@ func TestNormalizeGoVersionForCompare(t *testing.T) {
 		in   string
 		want string
 	}{
-		{name: "keep semver chars", in: "1.26.0-X.nodwarf5+meta", want: "1.26.0-X.nodwarf5+meta"},
-		{name: "replace colon", in: "1.26.0-X:nodwarf5", want: "1.26.0-X.nodwarf5"},
-		{name: "replace tilde", in: "1.26.0-X~nodwarf5", want: "1.26.0-X.nodwarf5"},
-		{name: "trim spaces", in: " 1.26.0-X:nodwarf5 ", want: "1.26.0-X.nodwarf5"},
+		{name: "plain version", in: "go1.26.0", want: "1.26.0"},
+		{name: "rc1", in: "go1.26.0rc1", want: "1.26.0rc1"},
+		{name: "experiment suffix", in: "go1.26.0-X:nodwarf5", want: "1.26.0"},
+		{name: "different experiment", in: "go1.26.0-X:jsonv2", want: "1.26.0"},
+		{name: "custom suffix", in: "go1.26.0-bigcorp", want: "1.26.0"},
 	}
 
 	for _, tt := range tests {

--- a/internal/goutil/version.go
+++ b/internal/goutil/version.go
@@ -155,9 +155,8 @@ func VersionUpToDate(current, available string) bool {
 	return versionUpToDate(current, available)
 }
 
-// GoVersionUpToDate is VersionUpToDate for Go toolchain versions: it first
-// normalizes known non-semver separators (e.g. "go1.26.0-X:nodwarf5") so custom
-// toolchains compare correctly. The "go" prefix must already be stripped.
+// GoVersionUpToDate compares Go toolchain versions after stripping the "go"
+// prefix and custom toolchain suffixes, following Go's own toolchain parsing.
 func GoVersionUpToDate(current, available string) bool {
 	return goVersionUpToDate(current, available)
 }

--- a/internal/goutil/version.go
+++ b/internal/goutil/version.go
@@ -85,8 +85,8 @@ func (p *Package) IsPackageUpToDate() bool {
 // Returns true if current >= available.
 func (p *Package) IsGoUpToDate() bool {
 	return goVersionUpToDate(
-		strings.TrimPrefix(p.GoVersion.Current, "go"),
-		strings.TrimPrefix(p.GoVersion.Latest, "go"),
+		p.GoVersion.Current,
+		p.GoVersion.Latest,
 	)
 }
 
@@ -112,26 +112,15 @@ func goVersionUpToDate(current, available string) bool {
 
 func normalizeGoVersionForCompare(ver string) string {
 	ver = strings.TrimSpace(ver)
-	if ver == "" {
-		return ver
+	ver = strings.TrimPrefix(ver, "go")
+
+	// Toolchain suffixes are not part of the Go release version.
+	// This follows cmd/go/internal/gover.FromToolchain semantics.
+	if i := strings.IndexAny(ver, "- \t"); i >= 0 {
+		ver = ver[:i]
 	}
 
-	var b strings.Builder
-	b.Grow(len(ver))
-	for _, r := range ver {
-		switch {
-		case r >= '0' && r <= '9',
-			r >= 'a' && r <= 'z',
-			r >= 'A' && r <= 'Z',
-			r == '.',
-			r == '-',
-			r == '+':
-			b.WriteRune(r)
-		default:
-			b.WriteByte('.')
-		}
-	}
-	return b.String()
+	return ver
 }
 
 // versionUpToDate parses versions and compares them.


### PR DESCRIPTION
## Summary

-X:nodwarf5 and -X:jsonv2 are toolchain metadata, not part of the Go release version. Treating them as SemVer prerelease identifiers can cause needless rebuilds when the base Go version is unchanged.

## Related issue

This bug was introduced in version v1.1.1, as a fix for #248.

## Checklist

- [x] Added or updated unit tests for the change
- [x] `make test` / `make vet` / `make fmt` pass locally
- [ ] If I changed `README.md`, I updated the translated READMEs under
      `doc/<lang>/README.md` for the affected sections, or confirmed the
      "translation may lag behind English" banner is present
      (see [CONTRIBUTING.md](../CONTRIBUTING.md#documentation-and-translations))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved Go toolchain version recognition for standard releases and release candidates.
* Correctly handles optional `go` prefixes when comparing versions.
* Ignores experimental, custom, and other toolchain suffixes to avoid incorrect version comparisons.
* Improved consistency when determining whether the installed Go toolchain meets the required version.
* Added coverage for version formats commonly encountered in custom Go builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->