### PR TITLE
docs: note the Topgrade integration in README and the website

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,9 @@ Go 1.24's built-in [`go tool`](https://go.dev/doc/modules/managing-dependencies#
 
 *Update time: 9 binaries each with a newer version available; gup updates in parallel, the others sequentially. AMD Ryzen AI Max+ 395 / go 1.26.4, median of 5 runs with a warm module cache; times depend on build time and CPU.*
 
+## Integrations
+[Topgrade](https://github.com/topgrade-rs/topgrade) updates the Go binaries under `$GOBIN` by running `gup update` when gup is installed. Nothing extra is needed on the gup side; how the step behaves is documented by Topgrade.
+
 ## FAQ
 
 ### `gup` fails with `fatal: not a git repository`

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -59,3 +59,9 @@ go install github.com/nao1215/gup@latest
 
 Homebrew, winget, mise, nix, aqua, and prebuilt packages are on the
 [install page](/install/).
+
+## Integrations
+
+[Topgrade](https://github.com/topgrade-rs/topgrade) updates the Go binaries
+under `$GOBIN` by running `gup update` when gup is installed. Nothing extra is
+needed on the gup side; how the step behaves is documented by Topgrade.


### PR DESCRIPTION
## Summary

[Topgrade](https://github.com/topgrade-rs/topgrade) runs `gup update` as its Go step, so people who already use Topgrade are updating their `$GOBIN` through gup without that being written down anywhere in gup's own docs. This adds a short "Integrations" section that states the fact and links to Topgrade.

## Changes

- `README.md`: new `## Integrations` section between "Feature comparison" and "FAQ".
- `website/content/_index.md`: the same section, in the same wording, at the end of the landing page.

## Design Decisions

The wording is a plain statement of what Topgrade does, not a "Used by" badge or an endorsement: Topgrade has not endorsed gup, and the text must not read as if it had. No Topgrade logo or branding is used. Details of how the step behaves (for example the `[go] gup_exclude` option) are left to Topgrade's own documentation so this section cannot go stale against their config schema. README and the website carry the same two sentences so the two stay in sync; the website copy only differs in line wrapping, matching the surrounding page.

The claim was checked against Topgrade's `src/steps/go.rs`, where `run_go_gup()` invokes `gup update`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about Go binary updates through `gup` when it is installed.
  * Documented that no additional setup is required for this integration.
  * Added the integration details to both the README and website landing page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->