### PR TITLE
fix(lock): lock what a command reads, and restore a detached lock atomically

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ The commands that change state take a lock on each resource they write, so a sec
 | `update` | `$GOBIN` and the `gup.json` it may write |
 | `import` | `$GOBIN` |
 | `remove` | `$GOBIN` |
-| `migrate` | `AFTER_PATH` |
+| `migrate` | `BEFORE_PATH` and `AFTER_PATH` |
 | `export`, `pin` | `$GOBIN` and the `gup.json` they write |
 | `unpin` | the `gup.json` it writes |
 
@@ -473,7 +473,11 @@ The second one exits non-zero after reporting who is in the way:
 > gup.json, so wait for it to finish and run this command again. If that process is
 > gone, gup reclaims /home/you/go/bin/.gup.lock by itself
 
-`export` and `pin` lock `$GOBIN` although they never write to it: what they write is a description of it, so a `gup remove` deleting a binary halfway through would leave a `gup.json` naming a tool that is no longer installed. `unpin` names an entry in `gup.json` and never looks at `$GOBIN`, so it does not wait behind one.
+`export`, `pin` and `migrate` lock directories they never write to, because what they write is derived from what they read there: `export`'s whole output is a description of `$GOBIN`, `pin` resolves its target against it, and `migrate` reinstalls into `AFTER_PATH` the versions it read in `BEFORE_PATH`. A `gup remove` deleting a binary halfway through any of those leaves a result describing a tool set that never existed. `unpin` names an entry in `gup.json` and never looks at `$GOBIN`, so it does not wait behind one.
+
+A `$GOBIN` that does not exist yet is created so it can be locked, by the commands that read it as well as those that install into it. Whether it exists is exactly what a concurrent `gup import` changes, and a command that skipped the lock because the directory was missing would be the one command in the set with no protection at all.
+
+Two commands write files and still take no lock: `gup completion --install` and `gup man`. Both write with the same atomic replace `gup.json` gets, and two runs of either produce byte-identical content, so the only thing a lock would add is a `.zshrc.lock` in your home directory. What neither a lock nor anything else can protect is your editor writing `.zshrc` at the same moment.
 
 Nothing that changes no state is blocked. `update --dry-run`, `import --dry-run`, `migrate --dry-run`, and `export --output` take no lock at all, and neither do the read-only commands (`list`, `check`, `version`, `completion`, `man`, `bug-report`) — gup replaces `gup.json` with an atomic rename, so a reader always sees a complete file and has nothing to wait for. That holds for a read-only `gup.json` too: the read-only bit is cleared for the length of the rename and put back, rather than moving the old file aside and leaving the path briefly empty.
 

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -46,12 +46,20 @@ func export(p *print.Printer, cmd *cobra.Command, _ []string) int {
 		p.Err(err)
 		return 1
 	}
-	configPath, err := getFlagString(cmd, "file")
+	explicit, err := getFlagString(cmd, "file")
 	if err != nil {
 		p.Err(err)
 		return 1
 	}
