### PR TITLE
docs(readme): credit the external maintainers who package gup

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -221,7 +221,8 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/4507647?v=4",
       "profile": "https://onee3.org",
       "contributions": [
-        "ideas"
+        "ideas",
+        "platform"
       ]
     },
     {
@@ -284,7 +285,8 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/29627898?v=4",
       "profile": "https://github.com/phanirithvij",
       "contributions": [
-        "bug"
+        "bug",
+        "platform"
       ]
     },
     {
@@ -303,6 +305,33 @@
       "profile": "https://github.com/hpsbranco",
       "contributions": [
         "code"
+      ]
+    },
+    {
+      "login": "Dominiquini",
+      "name": "Rafael Baboni Dominiquini",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1180808?v=4",
+      "profile": "https://rafaeldominiquini.ddns.net/",
+      "contributions": [
+        "platform"
+      ]
+    },
+    {
+      "login": "branchv",
+      "name": "Branch Vincent",
+      "avatar_url": "https://avatars.githubusercontent.com/u/19800529?v=4",
+      "profile": "https://github.com/branchv",
+      "contributions": [
+        "platform"
+      ]
+    },
+    {
+      "login": "Okeanos",
+      "name": "Nikolas Grottendieck",
+      "avatar_url": "https://avatars.githubusercontent.com/u/887496?v=4",
+      "profile": "https://nikolasgrottendieck.com/",
+      "contributions": [
+        "platform"
       ]
     }
   ],

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-33-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-36-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 [![Mentioned in Awesome Go](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go)
 [![reviewdog](https://github.com/nao1215/gup/actions/workflows/reviewdog.yml/badge.svg)](https://github.com/nao1215/gup/actions/workflows/reviewdog.yml)
@@ -589,7 +589,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://gabnotes.org"><img src="https://avatars.githubusercontent.com/u/3630554?v=4?s=64" width="64px;" alt="Crocmagnon"/><br /><sub><b>Crocmagnon</b></sub></a><br /><a href="https://github.com/nao1215/gup/issues?q=author%3ACrocmagnon" title="Bug reports">🐛</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://reliable.network"><img src="https://avatars.githubusercontent.com/u/1992842?v=4?s=64" width="64px;" alt="Luke Hamburg"/><br /><sub><b>Luke Hamburg</b></sub></a><br /><a href="https://github.com/nao1215/gup/issues?q=author%3Aluckman212" title="Bug reports">🐛</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://onee3.org"><img src="https://avatars.githubusercontent.com/u/4507647?v=4?s=64" width="64px;" alt="Frederick Zhang"/><br /><sub><b>Frederick Zhang</b></sub></a><br /><a href="#ideas-Frederick888" title="Ideas, Planning, & Feedback">🤔</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://onee3.org"><img src="https://avatars.githubusercontent.com/u/4507647?v=4?s=64" width="64px;" alt="Frederick Zhang"/><br /><sub><b>Frederick Zhang</b></sub></a><br /><a href="#ideas-Frederick888" title="Ideas, Planning, & Feedback">🤔</a> <a href="#platform-Frederick888" title="Packaging/porting to new platform">📦</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/trallnag"><img src="https://avatars.githubusercontent.com/u/24834206?v=4?s=64" width="64px;" alt="Tim Schwenke"/><br /><sub><b>Tim Schwenke</b></sub></a><br /><a href="#ideas-trallnag" title="Ideas, Planning, & Feedback">🤔</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/ybrhue"><img src="https://avatars.githubusercontent.com/u/35401453?v=4?s=64" width="64px;" alt="ybrhue"/><br /><sub><b>ybrhue</b></sub></a><br /><a href="#ideas-ybrhue" title="Ideas, Planning, & Feedback">🤔</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://nexiom.net"><img src="https://avatars.githubusercontent.com/u/3214803?v=4?s=64" width="64px;" alt="Samuel D. Leslie"/><br /><sub><b>Samuel D. Leslie</b></sub></a><br /><a href="#ideas-ralish" title="Ideas, Planning, & Feedback">🤔</a></td>
@@ -598,9 +598,14 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="http://www.craig-wood.com/nick/"><img src="https://avatars.githubusercontent.com/u/536803?v=4?s=64" width="64px;" alt="Nick Craig-Wood"/><br /><sub><b>Nick Craig-Wood</b></sub></a><br /><a href="#ideas-ncw" title="Ideas, Planning, & Feedback">🤔</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://chenrui.dev"><img src="https://avatars.githubusercontent.com/u/1580956?v=4?s=64" width="64px;" alt="Rui Chen"/><br /><sub><b>Rui Chen</b></sub></a><br /><a href="https://github.com/nao1215/gup/issues?q=author%3Achenrui333" title="Bug reports">🐛</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/phanirithvij"><img src="https://avatars.githubusercontent.com/u/29627898?v=4?s=64" width="64px;" alt="phanirithvij"/><br /><sub><b>phanirithvij</b></sub></a><br /><a href="https://github.com/nao1215/gup/issues?q=author%3Aphanirithvij" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/phanirithvij"><img src="https://avatars.githubusercontent.com/u/29627898?v=4?s=64" width="64px;" alt="phanirithvij"/><br /><sub><b>phanirithvij</b></sub></a><br /><a href="https://github.com/nao1215/gup/issues?q=author%3Aphanirithvij" title="Bug reports">🐛</a> <a href="#platform-phanirithvij" title="Packaging/porting to new platform">📦</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Darkcast"><img src="https://avatars.githubusercontent.com/u/1676655?v=4?s=64" width="64px;" alt="Darkcast"/><br /><sub><b>Darkcast</b></sub></a><br /><a href="https://github.com/nao1215/gup/issues?q=author%3ADarkcast" title="Bug reports">🐛</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/hpsbranco"><img src="https://avatars.githubusercontent.com/u/3085888?v=4?s=64" width="64px;" alt="HenriqueB"/><br /><sub><b>HenriqueB</b></sub></a><br /><a href="https://github.com/nao1215/gup/commits?author=hpsbranco" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://rafaeldominiquini.ddns.net/"><img src="https://avatars.githubusercontent.com/u/1180808?v=4?s=64" width="64px;" alt="Rafael Baboni Dominiquini"/><br /><sub><b>Rafael Baboni Dominiquini</b></sub></a><br /><a href="#platform-Dominiquini" title="Packaging/porting to new platform">📦</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/branchv"><img src="https://avatars.githubusercontent.com/u/19800529?v=4?s=64" width="64px;" alt="Branch Vincent"/><br /><sub><b>Branch Vincent</b></sub></a><br /><a href="#platform-branchv" title="Packaging/porting to new platform">📦</a></td>
+    </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://nikolasgrottendieck.com/"><img src="https://avatars.githubusercontent.com/u/887496?v=4?s=64" width="64px;" alt="Nikolas Grottendieck"/><br /><sub><b>Nikolas Grottendieck</b></sub></a><br /><a href="#platform-Okeanos" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## Summary

Five people package gup for ecosystems nao1215 does not control, and none of their packaging work was credited. This adds them to the Contributors table with the `platform` (📦) type, and adds that type to the two who were already listed for other contributions.

## Changes

- `.all-contributorsrc` / `README.md`: added Rafael Baboni Dominiquini (`Dominiquini`), Branch Vincent (`branchv`), and Nikolas Grottendieck (`Okeanos`) as `platform` contributors.
- `.all-contributorsrc` / `README.md`: added `platform` to Frederick Zhang (`Frederick888`) and `phanirithvij`, who were credited only for `ideas` and `bug` respectively.

Who maintains what: `Dominiquini` maintains the AUR `gup-bin` package, `Frederick888` maintains the AUR `gup` source package, `phanirithvij` maintains `gogup` in nixpkgs, `branchv` submitted the original homebrew-core formula, and `Okeanos` brought gup into the winget community repository.

The table was regenerated with `all-contributors-cli`, so the badge count moved from 33 to 36 and the row layout is the tool's own output rather than a hand edit.

## Design Decisions

`platform` is the all-contributors type defined as "Packaging/porting to support a new platform", which is exactly what these five did, so no new convention was needed.

The people credited are the ones who introduced a package or keep it in step with releases. Bot accounts that push routine version bumps (`damn-good-b0t`, `BrewTestBot`, `PckgrBot`) and Homebrew's own maintainers who ran later formula bumps are not included, since they are maintaining their registry rather than distributing gup.

Each identification is backed by evidence rather than a matching username. `phanirithvij` is declared in `maintainers/maintainer-list.nix` with a `github` field. `Dominiquini` was confirmed by the commit address on the AUR package resolving to exactly one GitHub account whose display name also matches. `branchv` and `Okeanos` are the commit authors of the original formula and manifest. `Frederick888` was matched on a full real-name match plus a same-family handle, as his address is not public on GitHub.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the contributor count and contributors table in the README.
  * Added platform contribution credits for existing contributors.
  * Recognized three new platform contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->