### PR TITLE
docs: document brew install gup from homebrew-core and the AUR packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Documentation: **https://nao1215.github.io/gup/**
 - Windows
 
 ## How to install
-gup is already available via `winget`, `mise`, `nix`, and `aqua` in addition to `go install` and Homebrew.
+gup is packaged in homebrew-core, the winget community repository, the mise and aqua registries, nixpkgs, and the AUR, in addition to `go install` and the prebuilt packages on the release page.
 
 ### Use "go install"
 If you do not have the Go development environment installed on your system, please install it from the [official website](https://go.dev/doc/install).
@@ -32,6 +32,11 @@ go install github.com/nao1215/gup@latest
 Building from source needs Go 1.25 or newer. On an older Go, install a prebuilt release binary or a package (see below) instead.
 
 ### Use homebrew
+gup is in homebrew-core, so no tap is required:
+```shell
+brew install gup
+```
+The GoReleaser-built formula in `nao1215/tap` is still published as an alternative. It installs the prebuilt release binary instead of building from source:
 ```shell
 brew install nao1215/tap/gup
 ```
@@ -55,6 +60,13 @@ nix profile install nixpkgs#gogup
 gup is registered in the [aqua](https://aquaproj.github.io/) standard registry. Add it to your `aqua.yaml`:
 ```shell
 aqua g -i nao1215/gup
+```
+
+### Use the AUR (Arch Linux)
+Two community-maintained packages are available: [`gup`](https://aur.archlinux.org/packages/gup) builds from source, [`gup-bin`](https://aur.archlinux.org/packages/gup-bin) installs the release binary.
+```shell
+paru -S gup      # or: yay -S gup
+paru -S gup-bin  # prebuilt binary
 ```
 
 ### Install from Package or Binary

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -36,6 +36,8 @@ The release workflow then:
 - updates the Homebrew tap (`nao1215/homebrew-tap`);
 - pushes the winget manifests to `nao1215/winget-pkgs` and opens the pull request against [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs).
 
+Packaging that needs nothing from us: the [homebrew-core formula](https://formulae.brew.sh/formula/gup) carries `autobump`, so Homebrew opens its own bump pull request from the new tag, and the AUR packages (`gup`, `gup-bin`) plus the nixpkgs `gogup` attribute are maintained by other people on their own schedule.
+
 ## Required secrets
 - `GITHUB_TOKEN`: provided automatically; used to create the GitHub Release.
 - `TAP_GITHUB_TOKEN`: a token with write access to `nao1215/homebrew-tap`,
@@ -52,7 +54,7 @@ Until this was wired up a third-party bot submitted gup's manifests on its own s
   generated notes and artifacts.
 - Verify a downloaded artifact as described in
   [Verifying release integrity](../README.md#verifying-release-integrity).
-- Confirm `brew upgrade gup` picks up the new version.
+- Confirm `brew upgrade gup` picks up the new version. The tap formula is pushed by the release job; the homebrew-core bump lands separately once Homebrew's autobump pull request merges.
 - Confirm the winget pull request was opened, under [pull requests authored by nao1215](https://github.com/microsoft/winget-pkgs/pulls/nao1215). A winget failure is logged without failing the release, so a green release job does not by itself mean the submission happened.
 - If no pull request appears, recover it by hand: the manifests were still generated under `dist/winget/manifests/n/nao1215/gup/<version>/`, and the three files can be committed to a `gup-<version>` branch on `nao1215/winget-pkgs` and submitted against `microsoft/winget-pkgs` `master`. A failure at the push step points at the token's scope; a failure only at the pull-request step points at a fine-grained token being used where a classic one is required.
 

--- a/doc_sync_test.go
+++ b/doc_sync_test.go
@@ -196,10 +196,13 @@ func Test_englishReadme_hasCanonicalInstallCommands(t *testing.T) {
 	// "How to install" section. Keep this list in sync with its command blocks.
 	canonicalCommands := []string{
 		"go install github.com/nao1215/gup@latest",
+		"brew install gup",
 		"brew install nao1215/tap/gup",
 		"winget install --id nao1215.gup",
 		"mise use -g gup@latest",
 		"nix profile install nixpkgs#gogup",
+		"aqua g -i nao1215/gup",
+		"paru -S gup-bin",
 	}
 	// obsoleteCommands are install lines gup has moved away from. Checking that
 	// the canonical form is PRESENT does not catch a superseded line left sitting

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -57,7 +57,7 @@ from any directory and keep alongside your dotfiles.
 go install github.com/nao1215/gup@latest
 ```
 
-Homebrew, winget, mise, nix, aqua, and prebuilt packages are on the
+Homebrew, winget, mise, nix, aqua, the AUR, and prebuilt packages are on the
 [install page](/install/).
 
 ## Integrations

--- a/website/content/install.md
+++ b/website/content/install.md
@@ -1,6 +1,6 @@
 ---
 title: Install
-description: Install gup with go install, Homebrew, winget, mise, nix, aqua, or a prebuilt .deb/.rpm/.apk package, and verify the release signatures.
+description: Install gup with go install, Homebrew, winget, mise, nix, aqua, the AUR, or a prebuilt .deb/.rpm/.apk package, and verify the release signatures.
 ---
 
 gup runs on Linux, macOS, and Windows. It shells out to `go`, so a Go toolchain
@@ -16,6 +16,16 @@ Building from source needs Go 1.25 or newer. On an older Go, take a prebuilt
 binary or a package below.
 
 ## Package managers
+
+gup is in homebrew-core, so Homebrew needs no tap:
+
+```shell
+brew install gup
+```
+
+The GoReleaser-built formula in `nao1215/tap` remains published as an
+alternative. It installs the prebuilt release binary rather than building from
+source:
 
 ```shell
 brew install nao1215/tap/gup
@@ -37,6 +47,16 @@ gup is in the [aqua](https://aquaproj.github.io/) standard registry:
 
 ```shell
 aqua g -i nao1215/gup
+```
+
+On Arch Linux, two community-maintained AUR packages exist:
+[`gup`](https://aur.archlinux.org/packages/gup) builds from source and
+[`gup-bin`](https://aur.archlinux.org/packages/gup-bin) installs the release
+binary.
+
+```shell
+paru -S gup      # or: yay -S gup
+paru -S gup-bin  # prebuilt binary
 ```
 
 ## Prebuilt packages and binaries


### PR DESCRIPTION
## Why

Two install routes drifted out of the docs.

**homebrew-core.** gup is now shipped by homebrew-core as [`gup`](https://formulae.brew.sh/formula/gup) (currently 1.8.1, `autobump: true`, bottles for arm64_tahoe/sequoia/sonoma, sonoma, arm64_linux, x86_64_linux). The README and the website only documented `brew install nao1215/tap/gup`, so the shortest and most discoverable command was missing.

**AUR.** Two community-maintained Arch packages track gup and both sit at 1.8.1: [`gup`](https://aur.archlinux.org/packages/gup) builds from source and [`gup-bin`](https://aur.archlinux.org/packages/gup-bin) installs the release binary. Neither was mentioned anywhere.

I re-checked the other ecosystems while I was here: winget (1.8.1), mise (`registry/gup.toml`, aqua backend), aqua (`nao1215/gup@v1.8.1`) and nixpkgs (`gogup` 1.8.0 on unstable) are all present and already documented. Scoop, MacPorts, Chocolatey, conda-forge, snap and asdf have no gup entry — only auto-scraped third-party Scoop buckets, which are not worth pointing users at.

## What changed

- `README.md`: `brew install gup` is now the first Homebrew line, with the tap kept as the prebuilt-binary alternative; a new "Use the AUR (Arch Linux)" section; the lead sentence lists the ecosystems accurately.
- `website/content/install.md` and `website/content/_index.md`: same two additions, plus the page description.
- `doc/RELEASE.md`: spells out which packaging the release job does **not** drive — homebrew-core autobumps itself from the tag, and the AUR and nixpkgs packages are maintained by other people — so a release checklist reader does not go looking for a job that never existed.
- `doc_sync_test.go`: `Test_englishReadme_hasCanonicalInstallCommands` now also pins `brew install gup`, `aqua g -i nao1215/gup` and `paru -S gup-bin`. The aqua line was already in the README but untested.

Docs only; no behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded installation guidance with additional package sources, including Homebrew Core, AUR, nixpkgs, winget, mise, and aqua.
  - Added Homebrew installation instructions and clarified the alternative tap option.
  - Added commands for installing source-based and prebuilt AUR packages.
  - Updated release verification guidance for independently managed package updates.
- **Tests**
  - Updated installation documentation checks to reflect the current recommended commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->