-	configPath = config.ResolveExportFilePath(configPath)
+	// The same resolution the state lock was taken from, symlink and all: see
+	// resolveExportPath. Resolving again here could follow a link that has been
+	// repointed since, sending the write to a file this command holds no lock on.
+	confPaths, err := resolveExportPath(cmd, explicit)
+	if err != nil {
+		p.Err(err)
+		return 1
+	}
+	configPath := confPaths.write
 
 	pkgs, err := pkgselect.PackageInfo(p)
 	if err != nil {
@@ -85,7 +93,7 @@ func export(p *print.Printer, cmd *cobra.Command, _ []string) int {
 	if output {
 		err = outputConfig(p, pkgs)
 	} else {
-		err = writeConfigFile(configPath, pkgs)
+		err = writeConfigFile(confPaths.target, pkgs)
 	}
 	if err != nil {
 		p.Err(err)

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -73,7 +73,7 @@ func export(p *print.Printer, cmd *cobra.Command, _ []string) int {
 	// (#341). configPath is the resolved destination: the explicit --file when
 	// given, otherwise the canonical user-level config, so the default (no --file)
 	// behavior of reading channels from the canonical config is unchanged.
-	channelSource := configPath
+	channelSource := confPaths.readTarget
 	// A malformed channel-source config must fail fast instead of silently
 	// exporting every package as @latest, which would drop intentionally pinned
 	// channels such as @main from the written gup.json (#369).
@@ -93,7 +93,7 @@ func export(p *print.Printer, cmd *cobra.Command, _ []string) int {
 	if output {
 		err = outputConfig(p, pkgs)
 	} else {
-		err = writeConfigFile(confPaths.target, pkgs)
+		err = writeConfigFile(confPaths.writeTarget, pkgs)
 	}
 	if err != nil {
 		p.Err(err)

--- a/cmd/pin.go
+++ b/cmd/pin.go
@@ -147,12 +147,12 @@ func runPin(p *print.Printer, cmd *cobra.Command, args []string) int {
 	}
 
 	// The same resolution the state lock was taken from: see resolveConfigPaths.
-	confReadPath, writePath, err := resolveConfigPaths(cmd, confFile)
+	confPaths, err := resolveConfigPaths(cmd, confFile)
 	if err != nil {
 		p.Err(err)
 		return 1
 	}
-	confPkgs, err := configstate.ReadFileIfExists(confReadPath)
+	confPkgs, err := configstate.ReadFileIfExists(confPaths.read)
 	if err != nil {
 		p.Err(err)
 		return 1
@@ -164,7 +164,7 @@ func runPin(p *print.Printer, cmd *cobra.Command, args []string) int {
 		return 1
 	}
 
-	if err := writeConfigFile(writePath, merged); err != nil {
+	if err := writeConfigFile(confPaths.target, merged); err != nil {
 		p.Err(err)
 		return 1
 	}
@@ -192,12 +192,12 @@ func runUnpin(p *print.Printer, cmd *cobra.Command, args []string) int {
 	}
 
 	// The same resolution the state lock was taken from: see resolveConfigPaths.
-	confReadPath, writePath, err := resolveConfigPaths(cmd, confFile)
+	confPaths, err := resolveConfigPaths(cmd, confFile)
 	if err != nil {
 		p.Err(err)
 		return 1
 	}
-	confPkgs, err := configstate.ReadFileIfExists(confReadPath)
+	confPkgs, err := configstate.ReadFileIfExists(confPaths.read)
 	if err != nil {
 		p.Err(err)
 		return 1
@@ -209,7 +209,7 @@ func runUnpin(p *print.Printer, cmd *cobra.Command, args []string) int {
 		return 0
 	}
 
-	if err := writeConfigFile(writePath, merged); err != nil {
+	if err := writeConfigFile(confPaths.target, merged); err != nil {
 		p.Err(err)
 		return 1
 	}

--- a/cmd/pin.go
+++ b/cmd/pin.go
@@ -152,7 +152,7 @@ func runPin(p *print.Printer, cmd *cobra.Command, args []string) int {
 		p.Err(err)
 		return 1
 	}
-	confPkgs, err := configstate.ReadFileIfExists(confPaths.read)
+	confPkgs, err := configstate.ReadFileIfExists(confPaths.readTarget)
 	if err != nil {
 		p.Err(err)
 		return 1
@@ -164,7 +164,7 @@ func runPin(p *print.Printer, cmd *cobra.Command, args []string) int {
 		return 1
 	}
 
-	if err := writeConfigFile(confPaths.target, merged); err != nil {
+	if err := writeConfigFile(confPaths.writeTarget, merged); err != nil {
 		p.Err(err)
 		return 1
 	}
@@ -197,7 +197,7 @@ func runUnpin(p *print.Printer, cmd *cobra.Command, args []string) int {
 		p.Err(err)
 		return 1
 	}
-	confPkgs, err := configstate.ReadFileIfExists(confPaths.read)
+	confPkgs, err := configstate.ReadFileIfExists(confPaths.readTarget)
 	if err != nil {
 		p.Err(err)
 		return 1
@@ -209,7 +209,7 @@ func runUnpin(p *print.Printer, cmd *cobra.Command, args []string) int {
 		return 0
 	}
 
-	if err := writeConfigFile(confPaths.target, merged); err != nil {
+	if err := writeConfigFile(confPaths.writeTarget, merged); err != nil {
 		p.Err(err)
 		return 1
 	}

--- a/cmd/statelock.go
+++ b/cmd/statelock.go
@@ -38,11 +38,22 @@ type lockTargets func(cmd *cobra.Command, args []string) ([]string, error)
 // command that is not listed here, and a test walks the registered commands to
 // make sure the list has not fallen behind.
 //
-// The read-only entries are a decision, not an omission. Every write gup
-// performs lands through an atomic rename, so a reader sees either the previous
-// complete gup.json or the next one, never a partial file; making readers block
-// would trade a race that cannot happen for a `gup list` that hangs behind a
-// long `gup update`.
+// The nil entries are a decision, not an omission. Every write gup performs
+// lands through an atomic rename, so a reader sees either the previous complete
+// gup.json or the next one, never a partial file; making readers block would
+// trade a race that cannot happen for a `gup list` that hangs behind a long
+// `gup update`.
+//
+// Two of those nil entries do write files, which is worth saying out loud rather
+// than leaving to be discovered: `completion --install` rewrites shell profiles
+// and completion files, and `man` writes man pages. They are unlocked on the
+// merits, not by oversight. Both write through the same atomic replace gup.json
+// gets, so no reader sees a partial file; both are deterministic, so two
+// concurrent runs write byte-identical content and a lost update loses nothing;
+// and the resources are the user's own dotfiles, where the cost of a lock is a
+// .zshrc.lock left in their home directory whenever one is interrupted. The
+// writer a lock could not exclude anyway - the user's editor - is the one that
+// would actually lose work.
 var commandLockPolicy = map[string]lockTargets{ //nolint:gochecknoglobals // the policy table itself
 	cmdNameUpdate:     updateLockTargets,
 	cmdNameImport:     importLockTargets,
@@ -158,51 +169,42 @@ func dirLockTarget(dir string) []string {
 // two processes writing one shared config contend even when their configuration
 // directories differ.
 func configFileLockTargets(cmd *cobra.Command, _ []string) ([]string, error) {
-	writePath, err := resolveConfigWritePath(cmd)
+	confFile, err := getFlagString(cmd, "file")
 	if err != nil {
 		return nil, err
 	}
-	return configFileLock(writePath)
-}
-
-// configFileLock returns the lock guarding the gup.json a command writes.
-//
-// It follows a symlink to the file the write actually lands on, because that is
-// what the write does: writeConfigFile resolves the link and rewrites its
-// target, so that a dotfile manager's link survives the update. A lock placed
-// beside the LINK would leave `--file link/gup.json` and
-// `--file real/gup.json` taking two different locks on one file, which is the
-// case a lock scoped to the resource exists to catch.
-func configFileLock(writePath string) ([]string, error) {
-	resolved, err := fileutil.ResolveSymlinkTarget(writePath)
+	resolved, err := resolveConfigPaths(cmd, confFile)
 	if err != nil {
-		return nil, fmt.Errorf("can not resolve config path %s: %w", writePath, err)
+		return nil, err
 	}
-	return []string{lockfile.PathForFile(resolved)}, nil
-}
-
-// resolveConfigWritePath returns where the command writes gup.json, using the
-// one resolution the command is allowed to make (see resolveConfigPaths).
-func resolveConfigWritePath(cmd *cobra.Command) (string, error) {
-	confFile, err := getFlagString(cmd, "file")
-	if err != nil {
-		return "", err
-	}
-	_, writePath, err := resolveConfigPaths(cmd, confFile)
-	return writePath, err
+	return []string{lockfile.PathForFile(resolved.target)}, nil
 }
 
 // resolvedConfigKey keys the config resolution on a command's context.
 type resolvedConfigKey struct{}
 
-// resolvedConfig is the pair of gup.json paths a command run works with: the one
-// it reads and the one it writes.
+// resolvedConfig is the set of gup.json paths a command run works with.
 type resolvedConfig struct {
-	// confFile is the --file value the pair was resolved from, so a caller asking
+	// rule names the resolution that produced these, because export resolves a
+	// path by different rules than the commands that also read the file.
+	rule string
+	// confFile is the --file value they were resolved from, so a caller asking
 	// about a different one is never answered from this.
 	confFile string
-	read     string
-	write    string
+	// read is the file the command reads its current state from, and write the
+	// path it was asked to write, as the user spelled it - which is what messages
+	// name, so a user sees the path they typed.
+	read  string
+	write string
+	// target is write with symlinks resolved: the file the write actually lands
+	// on, and therefore the only thing worth locking.
+	//
+	// It is carried rather than recomputed for the same reason the pair above is:
+	// resolving a link twice is asking the filesystem a question twice, and a link
+	// repointed between the lock and the write would send the write to a file the
+	// command holds no lock on. writeConfigFile is handed this path, so its own
+	// resolution has nothing left to follow.
+	target string
 }
 
 // resolveConfigPaths returns the gup.json the command reads and the one it
@@ -217,22 +219,50 @@ type resolvedConfig struct {
 // may be writing. So the answer is settled before the lock is taken and
 // remembered on the command's context, and the command body reads the same
 // answer the lock was taken for.
-func resolveConfigPaths(cmd *cobra.Command, confFile string) (read, write string, err error) {
-	if cached := cachedConfigPaths(cmd, confFile); cached != nil {
-		return cached.read, cached.write, nil
+func resolveConfigPaths(cmd *cobra.Command, confFile string) (*resolvedConfig, error) {
+	if cached := cachedConfigPaths(cmd, ruleImport, confFile); cached != nil {
+		return cached, nil
 	}
-	read, err = config.ResolveImportFilePath(confFile)
+	read, err := config.ResolveImportFilePath(confFile)
 	if err != nil {
-		return "", "", err
+		return nil, err
 	}
-	write = configstate.ResolveWritePath(confFile, read)
-	rememberConfigPaths(cmd, &resolvedConfig{confFile: confFile, read: read, write: write})
-	return read, write, nil
+	write := configstate.ResolveWritePath(confFile, read)
+	return newResolvedConfig(cmd, ruleImport, confFile, read, write)
+}
+
+// resolveExportPath is the same for `gup export`, which resolves where it writes
+// by its own rule - an explicit --file, else the user-level config - and reads
+// its saved channels back from that same file.
+func resolveExportPath(cmd *cobra.Command, confFile string) (*resolvedConfig, error) {
+	if cached := cachedConfigPaths(cmd, ruleExport, confFile); cached != nil {
+		return cached, nil
+	}
+	write := config.ResolveExportFilePath(confFile)
+	return newResolvedConfig(cmd, ruleExport, confFile, write, write)
+}
+
+// The resolution rules a resolvedConfig can come from.
+const (
+	ruleImport = "import"
+	ruleExport = "export"
+)
+
+// newResolvedConfig follows the write path to the file it lands on and remembers
+// the result for the rest of the command run.
+func newResolvedConfig(cmd *cobra.Command, rule, confFile, read, write string) (*resolvedConfig, error) {
+	target, err := fileutil.ResolveSymlinkTarget(write)
+	if err != nil {
+		return nil, fmt.Errorf("can not resolve config path %s: %w", write, err)
+	}
+	resolved := &resolvedConfig{rule: rule, confFile: confFile, read: read, write: write, target: target}
+	rememberConfigPaths(cmd, resolved)
+	return resolved, nil
 }
 
 // cachedConfigPaths returns the resolution already made for this command, or nil
 // when there is none to reuse.
-func cachedConfigPaths(cmd *cobra.Command, confFile string) *resolvedConfig {
+func cachedConfigPaths(cmd *cobra.Command, rule, confFile string) *resolvedConfig {
 	if cmd == nil {
 		return nil
 	}
@@ -241,7 +271,7 @@ func cachedConfigPaths(cmd *cobra.Command, confFile string) *resolvedConfig {
 		return nil
 	}
 	cached, ok := ctx.Value(resolvedConfigKey{}).(*resolvedConfig)
-	if !ok || cached.confFile != confFile {
+	if !ok || cached.rule != rule || cached.confFile != confFile {
 		return nil
 	}
 	return cached
@@ -320,11 +350,11 @@ func exportLockTargets(cmd *cobra.Command, _ []string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	confLock, err := configFileLock(config.ResolveExportFilePath(explicit))
+	resolved, err := resolveExportPath(cmd, explicit)
 	if err != nil {
 		return nil, err
 	}
-	return append(installedBinDirLockTarget(), confLock...), nil
+	return append(installedBinDirLockTarget(), lockfile.PathForFile(resolved.target)), nil
 }
 
 // pinLockTargets locks the gup.json `gup pin` rewrites and the $GOBIN it
@@ -341,27 +371,41 @@ func pinLockTargets(cmd *cobra.Command, args []string) ([]string, error) {
 }
 
 // installedBinDirLockTarget returns the lock guarding the $GOBIN a command
-// READS, and nothing when it cannot be resolved or does not exist yet.
+// READS, creating the directory when it is not there yet.
 //
-// It deliberately does not create the directory the way dirLockTarget does. That
-// creation exists for the commands that install into $GOBIN, where two first
-// runs would otherwise collide in a directory neither had locked; a command that
-// only reads $GOBIN has nothing to collide over, and creating a directory as a
-// side effect of `gup export` would be a surprise. A $GOBIN that is not there
-// holds no binaries either, so there is nothing to keep still.
+// Skipping the lock for a $GOBIN that does not exist looks safe - nothing is
+// installed, so there is nothing to read - and is not. Whether it exists is
+// precisely what another gup can change: an `import` racing an `export` creates
+// $GOBIN and fills it, and the export, holding no lock because the directory was
+// missing when it looked, reads a directory mid-install and writes what it found
+// over a gup.json that described a complete tool set. An empty environment is a
+// normal first run for export, which writes an empty configuration rather than
+// failing, so that overwrite is silent.
+//
+// The directory is therefore created and locked, as it is for the commands that
+// install into it. That leaves an empty $GOBIN behind on a machine that had
+// none, which is the same thing `gup update` and `gup remove` already do, and a
+// far smaller surprise than a gup.json rewritten from a half-populated read.
 func installedBinDirLockTarget() []string {
 	gobin, err := goutil.GoBin()
-	if err != nil || !fileutil.IsDir(gobin) {
+	if err != nil {
 		return nil
 	}
-	return []string{lockfile.PathForDir(gobin)}
+	return dirLockTarget(gobin)
 }
 
-// migrateLockTargets locks AFTER_PATH, the directory `gup migrate` installs
-// into. That is deliberately NOT $GOBIN: migrate takes both directories as
-// arguments and may touch neither the current $GOBIN nor gup.json, so locking
-// $GOBIN would guard a resource it does not write while leaving the one it does
-// unprotected.
+// migrateLockTargets locks both directories `gup migrate` depends on: AFTER_PATH,
+// which it installs into, and BEFORE_PATH, which it reads the versions out of.
+// Neither is necessarily $GOBIN - migrate takes both as arguments and may touch
+// neither the current $GOBIN nor gup.json - so locking $GOBIN instead would
+// guard a resource it does not use and leave both of these unprotected.
+//
+// BEFORE_PATH is locked for the reason export locks $GOBIN: what migrate writes
+// into AFTER_PATH is derived from what it read there, so a `gup remove` (or
+// another migration installing into it) changing it mid-scan produces a
+// migration of a tool set that never existed. Deadlock is not a concern even
+// when two migrations name the directories the other way round, because the
+// locks are taken in sorted order rather than the order they are given in.
 func migrateLockTargets(cmd *cobra.Command, args []string) ([]string, error) {
 	dryRun, err := getFlagBool(cmd, "dry-run")
 	if err != nil {
@@ -381,5 +425,14 @@ func migrateLockTargets(cmd *cobra.Command, args []string) ([]string, error) {
 	if !fileutil.IsDir(args[0]) {
 		return nil, nil
 	}
-	return dirLockTarget(args[1]), nil
+	after := dirLockTarget(args[1])
+	if after == nil {
+		// AFTER_PATH cannot be a directory (a regular file sits there, or its
+		// parent refuses the mkdir). The command reports that better than any lock
+		// error would, and it writes nothing, so neither directory needs guarding.
+		return nil, nil
+	}
+	// BEFORE_PATH exists - the check above made sure - so this locks it without
+	// creating anything.
+	return append(dirLockTarget(args[0]), after...), nil
 }

--- a/cmd/statelock.go
+++ b/cmd/statelock.go
@@ -177,7 +177,7 @@ func configFileLockTargets(cmd *cobra.Command, _ []string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return []string{lockfile.PathForFile(resolved.target)}, nil
+	return []string{lockfile.PathForFile(resolved.writeTarget)}, nil
 }
 
 // resolvedConfigKey keys the config resolution on a command's context.
@@ -196,15 +196,22 @@ type resolvedConfig struct {
 	// name, so a user sees the path they typed.
 	read  string
 	write string
-	// target is write with symlinks resolved: the file the write actually lands
-	// on, and therefore the only thing worth locking.
+	// readTarget and writeTarget are those two with symlinks resolved: the files
+	// the command actually reads and actually writes, and therefore the only
+	// things worth locking or handing to an opener.
 	//
-	// It is carried rather than recomputed for the same reason the pair above is:
-	// resolving a link twice is asking the filesystem a question twice, and a link
-	// repointed between the lock and the write would send the write to a file the
-	// command holds no lock on. writeConfigFile is handed this path, so its own
-	// resolution has nothing left to follow.
-	target string
+	// They are carried rather than recomputed for the same reason the pair above
+	// is. Resolving a link twice is asking the filesystem a question twice, and a
+	// dotfile manager repointing the link between the two answers is enough to
+	// send the write to a file the command holds no lock on - or, just as bad, to
+	// merge the contents of a file it never locked into the one it did.
+	//
+	// The two resolve to the same file in every resolution these rules can
+	// produce: an explicit --file is both, and auto-detection picks one path for
+	// both. They are kept apart because the rules say so, not because a case is
+	// known where they diverge.
+	readTarget  string
+	writeTarget string
 }
 
 // resolveConfigPaths returns the gup.json the command reads and the one it
@@ -251,11 +258,19 @@ const (
 // newResolvedConfig follows the write path to the file it lands on and remembers
 // the result for the rest of the command run.
 func newResolvedConfig(cmd *cobra.Command, rule, confFile, read, write string) (*resolvedConfig, error) {
-	target, err := fileutil.ResolveSymlinkTarget(write)
+	readTarget, err := fileutil.ResolveSymlinkTarget(read)
+	if err != nil {
+		return nil, fmt.Errorf("can not resolve config path %s: %w", read, err)
+	}
+	writeTarget, err := fileutil.ResolveSymlinkTarget(write)
 	if err != nil {
 		return nil, fmt.Errorf("can not resolve config path %s: %w", write, err)
 	}
-	resolved := &resolvedConfig{rule: rule, confFile: confFile, read: read, write: write, target: target}
+	resolved := &resolvedConfig{
+		rule: rule, confFile: confFile,
+		read: read, write: write,
+		readTarget: readTarget, writeTarget: writeTarget,
+	}
 	rememberConfigPaths(cmd, resolved)
 	return resolved, nil
 }
@@ -354,7 +369,7 @@ func exportLockTargets(cmd *cobra.Command, _ []string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return append(installedBinDirLockTarget(), lockfile.PathForFile(resolved.target)), nil
+	return append(installedBinDirLockTarget(), lockfile.PathForFile(resolved.writeTarget)), nil
 }
 
 // pinLockTargets locks the gup.json `gup pin` rewrites and the $GOBIN it

--- a/cmd/statelock_test.go
+++ b/cmd/statelock_test.go
@@ -663,7 +663,7 @@ func Test_resolveConfigPaths_answersOncePerCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveConfigPaths() error: %v", err)
 	}
-	if again.read != first.read || again.write != first.write || again.target != first.target {
+	if again.read != first.read || again.write != first.write || again.writeTarget != first.writeTarget {
 		t.Errorf("resolveConfigPaths() = %+v the second time, want the answer the lock was taken for %+v",
 			again, first)
 	}
@@ -785,8 +785,11 @@ func Test_resolveConfigPaths_followsTheSymlinkOnce(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveConfigPaths() error: %v", err)
 	}
-	if resolved.target != real {
-		t.Fatalf("target = %q, want the file the write lands on %q", resolved.target, real)
+	if resolved.writeTarget != real {
+		t.Fatalf("writeTarget = %q, want the file the write lands on %q", resolved.writeTarget, real)
+	}
+	if resolved.readTarget != real {
+		t.Fatalf("readTarget = %q, want the file the command reads %q", resolved.readTarget, real)
 	}
 	// The path the user typed is what messages name, so it is kept as given.
 	if resolved.write != link {
@@ -807,7 +810,12 @@ func Test_resolveConfigPaths_followsTheSymlinkOnce(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveConfigPaths() error: %v", err)
 	}
-	if again.target != real {
-		t.Errorf("target = %q after the link moved, want the locked file %q", again.target, real)
+	if again.writeTarget != real {
+		t.Errorf("writeTarget = %q after the link moved, want the locked file %q", again.writeTarget, real)
+	}
+	// The read is pinned to the same file, or a repointed link would merge a
+	// config the command never locked into the one it did.
+	if again.readTarget != real {
+		t.Errorf("readTarget = %q after the link moved, want the locked file %q", again.readTarget, real)
 	}
 }

--- a/cmd/statelock_test.go
+++ b/cmd/statelock_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/adrg/xdg"
+	"github.com/nao1215/gup/internal/fileutil"
 	"github.com/nao1215/gup/internal/lockfile"
 	"github.com/nao1215/gup/internal/print"
 	"github.com/spf13/cobra"
@@ -327,6 +328,7 @@ func Test_lockTargets(t *testing.T) {
 	gobin := t.TempDir()
 	configHome := t.TempDir()
 	after := t.TempDir()
+	migrateBefore := t.TempDir()
 	explicit := filepath.Join(t.TempDir(), "shared-gup.json")
 
 	t.Setenv("GOBIN", gobin)
@@ -391,10 +393,11 @@ func Test_lockTargets(t *testing.T) {
 			want: []string{lockfile.PathForDir(gobin)},
 		},
 		{
-			// migrate writes into AFTER_PATH, which is neither $GOBIN nor gup.json.
+			// migrate writes into AFTER_PATH and reads BEFORE_PATH, neither of which
+			// is necessarily $GOBIN or gup.json.
 			name: testCmdMigrate,
-			args: []string{t.TempDir(), after},
-			want: []string{lockfile.PathForDir(after)},
+			args: []string{migrateBefore, after},
+			want: []string{lockfile.PathForDir(migrateBefore), lockfile.PathForDir(after)},
 		},
 		{
 			name:  testCmdMigrate + " --dry-run",
@@ -643,12 +646,12 @@ func Test_resolveConfigPaths_answersOncePerCommand(t *testing.T) {
 	t.Chdir(t.TempDir())
 
 	cmd := newLockTestCommand(&bytes.Buffer{})
-	read, write, err := resolveConfigPaths(cmd, "")
+	first, err := resolveConfigPaths(cmd, "")
 	if err != nil {
 		t.Fatalf("resolveConfigPaths() error: %v", err)
 	}
-	if want := filepath.Join(configHome, "gup", "gup.json"); write != want {
-		t.Fatalf("write path = %q, want the user-level config %q", write, want)
+	if want := filepath.Join(configHome, "gup", "gup.json"); first.write != want {
+		t.Fatalf("write path = %q, want the user-level config %q", first.write, want)
 	}
 
 	// Another gup, started in this directory, creates the local config.
@@ -656,13 +659,13 @@ func Test_resolveConfigPaths_answersOncePerCommand(t *testing.T) {
 		t.Fatalf("failed to write ./gup.json: %v", err)
 	}
 
-	gotRead, gotWrite, err := resolveConfigPaths(cmd, "")
+	again, err := resolveConfigPaths(cmd, "")
 	if err != nil {
 		t.Fatalf("resolveConfigPaths() error: %v", err)
 	}
-	if gotRead != read || gotWrite != write {
-		t.Errorf("resolveConfigPaths() = (%q, %q) the second time, want the answer the lock was taken for (%q, %q)",
-			gotRead, gotWrite, read, write)
+	if again.read != first.read || again.write != first.write || again.target != first.target {
+		t.Errorf("resolveConfigPaths() = %+v the second time, want the answer the lock was taken for %+v",
+			again, first)
 	}
 }
 
@@ -672,17 +675,17 @@ func Test_resolveConfigPaths_answersOncePerCommand(t *testing.T) {
 func Test_resolveConfigPaths_isPerFileValue(t *testing.T) {
 	t.Chdir(t.TempDir())
 	cmd := newLockTestCommand(&bytes.Buffer{})
-	if _, _, err := resolveConfigPaths(cmd, ""); err != nil {
+	if _, err := resolveConfigPaths(cmd, ""); err != nil {
 		t.Fatalf("resolveConfigPaths() error: %v", err)
 	}
 
 	explicit := filepath.Join(t.TempDir(), "other-gup.json")
-	_, write, err := resolveConfigPaths(cmd, explicit)
+	resolved, err := resolveConfigPaths(cmd, explicit)
 	if err != nil {
 		t.Fatalf("resolveConfigPaths() error: %v", err)
 	}
-	if write != explicit {
-		t.Errorf("write path = %q, want %q", write, explicit)
+	if resolved.write != explicit {
+		t.Errorf("write path = %q, want %q", resolved.write, explicit)
 	}
 }
 
@@ -694,12 +697,12 @@ func Test_resolveConfigPaths_withoutACommandContext(t *testing.T) {
 	explicit := filepath.Join(t.TempDir(), "explicit-gup.json")
 
 	for _, cmd := range []*cobra.Command{nil, {Use: testCmdGup}} {
-		_, write, err := resolveConfigPaths(cmd, explicit)
+		resolved, err := resolveConfigPaths(cmd, explicit)
 		if err != nil {
 			t.Fatalf("resolveConfigPaths() error: %v", err)
 		}
-		if write != explicit {
-			t.Errorf("write path = %q, want %q", write, explicit)
+		if resolved.write != explicit {
+			t.Errorf("write path = %q, want %q", resolved.write, explicit)
 		}
 	}
 }
@@ -740,19 +743,71 @@ func Test_updateLockTargets_locksTheFileASymlinkPointsAt(t *testing.T) {
 	}
 }
 
-// Test_installedBinDirLockTarget_doesNotCreateTheDirectory covers the difference
-// between locking a directory a command WRITES and one it only reads. The
-// writers create it, because two first runs would otherwise install into a
-// directory neither had locked; a reader has nothing to collide over, and
-// `gup export` creating $GOBIN as a side effect would be a surprise.
-func Test_installedBinDirLockTarget_doesNotCreateTheDirectory(t *testing.T) {
+// Test_installedBinDirLockTarget_locksA$GOBINThatDoesNotExistYet is the case
+// that makes skipping the lock unsafe. Whether $GOBIN exists is exactly what
+// another gup can change: an import creates it and fills it while an export is
+// walking it, and an export that took no lock because the directory was missing
+// writes what it found over a gup.json that described a complete tool set.
+func Test_installedBinDirLockTarget_locksAGobinThatDoesNotExistYet(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "no-such-gobin")
 	t.Setenv("GOBIN", missing)
 
-	if got := installedBinDirLockTarget(); got != nil {
-		t.Errorf("installedBinDirLockTarget() = %v, want no lock for a $GOBIN that does not exist", got)
+	got := installedBinDirLockTarget()
+	if want := []string{lockfile.PathForDir(missing)}; !slices.Equal(got, want) {
+		t.Fatalf("installedBinDirLockTarget() = %v, want %v", got, want)
 	}
-	if _, err := os.Stat(missing); !os.IsNotExist(err) {
-		t.Errorf("$GOBIN was created by a command that only reads it: %v", err)
+	if !fileutil.IsDir(missing) {
+		t.Error("$GOBIN was not created, so the lock would guard a directory another gup can still create")
+	}
+}
+
+// Test_resolveConfigPaths_followsTheSymlinkOnce covers the write target, which
+// is the thing the lock is taken on. Following the link at lock time and again
+// at write time asks the filesystem the same question twice, and a link
+// repointed in between sends the write to a file the command holds no lock on -
+// so the answer is settled once and carried.
+func Test_resolveConfigPaths_followsTheSymlinkOnce(t *testing.T) {
+	if runtime.GOOS == goosWindows {
+		t.Skip("symlink creation needs privileges on Windows; the rule is POSIX-specific here")
+	}
+	dir := t.TempDir()
+	real := filepath.Join(dir, "real-gup.json")
+	if err := os.WriteFile(real, []byte(`{"schema_version":1,"packages":[]}`), 0o600); err != nil {
+		t.Fatalf("failed to write the config: %v", err)
+	}
+	link := filepath.Join(dir, "link-gup.json")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("failed to link the config: %v", err)
+	}
+
+	cmd := newLockTestCommand(&bytes.Buffer{})
+	resolved, err := resolveConfigPaths(cmd, link)
+	if err != nil {
+		t.Fatalf("resolveConfigPaths() error: %v", err)
+	}
+	if resolved.target != real {
+		t.Fatalf("target = %q, want the file the write lands on %q", resolved.target, real)
+	}
+	// The path the user typed is what messages name, so it is kept as given.
+	if resolved.write != link {
+		t.Errorf("write = %q, want the path as it was given %q", resolved.write, link)
+	}
+
+	// The link is repointed the way a dotfile manager would, mid-command. The
+	// answer the lock was taken for must not move with it.
+	elsewhere := filepath.Join(dir, "elsewhere-gup.json")
+	if err := os.Remove(link); err != nil {
+		t.Fatalf("failed to remove the link: %v", err)
+	}
+	if err := os.Symlink(elsewhere, link); err != nil {
+		t.Fatalf("failed to repoint the link: %v", err)
+	}
+
+	again, err := resolveConfigPaths(cmd, link)
+	if err != nil {
+		t.Fatalf("resolveConfigPaths() error: %v", err)
+	}
+	if again.target != real {
+		t.Errorf("target = %q after the link moved, want the locked file %q", again.target, real)
 	}
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -185,7 +185,7 @@ func gup(deps dependencies, p *print.Printer, cmd *cobra.Command, args []string)
 		p.Err(err)
 		return 1
 	}
-	confReadPath := confPaths.read
+	confReadPath := confPaths.readTarget
 
 	// A malformed or unreadable config must fail fast instead of silently
 	// falling back to @latest, which would update from the wrong channel and
@@ -212,7 +212,7 @@ func gup(deps dependencies, p *print.Printer, cmd *cobra.Command, args []string)
 		merged := configstate.MergePackages(confPkgs, succeededPkgs, channelMap, renamedPkgs)
 		// The write goes to the file the lock was taken on, following the symlink
 		// exactly once: resolving it again here could land somewhere else.
-		if err := writeConfigFile(confPaths.target, merged); err != nil {
+		if err := writeConfigFile(confPaths.writeTarget, merged); err != nil {
 			p.Warn("failed to write " + confPaths.write + ": " + err.Error())
 		}
 	}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -180,11 +180,12 @@ func gup(deps dependencies, p *print.Printer, cmd *cobra.Command, args []string)
 	// resolving again could land on a different file (another process creating
 	// ./gup.json while this update runs) and write it while holding a lock on the
 	// file that was resolved first.
-	confReadPath, confWritePath, err := resolveConfigPaths(cmd, opts.confFile)
+	confPaths, err := resolveConfigPaths(cmd, opts.confFile)
 	if err != nil {
 		p.Err(err)
 		return 1
 	}
+	confReadPath := confPaths.read
 
 	// A malformed or unreadable config must fail fast instead of silently
 	// falling back to @latest, which would update from the wrong channel and
@@ -209,8 +210,10 @@ func gup(deps dependencies, p *print.Printer, cmd *cobra.Command, args []string)
 
 	if !opts.dryRun && (configstate.ShouldPersistChannels(opts.mainPkgNames, opts.masterPkgNames, opts.latestPkgNames) || len(renamedPkgs) > 0) {
 		merged := configstate.MergePackages(confPkgs, succeededPkgs, channelMap, renamedPkgs)
-		if err := writeConfigFile(confWritePath, merged); err != nil {
-			p.Warn("failed to write " + confWritePath + ": " + err.Error())
+		// The write goes to the file the lock was taken on, following the symlink
+		// exactly once: resolving it again here could land somewhere else.
+		if err := writeConfigFile(confPaths.target, merged); err != nil {
+			p.Warn("failed to write " + confPaths.write + ": " + err.Error())
 		}
 	}
 

--- a/e2e/atago/lock.atago.yaml
+++ b/e2e/atago/lock.atago.yaml
@@ -408,3 +408,64 @@ scenarios:
           dir:
             path: new-gobin
             exists: false
+
+  - name: migrate contends over the directory it reads, not only the one it writes
+    # What migrate installs into AFTER_PATH is derived from what it read in
+    # BEFORE_PATH, so a gup changing BEFORE_PATH mid-scan produces a migration of
+    # a tool set that never existed. Locking only the destination left the source
+    # open to exactly that.
+    env: *iso
+    steps:
+      - fixture:
+          file: old-gobin/.keep
+          content: "placeholder so BEFORE_PATH exists"
+      - fixture:
+          file: new-gobin/.keep
+          content: "placeholder so AFTER_PATH exists"
+      # A live lock on the SOURCE directory, held by a machine whose PIDs mean
+      # nothing here.
+      - fixture:
+          file: old-gobin/.gup.lock
+          content: |
+            {"pid":424242,"host":"some-other-machine","command":"migrate","acquired":"2026-01-01T00:00:00Z","nonce":"e2e-holder"}
+      - run:
+          command: gup migrate ${workdir}/old-gobin ${workdir}/new-gobin
+          env: *iso
+      - assert:
+          exit_code: 1
+          stderr:
+            contains: "another gup process is already running"
+
+  - name: export locks a $GOBIN that does not exist yet by creating it
+    # Whether $GOBIN exists is exactly what another gup can change: an import
+    # creates it and fills it while an export walks it. An export that skipped
+    # the lock because the directory was missing would write what it found -
+    # nothing, or half an install - over a gup.json describing a complete tool
+    # set, and an empty environment is a normal first run for export, so that
+    # overwrite is silent.
+    #
+    # A lock file lives inside the directory it guards, so guarding a $GOBIN that
+    # is not there means creating it. That is the observable part of the rule,
+    # and the reason this scenario watches for a directory rather than for a
+    # refusal: the interleaving itself is a race no spec can stage.
+    env: &fresh
+      HOME: "${workdir}/home"
+      XDG_CONFIG_HOME: "${workdir}/config"
+      GOBIN: "${workdir}/unborn-gobin"
+      GOPATH: "${workdir}/gopath"
+      GUP_LOCK_WAIT: "200ms"
+    steps:
+      - run:
+          command: gup export
+          env: *fresh
+      - assert:
+          exit_code: 0
+      - assert:
+          dir:
+            path: unborn-gobin
+            exists: true
+      # And the lock it took is handed back, not left lying in the new directory.
+      - assert:
+          file:
+            path: unborn-gobin/.gup.lock
+            exists: false

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -538,19 +538,22 @@ func detach(path, reason string) (string, error) {
 // Renaming it back unconditionally would be a second bug of the same shape as
 // the one detaching prevents: a process that acquired the path while the file
 // was aside would lose its lock without being told, and go on working next to
-// whoever holds the restored one. So the file goes back only into an empty
-// path, and os.Link is what asks that question atomically - it fails rather than
-// replacing, which os.Rename does silently on both Unix and Windows.
+// whoever holds the restored one. So the file goes back only into an empty path,
+// and both ways of doing that here are atomic about it - neither asks whether
+// the path is free and then acts on the answer, because that pair is exactly the
+// race being closed.
 //
-// Link is not available on every filesystem (FAT, some network shares), so a
-// checked rename stands in where it is refused for that reason. The check is not
-// atomic, which is the honest cost of the fallback; it is still bounded by a
-// window orders of magnitude smaller than the one it replaces.
+// os.Link is tried first because it puts the file back whole: same inode, same
+// content, same modification time, in one operation that fails rather than
+// replacing. Where hard links are unavailable (FAT, some network shares) the
+// file is re-created exclusively instead, which fails the same way for the same
+// reason and restores the modification time afterwards, since that is what a
+// waiter judges staleness from.
 //
 // When the path is occupied the detached file is discarded. Its owner is left
 // without a lock, which is bad, but it is the outcome that at least leaves ONE
-// process holding the resource rather than two believing they do - and the
-// owner learns of it, because everything it does next checks the nonce.
+// process holding the resource rather than two believing they do - and the owner
+// learns of it, because everything it does next checks the nonce.
 func restore(aside, path string) {
 	switch err := os.Link(aside, path); {
 	case err == nil:
@@ -561,27 +564,44 @@ func restore(aside, path string) {
 		_ = os.Remove(aside)
 		return
 	}
-	restoreByRename(aside, path)
+	restoreByRecreating(aside, path)
 }
 
-// restoreByRename is restore's fallback for a filesystem that refuses hard
-// links. It asks whether the path is free and then renames into it, which is two
-// operations rather than one - the honest cost of not having Link. The window it
-// leaves is still orders of magnitude smaller than renaming without asking.
-func restoreByRename(aside, path string) {
-	// Only a definite "nothing is there" allows the rename. Any other answer -
-	// occupied, or a directory that will not say - leaves the file where it is,
-	// because renaming on an answer this did not get would overwrite whatever it
-	// could not see, which is the whole thing this function exists to avoid.
-	if _, err := os.Lstat(path); !errors.Is(err, fs.ErrNotExist) {
-		_ = os.Remove(aside)
+// restoreByRecreating is restore's fallback for a filesystem with no hard links.
+// It re-creates the lock file exclusively and copies the detached one into it,
+// so the question "is the path free" is answered by the operation that fills it
+// rather than by a check somebody can invalidate before the next line runs.
+func restoreByRecreating(aside, path string) {
+	defer func() { _ = os.Remove(aside) }()
+
+	info, err := os.Stat(aside)
+	if err != nil {
 		return
 	}
-	if err := os.Rename(aside, path); err != nil {
-		// Nothing further can be done: the file cannot go back and must not be
-		// left lying around under a name no owner will ever recognize.
-		_ = os.Remove(aside)
+	raw, err := os.ReadFile(filepath.Clean(aside))
+	if err != nil {
+		return
 	}
+
+	//nolint:gosec // G304: the path is gup's own lock file, and O_EXCL is the point of the call.
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, lockFileMode)
+	if err != nil {
+		// Occupied, or unwritable: either way this file does not go back.
+		return
+	}
+	_, writeErr := file.Write(raw)
+	if closeErr := file.Close(); writeErr == nil {
+		writeErr = closeErr
+	}
+	if writeErr != nil {
+		// A half-written lock file names nobody and would be reclaimed as rubbish
+		// once it ages; removing it now is the same outcome, sooner.
+		_ = os.Remove(path)
+		return
+	}
+	// The modification time is what staleness is measured from, so a restored
+	// lock has to carry the one it had rather than looking freshly touched.
+	_ = os.Chtimes(path, info.ModTime(), info.ModTime())
 }
 
 // createLockFile creates path exclusively and writes the owner record into it.

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -1388,24 +1388,42 @@ func rollbackAgainstAReclaimedFirstLock(t *testing.T) error {
 	return err
 }
 
-// TestRestoreByRename covers restore's fallback for filesystems with no hard
+// TestRestoreByRecreating covers restore's fallback for filesystems with no hard
 // links, which the test machine almost certainly has - so the fallback is driven
-// directly. It must follow the same rule as the Link path: back into an empty
-// path, never over a lock somebody else took.
-func TestRestoreByRename(t *testing.T) {
+// directly. It must follow the same rule as the Link path, and be atomic about
+// it: the path is filled by the operation that claims it, never by a check
+// followed by a write.
+func TestRestoreByRecreating(t *testing.T) {
 	t.Parallel()
 
-	t.Run("restores into a free path", func(t *testing.T) {
+	t.Run("restores into a free path, modification time and all", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
 		path := filepath.Join(dir, "gup.lock")
 		aside := filepath.Join(dir, "gup.lock.stale-1-1")
 		writeOwner(t, aside, Owner{PID: 1, Host: remoteHost, Command: cmdUpdate, Nonce: ownerHolder})
+		old := time.Now().Add(-30 * time.Second).Truncate(time.Second)
+		if err := os.Chtimes(aside, old, old); err != nil {
+			t.Fatalf("failed to backdate the detached file: %v", err)
+		}
+		content := readAll(t, aside)
 
-		restoreByRename(aside, path)
+		restoreByRecreating(aside, path)
 
-		if got := readOwnerForTest(t, path); got.Nonce != ownerHolder {
-			t.Errorf("the lock at the path is %q, want the restored owner's %q", got.Nonce, ownerHolder)
+		if got := readAll(t, path); got != content {
+			t.Errorf("the restored lock file reads %q, want %q", got, content)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("the lock file was not put back: %v", err)
+		}
+		// Staleness is measured from this, so a restored lock must not look
+		// freshly touched - that would hide an owner's death from every waiter.
+		if !info.ModTime().Equal(old) {
+			t.Errorf("the restored lock file's modification time is %v, want %v", info.ModTime(), old)
+		}
+		if _, err := os.Stat(aside); !os.IsNotExist(err) {
+			t.Errorf("the detached file was left behind: %v", err)
 		}
 	})
 
@@ -1417,13 +1435,25 @@ func TestRestoreByRename(t *testing.T) {
 		writeOwner(t, aside, Owner{PID: 1, Host: remoteHost, Command: cmdUpdate, Nonce: ownerHolder})
 		writeOwner(t, path, Owner{PID: os.Getpid(), Host: hostname(t), Command: cmdRemove, Nonce: successorNonce})
 
-		restoreByRename(aside, path)
+		restoreByRecreating(aside, path)
 
 		if got := readOwnerForTest(t, path); got.Nonce != successorNonce {
 			t.Errorf("the lock at the path is %q, want the newcomer's %q", got.Nonce, successorNonce)
 		}
 		if _, err := os.Stat(aside); !os.IsNotExist(err) {
 			t.Errorf("the detached file was left behind: %v", err)
+		}
+	})
+
+	t.Run("discards a detached file it cannot read", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "gup.lock")
+
+		restoreByRecreating(filepath.Join(dir, "not-there"), path)
+
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("a lock file was created out of nothing: %v", err)
 		}
 	})
 }

--- a/website/content/reference.md
+++ b/website/content/reference.md
@@ -95,7 +95,7 @@ second one refuses to start instead of interleaving:
 | `update` | `$GOBIN` and the `gup.json` it may write |
 | `import` | `$GOBIN` |
 | `remove` | `$GOBIN` |
-| `migrate` | `AFTER_PATH` |
+| `migrate` | `BEFORE_PATH` and `AFTER_PATH` |
 | `export`, `pin` | `$GOBIN` and the `gup.json` they write |
 | `unpin` | the `gup.json` it writes |
 
@@ -116,10 +116,18 @@ Two `gup update` runs at once would both install and then both write
 `gup remove` deleting a binary a concurrent `gup update` is reinstalling is the
 same collision with a worse result.
 
-`export` and `pin` lock `$GOBIN` although they never write to it: what they
-write describes it, so a `gup remove` deleting a binary halfway through would
-record a tool that is no longer installed. `unpin` only names an entry in
-`gup.json`, so it does not wait behind one.
+`export`, `pin` and `migrate` lock directories they never write to, because
+what they write is derived from what they read there: export describes `$GOBIN`,
+pin resolves its target against it, and migrate reinstalls the versions it read
+in `BEFORE_PATH`. A `gup remove` deleting a binary halfway through leaves a
+result describing a tool set that never existed. `unpin` only names an entry in
+`gup.json`, so it does not wait behind one. A `$GOBIN` that does not exist yet
+is created so that it can be locked — whether it exists is precisely what a
+concurrent `gup import` changes.
+
+`gup completion --install` and `gup man` write files and take no lock: both
+write atomically, and two runs of either produce byte-identical content, so a
+lock would only add a `.zshrc.lock` to your home directory.
 
 Nothing that changes no state is blocked. `--dry-run` runs and `export --output`
 take no lock, and neither do the read-only commands (`list`, `check`, `version`,


### PR DESCRIPTION
## Summary

A third review pass over the state lock (#454, #455, #457) found four more gaps: a lock skipped exactly when it was needed, a directory read without being guarded, a symlink resolved twice, and a recovery path that checked the destination and then wrote to it. Each is fixed here, with unit tests and two end-to-end scenarios that fail against the code as it was.

## Changes

- `cmd/statelock.go`: `export` and `pin` now lock `$GOBIN` whether or not it exists, creating it as the installing commands do. Skipping the lock for a missing directory made the first run the one run with no protection: a concurrent `gup import` creates and fills `$GOBIN` while the export walks it, and the export writes what it found over a `gup.json` that described a complete tool set — silently, since an empty environment is a normal first run for export.
- `cmd/statelock.go`: `migrate` locks `BEFORE_PATH` as well as `AFTER_PATH`. What it installs into the one is derived from what it read in the other, so a `gup remove` pointed at the source changes that set mid-scan. Locks are taken in sorted order, so two migrations naming the directories the other way round cannot deadlock.
- `cmd/statelock.go`, `cmd/update.go`, `cmd/pin.go`, `cmd/export.go`: the `gup.json` symlink is resolved once, beside the read and write paths, and the resolved target is handed to the write. It was resolved once for the lock and again inside `writeConfigFile`, so a link repointed in between sent the write to a file the command held no lock on.
- `internal/lockfile/lockfile.go`: the no-hard-link fallback in `restore` re-creates the lock file with `O_CREATE|O_EXCL` instead of checking the path with `Lstat` and then renaming into it. That pair was the same race detaching exists to close.
- `cmd/statelock.go`: the policy table now states why `completion --install` and `man` write files and take no lock.
- `e2e/atago/lock.atago.yaml`, `README.md`, `website/content/reference.md`.

## Design Decisions

Locking a directory a command only reads is now the rule wherever the command's output describes that directory — `export` and `pin` over `$GOBIN`, `migrate` over `BEFORE_PATH`. The previous refinement, "lock it only if it exists, so a read never creates a directory", was wrong in the one case that mattered: existence is itself a thing another gup changes, and a lock file lives inside what it guards, so a lock on a missing `$GOBIN` means creating it. An empty `$GOBIN` on a machine that had none is the same footprint `gup update` and `gup remove` already leave.

`restore`'s fallback answers "is the path free" with the operation that fills it rather than with a check followed by a write. `os.Link` stays the first choice because it puts the file back whole — same inode, content and timestamps, in one operation — and the exclusive re-create copies the content and restores the modification time, which is what a waiter measures staleness from.

`completion --install` and `man` stay unlocked on the merits. Both write through the same atomic replace `gup.json` gets, and both are deterministic, so two concurrent runs write byte-identical content and a lost update loses nothing. A lock would leave a `.zshrc.lock` in the user's home whenever one is interrupted, and would still not exclude the writer that could actually lose their work: the user's editor.

## Limitations

The `$GOBIN`-creation interleaving cannot be staged deterministically in the end-to-end suite — a lock file inside the directory means holding the lock implies the directory exists — so that scenario pins the observable half of the rule (the directory is created and the lock handed back) and the unit test covers the target list. The symlink fix closes the window between gup's own two resolutions; a link repointed between the single resolution and the rename is outside what a lock can cover.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration handling for exports using alternate destinations.
  * Ensured symlinked configuration paths remain consistent throughout commands.
  * Automatically creates and locks a missing `GOBIN` directory when needed.
  * Strengthened lock restoration to prevent conflicting operations.
  * `migrate` now locks both source and destination directories.

* **Documentation**
  * Clarified locking behavior for `export`, `pin`, and `migrate`.
  * Documented that `completion --install` and `man` write files without locking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->