### PR TITLE
fix(website): make punctuation visible in dark mode

### DIFF
--- a/website/assets/css/chroma.css
+++ b/website/assets/css/chroma.css
@@ -134,6 +134,7 @@
   /* LiteralNumberInteger */ .chroma .mi { color:#a5d6ff }
   /* LiteralNumberIntegerLong */ .chroma .il { color:#a5d6ff }
   /* LiteralNumberOct */ .chroma .mo { color:#a5d6ff }
+  /* Punctuation */ .chroma .p { color:#e6edf3 }
   /* Operator */ .chroma .o { color:#ff7b72;font-weight:bold }
   /* OperatorWord */ .chroma .ow { color:#ff7b72;font-weight:bold }
   /* OperatorReserved */ .chroma .or { color:#ff7b72;font-weight:bold }


### PR DESCRIPTION
github-dark publishes no Punctuation entry, so the light theme's `.chroma .p { color:#1f2328 }` stayed in force under `prefers-color-scheme: dark`. Every colon, bracket and brace in a highlighted block rendered near-black on the #0d1117 background — a YAML snippet read `- uses  actions/checkout@v6`, which is not YAML.

Restores the dark foreground for punctuation. The same one-line fix has landed in atago, sqly, block, block-registry and setup-block, which share this stylesheet byte-for-byte.

(Direct push was declined by the protected branch, hence a PR.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark-mode code syntax highlighting by adding a clearer color for punctuation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->