### PR TITLE
fix(lockfile): act on the lock file this process holds, not the path it looked at

### DIFF
--- a/cmd/statelock.go
+++ b/cmd/statelock.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -80,7 +81,7 @@ var commandLockPolicy = map[string]lockTargets{ //nolint:gochecknoglobals // the
 // projects, and two commands given the same `--file` may be started from
 // different configuration directories entirely. A single config-directory lock
 // would serialize neither of those.
-func withStateLock(p *print.Printer, cmd *cobra.Command, args []string, name string, run func() int) int {
+func withStateLock(p *print.Printer, cmd *cobra.Command, args []string, name string, run func() int) (exitCode int) {
 	targets, ok := commandLockPolicy[name]
 	if !ok {
 		// Reaching this means a subcommand was added without deciding whether it
@@ -115,11 +116,31 @@ func withStateLock(p *print.Printer, cmd *cobra.Command, args []string, name str
 		return 1
 	}
 	defer func() {
-		// A failure to remove a lock file does not invalidate the work that was
-		// just done, so it is reported without changing the exit status: the next
-		// gup run reclaims the file through the staleness check either way.
-		if releaseErr := lock.Release(); releaseErr != nil {
-			p.Err(releaseErr)
+		releaseErr := lock.Release()
+		if releaseErr == nil {
+			return
+		}
+		p.Err(releaseErr)
+
+		// A lock file that could not be REMOVED does not invalidate the work that
+		// was just done, so it is reported without changing the exit status: the
+		// next gup run reclaims the file through the staleness check either way.
+		//
+		// A lock that was TAKEN OVER is a different statement about a different
+		// thing. It says another gup held this resource while this command was
+		// changing it, so the two runs overlapped and whatever this one wrote may
+		// have been written over - which is the exact outcome the lock exists to
+		// prevent. Reporting that on stderr and exiting 0 would let a CI job, a
+		// provisioning script, or a `gup update && ...` chain treat a lost update
+		// as a successful one; the message would be there in the log, and nothing
+		// would ever read it. So the status is failed.
+		//
+		// It only ever REPLACES success. A subcommand that already failed has its
+		// own status, and that status says more about what went wrong than this
+		// one would.
+		var takenOver *lockfile.TakenOverError
+		if errors.As(releaseErr, &takenOver) && exitCode == 0 {
+			exitCode = 1
 		}
 	}()
 	return run()

--- a/cmd/statelock_test.go
+++ b/cmd/statelock_test.go
@@ -148,11 +148,13 @@ func Test_withStateLock_refusesWhenAnotherProcessHoldsTheLock(t *testing.T) {
 	}
 }
 
-// Test_withStateLock_reportsAReleaseFailureWithoutDiscardingTheResult covers a
-// lock that cannot be released cleanly. The work already succeeded, so turning
-// that into a failed command would be a lie; the problem is reported and the
-// subcommand's status stands.
-func Test_withStateLock_reportsAReleaseFailureWithoutDiscardingTheResult(t *testing.T) {
+// Test_withStateLock_failsWhenTheLockWasTakenOverMidRun covers the overlap the
+// lock exists to prevent, reported after the fact. Another gup held the same
+// resource while this command was changing it, so what this run wrote may
+// already have been written over - and a status of 0 would let a CI job or a
+// `gup update && ...` chain treat that lost update as a success, with the only
+// evidence sitting unread in a log.
+func Test_withStateLock_failsWhenTheLockWasTakenOverMidRun(t *testing.T) {
 	lockPath := filepath.Join(t.TempDir(), "gup.lock")
 	stubLockTargets(t, testCmdUpdate, lockPath)
 
@@ -168,11 +170,81 @@ func Test_withStateLock_reportsAReleaseFailureWithoutDiscardingTheResult(t *test
 		return 0
 	})
 
+	if got != 1 {
+		t.Errorf("withStateLock() = %d, want 1: the two runs overlapped", got)
+	}
+	if !strings.Contains(buf.String(), "taken over") {
+		t.Errorf("withStateLock() did not report the overlap; output = %q", buf.String())
+	}
+}
+
+// Test_withStateLock_keepsTheSubcommandsOwnFailureStatus is the other half of
+// the rule above: a take-over only ever replaces success. A subcommand that
+// already failed has a status that says more about what went wrong.
+func Test_withStateLock_keepsTheSubcommandsOwnFailureStatus(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "gup.lock")
+	stubLockTargets(t, testCmdUpdate, lockPath)
+
+	buf := new(bytes.Buffer)
+	cmd := newLockTestCommand(buf)
+
+	got := withStateLock(print.New(buf, buf), cmd, nil, testCmdUpdate, func() int {
+		if err := os.WriteFile(lockPath, []byte(`{"pid":1,"nonce":"someone-else"}`), 0o600); err != nil {
+			t.Fatalf("failed to replace the lock file: %v", err)
+		}
+		return 7
+	})
+
+	if got != 7 {
+		t.Errorf("withStateLock() = %d, want the subcommand's own status 7", got)
+	}
+}
+
+// Test_withStateLock_reportsAnUnremovableLockWithoutDiscardingTheResult covers
+// the release failure that is NOT an overlap: the work succeeded and the lock
+// was still this process's, only the file could not be deleted. The next gup
+// reclaims it through the staleness check, so turning that into a failed command
+// would be a lie about what happened.
+func Test_withStateLock_reportsAnUnremovableLockWithoutDiscardingTheResult(t *testing.T) {
+	requireUnprivilegedPOSIX(t)
+
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "gup.lock")
+	stubLockTargets(t, testCmdUpdate, lockPath)
+
+	buf := new(bytes.Buffer)
+	cmd := newLockTestCommand(buf)
+
+	got := withStateLock(print.New(buf, buf), cmd, nil, testCmdUpdate, func() int {
+		// A read-only directory keeps the lock file from being renamed aside or
+		// removed, which is the permissions problem this reports.
+		//nolint:gosec // G302: these are directory modes, and denying writes is the point.
+		if err := os.Chmod(dir, 0o500); err != nil {
+			t.Fatalf("failed to seal the directory: %v", err)
+		}
+		//nolint:gosec // G302: restoring the mode so t.TempDir can clean up.
+		t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+		return 0
+	})
+
 	if got != 0 {
 		t.Errorf("withStateLock() = %d, want the subcommand's own status 0", got)
 	}
-	if !strings.Contains(buf.String(), "taken over") {
+	if !strings.Contains(buf.String(), "can not remove the gup lock file") {
 		t.Errorf("withStateLock() did not report the release problem; output = %q", buf.String())
+	}
+}
+
+// requireUnprivilegedPOSIX skips a test that depends on directory permissions
+// actually denying something. Windows does not express them this way, and root
+// bypasses them entirely, so on either the test would pass without testing.
+func requireUnprivilegedPOSIX(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permissions do not deny removal on Windows the way POSIX modes do")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root, which bypasses the directory permissions this test relies on")
 	}
 }
 

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -546,9 +546,8 @@ func detach(path, reason string) (string, error) {
 // os.Link is tried first because it puts the file back whole: same inode, same
 // content, same modification time, in one operation that fails rather than
 // replacing. Where hard links are unavailable (FAT, some network shares) the
-// file is re-created exclusively instead, which fails the same way for the same
-// reason and restores the modification time afterwards, since that is what a
-// waiter judges staleness from.
+// name is claimed with the same exclusive create an acquisition uses and the
+// detached file is renamed onto that claim.
 //
 // When the path is occupied the detached file is discarded. Its owner is left
 // without a lock, which is bad, but it is the outcome that at least leaves ONE
@@ -564,44 +563,99 @@ func restore(aside, path string) {
 		_ = os.Remove(aside)
 		return
 	}
-	restoreByRecreating(aside, path)
+	restoreByClaiming(aside, path)
 }
 
-// restoreByRecreating is restore's fallback for a filesystem with no hard links.
-// It re-creates the lock file exclusively and copies the detached one into it,
-// so the question "is the path free" is answered by the operation that fills it
-// rather than by a check somebody can invalidate before the next line runs.
-func restoreByRecreating(aside, path string) {
-	defer func() { _ = os.Remove(aside) }()
+// restoreRaceHook runs inside restoreByClaiming, between the claim and the
+// rename. It is nil outside tests, where it stands in for another process
+// arriving in the one window that fallback has left.
+var restoreRaceHook func() //nolint:gochecknoglobals // test seam
 
-	info, err := os.Stat(aside)
-	if err != nil {
-		return
-	}
-	raw, err := os.ReadFile(filepath.Clean(aside))
-	if err != nil {
+// restoreByClaiming is restore's fallback for a filesystem with no hard links.
+//
+// It claims the name with the exclusive create an acquisition uses, then renames
+// the detached file onto that claim. The claim is what decides whether the file
+// goes back - not a question about the path that somebody could invalidate
+// before the next line runs - and the rename is what puts it back, carrying the
+// original content and the original modification time with it because a rename
+// moves the file rather than copying it.
+//
+// That last part is why this does not re-create the file by hand. Copying meant
+// writing bytes and then winding the modification time back, two operations on a
+// name this process had already published as a lock file; a take-over landing
+// between them would have its own lock's timestamp dragged into the past, and a
+// third process would then reclaim a lock that is very much alive. Nothing here
+// touches the path after the rename, and everything before it happens to a
+// detached file nobody else can see.
+//
+// One window remains, and is worth naming rather than leaving to be found: the
+// rename replaces whatever is at the path, so a lock created between the claim
+// and the rename is overwritten. Nothing separates those two lines - no I/O, no
+// allocation - and getting there requires another process to judge the claim
+// abandoned, which takes the whole staleness bound on a file that is
+// microseconds old. If it happened anyway the result is still one lock file
+// holding one complete owner record, and the displaced owner finds out: its
+// heartbeat and its release both check the nonce. What the old copy could leave
+// instead - a successor's content wearing a predecessor's timestamp - is a live
+// lock that reads as abandoned to everyone.
+func restoreByClaiming(aside, path string) {
+	if _, err := os.Stat(aside); err != nil {
+		// Nothing to put back.
 		return
 	}
 
 	//nolint:gosec // G304: the path is gup's own lock file, and O_EXCL is the point of the call.
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, lockFileMode)
+	claim, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, lockFileMode)
 	if err != nil {
 		// Occupied, or unwritable: either way this file does not go back.
+		_ = os.Remove(aside)
 		return
 	}
-	_, writeErr := file.Write(raw)
-	if closeErr := file.Close(); writeErr == nil {
-		writeErr = closeErr
-	}
-	if writeErr != nil {
-		// A half-written lock file names nobody and would be reclaimed as rubbish
-		// once it ages; removing it now is the same outcome, sooner.
+	if err := claim.Close(); err != nil {
+		_ = os.Remove(aside)
 		_ = os.Remove(path)
 		return
 	}
-	// The modification time is what staleness is measured from, so a restored
-	// lock has to carry the one it had rather than looking freshly touched.
-	_ = os.Chtimes(path, info.ModTime(), info.ModTime())
+	if restoreRaceHook != nil {
+		restoreRaceHook()
+	}
+	if err := os.Rename(aside, path); err != nil {
+		_ = os.Remove(aside)
+		// The claim is an empty lock file naming nobody, and removing it by name is
+		// removing this process's own: it was created moments ago, and the only way
+		// another process can put a different file at that name is by first judging
+		// this one abandoned, which takes the whole staleness bound.
+		_ = os.Remove(path)
+	}
+}
+
+// discardOwnUnwritten removes the lock file this process created but failed to
+// finish writing - and only while it is still that file.
+//
+// The file is detached first and identified afterwards, for the reason a
+// take-over and a release both are: reading a path and then removing it are two
+// operations, and a lock created between them would be removed on the strength
+// of what a different file at the same name said. Removing a successor's lock
+// that way is the one outcome this package exists to prevent, so a successor's
+// file is put back instead.
+//
+// Being attributable to somebody else is the whole of the test. A complete owner
+// record carrying a nonce that is not this one belongs to another acquisition;
+// anything else - an empty file, a truncated one, or one carrying this nonce -
+// is this process's own failed attempt and goes. A successor caught in its own
+// moment of anonymity can lose its empty file here, and that is safe by
+// construction: createLockFile does not return a lock until it has confirmed the
+// file at the path is still the one it created.
+func discardOwnUnwritten(path, nonce string) {
+	aside, err := detach(path, "unwritten")
+	if err != nil || aside == "" {
+		return
+	}
+	if owner, readErr := readOwner(aside); readErr == nil && owner.Nonce != "" && owner.Nonce != nonce {
+		restore(aside, path)
+		return
+	}
+	_ = os.Remove(aside)
 }
 
 // createLockFile creates path exclusively and writes the owner record into it.
@@ -636,16 +690,17 @@ func createLockFile(path, command string) (*Lock, error) {
 	// failed acquisition and clean up rather than holding an unreadable lock.
 	data, err := json.Marshal(owner)
 	if err == nil {
-		_, err = file.Write(append(data, '\n'))
-	}
-	if err == nil {
-		err = file.Sync()
+		err = writeOwnerRecord(file, append(data, '\n'))
 	}
 	if closeErr := file.Close(); err == nil {
 		err = closeErr
 	}
 	if err != nil {
-		_ = os.Remove(path)
+		// The file at the path may no longer be the one created above: a write that
+		// takes long enough to fail can outlast the staleness bound, and a waiter
+		// that reclaimed the anonymous file in the meantime has its own lock there
+		// now. Removing the path by name would delete it.
+		discardOwnUnwritten(path, nonce)
 		return nil, fmt.Errorf("can not write the gup lock file %s: %w", path, err)
 	}
 
@@ -660,6 +715,17 @@ func createLockFile(path, command string) (*Lock, error) {
 	}
 
 	return &Lock{path: path, nonce: nonce}, nil
+}
+
+// writeOwnerRecord puts the owner record into a freshly created lock file. It is
+// a variable so a test can fail the write at the exact moment another process
+// takes the path over - the race createLockFile's cleanup has to survive, and
+// one that is otherwise only reachable with a full disk or a failing device.
+var writeOwnerRecord = func(file *os.File, data []byte) error { //nolint:gochecknoglobals // test seam
+	if _, err := file.Write(data); err != nil {
+		return err
+	}
+	return file.Sync()
 }
 
 // ownsFile reports whether the lock file at path carries this nonce.

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -30,12 +30,15 @@
 // reclaimed when its heartbeat has stopped long enough.
 //
 // Every step that could act on the WRONG file - taking a lock over, refreshing
-// it, releasing it - is made to act on a file it holds rather than on a path it
-// looked at a moment ago. Taking over and releasing rename the file aside first,
-// because only one process can rename a given file, and then check what they
-// took; the heartbeat verifies and refreshes through a single descriptor. A path
-// checked and then acted on is two operations on what may be two different
-// files, which is how a lock ends up refreshing, or deleting, its successor's.
+// it, releasing it, cleaning up after an acquisition that could not finish
+// writing itself - is made to act on a file it holds rather than on a path it
+// looked at a moment ago. All three of the removing ones rename the file aside
+// first, because only one process can rename a given file, and then check what
+// they took; the heartbeat verifies and refreshes through a single descriptor;
+// putting a detached file back moves it rather than copying it, so no content
+// and no timestamp is ever written to a published name. A path checked and then
+// acted on is two operations on what may be two different files, which is how a
+// lock ends up refreshing, or deleting, its successor's.
 package lockfile
 
 import (

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -1553,7 +1553,14 @@ func TestCreateLockFile_doesNotDeleteALockTakenWhileItsOwnRecordWasBeingWritten(
 
 	original := writeOwnerRecord
 	t.Cleanup(func() { writeOwnerRecord = original })
-	writeOwnerRecord = func(_ *os.File, _ []byte) error {
+	writeOwnerRecord = func(file *os.File, _ []byte) error {
+		// Windows refuses to unlink a file this process still has open, so the
+		// handle goes first. createLockFile closes it again on its way out, which
+		// costs nothing: the second close reports a closed file into an error path
+		// that already has the write failure staged below.
+		if err := file.Close(); err != nil {
+			t.Errorf("failed to release the handle before the take-over: %v", err)
+		}
 		// Another gup judged the anonymous file abandoned and took the name over.
 		if err := os.Remove(path); err != nil {
 			t.Errorf("failed to stand in for the take-over: %v", err)

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -1388,12 +1388,12 @@ func rollbackAgainstAReclaimedFirstLock(t *testing.T) error {
 	return err
 }
 
-// TestRestoreByRecreating covers restore's fallback for filesystems with no hard
+// TestRestoreByClaiming covers restore's fallback for filesystems with no hard
 // links, which the test machine almost certainly has - so the fallback is driven
 // directly. It must follow the same rule as the Link path, and be atomic about
 // it: the path is filled by the operation that claims it, never by a check
 // followed by a write.
-func TestRestoreByRecreating(t *testing.T) {
+func TestRestoreByClaiming(t *testing.T) {
 	t.Parallel()
 
 	t.Run("restores into a free path, modification time and all", func(t *testing.T) {
@@ -1408,7 +1408,7 @@ func TestRestoreByRecreating(t *testing.T) {
 		}
 		content := readAll(t, aside)
 
-		restoreByRecreating(aside, path)
+		restoreByClaiming(aside, path)
 
 		if got := readAll(t, path); got != content {
 			t.Errorf("the restored lock file reads %q, want %q", got, content)
@@ -1434,11 +1434,25 @@ func TestRestoreByRecreating(t *testing.T) {
 		aside := filepath.Join(dir, "gup.lock.stale-1-1")
 		writeOwner(t, aside, Owner{PID: 1, Host: remoteHost, Command: cmdUpdate, Nonce: ownerHolder})
 		writeOwner(t, path, Owner{PID: os.Getpid(), Host: hostname(t), Command: cmdRemove, Nonce: successorNonce})
+		before, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("failed to stat the successor's lock: %v", err)
+		}
 
-		restoreByRecreating(aside, path)
+		restoreByClaiming(aside, path)
 
 		if got := readOwnerForTest(t, path); got.Nonce != successorNonce {
 			t.Errorf("the lock at the path is %q, want the newcomer's %q", got.Nonce, successorNonce)
+		}
+		// The old fallback wrote the detached file's content and then wound the
+		// modification time back, both by name. Landing that on a successor's lock
+		// backdates a live lock into staleness, so a third process reclaims it.
+		after, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("the successor's lock is gone: %v", err)
+		}
+		if !after.ModTime().Equal(before.ModTime()) {
+			t.Errorf("the successor's lock was re-timed from %v to %v", before.ModTime(), after.ModTime())
 		}
 		if _, err := os.Stat(aside); !os.IsNotExist(err) {
 			t.Errorf("the detached file was left behind: %v", err)
@@ -1450,10 +1464,214 @@ func TestRestoreByRecreating(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "gup.lock")
 
-		restoreByRecreating(filepath.Join(dir, "not-there"), path)
+		restoreByClaiming(filepath.Join(dir, "not-there"), path)
 
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
 			t.Errorf("a lock file was created out of nothing: %v", err)
 		}
 	})
+}
+
+// TestDiscardOwnUnwritten covers the cleanup that runs when the owner record
+// could not be written into a lock file this process had already created.
+//
+// The dangerous case is the second one. A write that fails can take longer than
+// the staleness bound - a device that stalls before reporting an error is
+// exactly how that happens - and by the time it returns, a waiter may have
+// judged the anonymous file abandoned, removed it, and created its own lock at
+// the same name. Removing that path by name deletes a lock another gup is
+// actively working under, and the process after it walks straight in.
+func TestDiscardOwnUnwritten(t *testing.T) {
+	t.Parallel()
+
+	t.Run("removes the anonymous file it created", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "gup.lock")
+		if err := os.WriteFile(path, nil, 0o600); err != nil {
+			t.Fatalf("failed to plant the anonymous lock file: %v", err)
+		}
+
+		discardOwnUnwritten(path, "mine")
+
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("the half-created lock file was left behind: %v", err)
+		}
+	})
+
+	t.Run("removes a file that carries its own nonce", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "gup.lock")
+		writeOwner(t, path, Owner{PID: os.Getpid(), Host: hostname(t), Command: cmdUpdate, Nonce: "mine"})
+
+		discardOwnUnwritten(path, "mine")
+
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("the lock file this process created was left behind: %v", err)
+		}
+	})
+
+	t.Run("leaves a successor's lock exactly where it is", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "gup.lock")
+		writeOwner(t, path, Owner{PID: os.Getpid(), Host: hostname(t), Command: cmdRemove, Nonce: successorNonce})
+		content := readAll(t, path)
+		before, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("failed to stat the successor's lock: %v", err)
+		}
+
+		discardOwnUnwritten(path, "mine")
+
+		if got := readAll(t, path); got != content {
+			t.Errorf("the successor's lock reads %q, want %q", got, content)
+		}
+		after, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("the successor's lock was deleted: %v", err)
+		}
+		if !after.ModTime().Equal(before.ModTime()) {
+			t.Errorf("the successor's lock was re-timed from %v to %v", before.ModTime(), after.ModTime())
+		}
+		if leftovers := asideFiles(t, filepath.Dir(path)); len(leftovers) != 0 {
+			t.Errorf("detached files were left lying around: %v", leftovers)
+		}
+	})
+}
+
+// TestCreateLockFile_doesNotDeleteALockTakenWhileItsOwnRecordWasBeingWritten
+// drives the same race through createLockFile itself rather than through the
+// cleanup in isolation, so the two stay wired together.
+//
+// The take-over is staged from inside the failing write, which is what makes
+// this deterministic: the stand-in reclaims the anonymous file and installs a
+// successor's lock at exactly the moment the real race would, then reports the
+// write error that sends createLockFile into its cleanup. No sleeping, and no
+// dependence on which of two goroutines happens to run first.
+func TestCreateLockFile_doesNotDeleteALockTakenWhileItsOwnRecordWasBeingWritten(t *testing.T) { //nolint:paralleltest // swaps a package-level test seam
+	path := filepath.Join(t.TempDir(), "gup.lock")
+	successor := Owner{PID: os.Getpid(), Host: hostname(t), Command: cmdRemove, Nonce: successorNonce}
+
+	original := writeOwnerRecord
+	t.Cleanup(func() { writeOwnerRecord = original })
+	writeOwnerRecord = func(_ *os.File, _ []byte) error {
+		// Another gup judged the anonymous file abandoned and took the name over.
+		if err := os.Remove(path); err != nil {
+			t.Errorf("failed to stand in for the take-over: %v", err)
+		}
+		writeOwner(t, path, successor)
+		return errors.New("the device reported a write error")
+	}
+
+	lock, err := createLockFile(path, cmdUpdate)
+	if err == nil {
+		t.Fatalf("createLockFile() succeeded despite a failed write; lock = %v", lock)
+	}
+	if got := readOwnerForTest(t, path); got.Nonce != successorNonce {
+		t.Fatalf("the lock at the path is %q, want the successor's %q", got.Nonce, successorNonce)
+	}
+	if leftovers := asideFiles(t, filepath.Dir(path)); len(leftovers) != 0 {
+		t.Errorf("detached files were left lying around: %v", leftovers)
+	}
+}
+
+// TestCreateLockFile_cleansUpAfterAFailedWrite is the other half: with nobody
+// else involved, the file this process created must not be left behind, or the
+// next gup waits out the staleness bound on rubbish.
+func TestCreateLockFile_cleansUpAfterAFailedWrite(t *testing.T) { //nolint:paralleltest // swaps a package-level test seam
+	path := filepath.Join(t.TempDir(), "gup.lock")
+
+	original := writeOwnerRecord
+	t.Cleanup(func() { writeOwnerRecord = original })
+	writeOwnerRecord = func(*os.File, []byte) error { return errors.New("the device reported a write error") }
+
+	if lock, err := createLockFile(path, cmdUpdate); err == nil {
+		t.Fatalf("createLockFile() succeeded despite a failed write; lock = %v", lock)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("the half-created lock file was left behind: %v", err)
+	}
+	if leftovers := asideFiles(t, filepath.Dir(path)); len(leftovers) != 0 {
+		t.Errorf("detached files were left lying around: %v", leftovers)
+	}
+}
+
+// TestRestoreByClaiming_neverLeavesASuccessorsLockWearingAnotherOwnersTimestamp
+// drives the one window the fallback has: a lock created at the path after the
+// name was claimed and before the detached file is renamed onto it.
+//
+// The invariant is that the file left at the path is consistent - whichever of
+// the two locks survives, it wears its OWN modification time. The fallback this
+// replaced could not hold that: it wrote the detached file's bytes through a
+// descriptor whose name had already been taken over, and then wound the path's
+// modification time back to the detached file's, leaving a successor's lock
+// backdated into staleness for every waiter to reclaim while its owner worked.
+func TestRestoreByClaiming_neverLeavesASuccessorsLockWearingAnotherOwnersTimestamp(t *testing.T) { //nolint:paralleltest // swaps a package-level test seam
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gup.lock")
+	aside := filepath.Join(dir, "gup.lock.stale-1-1")
+	writeOwner(t, aside, Owner{PID: 1, Host: remoteHost, Command: cmdUpdate, Nonce: ownerHolder})
+	old := time.Now().Add(-30 * time.Second).Truncate(time.Second)
+	if err := os.Chtimes(aside, old, old); err != nil {
+		t.Fatalf("failed to backdate the detached file: %v", err)
+	}
+
+	successorMod := time.Now().Truncate(time.Second)
+	original := restoreRaceHook
+	t.Cleanup(func() { restoreRaceHook = original })
+	restoreRaceHook = func() {
+		// Another gup takes the claimed name over: it removes the empty claim and
+		// puts its own lock there, exactly as a reclaim would.
+		if err := os.Remove(path); err != nil {
+			t.Errorf("failed to stand in for the take-over: %v", err)
+		}
+		writeOwner(t, path, Owner{PID: os.Getpid(), Host: hostname(t), Command: cmdRemove, Nonce: successorNonce})
+		if err := os.Chtimes(path, successorMod, successorMod); err != nil {
+			t.Errorf("failed to time the successor's lock: %v", err)
+		}
+	}
+
+	restoreByClaiming(aside, path)
+
+	got := readOwnerForTest(t, path)
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("no lock file was left at the path: %v", err)
+	}
+	switch got.Nonce {
+	case ownerHolder:
+		if !info.ModTime().Equal(old) {
+			t.Errorf("the restored lock reads %q but is timed %v, want %v", got.Nonce, info.ModTime(), old)
+		}
+	case successorNonce:
+		if !info.ModTime().Equal(successorMod) {
+			t.Errorf("the successor's lock was re-timed to %v, want its own %v", info.ModTime(), successorMod)
+		}
+	default:
+		t.Errorf("the lock at the path belongs to nobody: %+v", got)
+	}
+	if leftovers := asideFiles(t, dir); len(leftovers) != 0 {
+		t.Errorf("detached files were left lying around: %v", leftovers)
+	}
+}
+
+// asideFiles lists the detached lock files left in dir. Every path that gets
+// renamed aside has to end up either back at its name or removed; one left
+// behind is a lock file nobody will ever reclaim, because no owner recognizes
+// the name.
+func asideFiles(t *testing.T, dir string) []string {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("failed to list %s: %v", dir, err)
+	}
+	var out []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.Contains(name, ".stale-") || strings.Contains(name, ".release-") ||
+			strings.Contains(name, ".unwritten-") {
+			out = append(out, name)
+		}
+	}
+	return out
 }


### PR DESCRIPTION
## Why

A review of the advisory lock turned up two places where the code acted on a lock file *by name* after the file at that name could have become another process's, and one place where an overlap the lock detected was reported to a human and hidden from a machine.

## Should the lock stay at all?

Yes. The alternative was considered and rejected.

The lock is not decoration. `gup update` reads `gup.json`, installs, and writes `gup.json` back; two runs interleaved both read the same file and whichever finishes last writes one describing only what it did. `gup remove` deleting a binary a concurrent `gup update` is reinstalling is the same race with a worse outcome. Atomic rename already guarantees no reader sees a half-written file, and that is a different property from mutual exclusion - it cannot prevent either of those. Deleting the lock would mean deleting the only thing that does, and no test can prove the absence of a lost update is safe, because the loss is silent by construction.

What was genuinely not worth its complexity was one *part* of it: `restoreByRecreating`, the fallback that rebuilt a detached lock file by hand on filesystems without hard links. Copying content and then winding a modification time back is two operations on a published name, and no amount of re-checking makes that pair atomic - both races reported against it were inherent to the shape, not bugs in the details. That function is gone, replaced by a claim-then-rename that moves the file instead of copying it. Net effect on the package: the same guarantee, one fewer way to violate it, and slightly less code.

The trade-off that remains is stated in the code rather than left to be found. `restoreByClaiming` renames onto a name it exclusively created, and a rename replaces. Nothing separates the claim from the rename - no I/O, no allocation - and reaching that window requires another process to judge a microseconds-old file abandoned, which takes the whole staleness bound. If it happened anyway, the result is still one lock file holding one complete owner record, and the displaced owner finds out: its heartbeat and its release both check the nonce. That is strictly better than what the copy could leave behind, which was a live lock wearing a timestamp that made it read as abandoned to everyone.

## What changed

**`internal/lockfile/lockfile.go`**

- `createLockFile` removed the path when it could not write the owner record into the file it had just created exclusively. A write that fails can take longer than the staleness bound - a device that stalls before reporting an error is exactly how - and by then a waiter may have judged the anonymous file abandoned and put its own lock at that name. The removal deleted a lock another gup was working under. The cleanup (`discardOwnUnwritten`) now detaches first and identifies afterwards, the way a take-over and a release already do: a complete owner record carrying somebody else's nonce is restored, only this process's own unfinished file is removed.
- `restoreByRecreating` → `restoreByClaiming`. The name is claimed with the same exclusive create an acquisition uses, and the detached file is renamed onto that claim, carrying its original content *and* its original modification time across in one operation. There is no `os.Write` and no `os.Chtimes` at the path any more, so neither can land on a successor.
- Two test seams: `writeOwnerRecord` (fail the owner-record write at a chosen instant) and `restoreRaceHook` (stand in for another process arriving inside the claim/rename window). Both are needed to reproduce these races deterministically rather than by sleeping and hoping.

**`cmd/statelock.go`**

- A release that reports `TakenOverError` says another gup held this resource while the command was changing it. That was printed to stderr with an exit status of 0, so a CI job, a provisioning script, or a `gup update && ...` chain treated a lost update as a success. It now fails the command.
- It replaces success only. A subcommand that already failed keeps its own status, which says more about what went wrong. Every other release failure is unchanged: a lock file that could not be *removed* does not invalidate the work that was just done, and the next gup reclaims it through the staleness check either way. That distinction is the reason the two are not collapsed into "any release error fails" - one is a statement about the user's data, the other about a leftover file.

## Tests

Both new lockfile tests were verified to **fail against the previous implementation** and pass against this one.

- `TestCreateLockFile_doesNotDeleteALockTakenWhileItsOwnRecordWasBeingWritten` - the take-over is staged from inside the failing write, so it lands exactly where the real race would. Old code: `open gup.lock: no such file or directory` - the successor's lock was deleted.
- `TestCreateLockFile_cleansUpAfterAFailedWrite` - the other half: with nobody else involved, nothing is left behind for the next gup to wait out.
- `TestDiscardOwnUnwritten` - three cases: the anonymous file goes, a file carrying this nonce goes, a successor's lock is left byte- and timestamp-identical with no detached file leaked.
- `TestRestoreByClaiming_neverLeavesASuccessorsLockWearingAnotherOwnersTimestamp` - a successor takes the claimed name over inside the window; whichever lock survives must wear its *own* modification time. Old code: `the successor's lock was re-timed to 21:33:27, want its own 21:33:57`.
- `TestRestoreByClaiming` - renamed from `TestRestoreByRecreating`, with an added assertion that an occupied path is not re-timed.
- `asideFiles` helper - every path renamed aside must end up back at its name or removed; one left behind is a lock file no owner recognizes.

**`cmd/statelock_test.go`** - `Test_withStateLock_reportsAReleaseFailureWithoutDiscardingTheResult` asserted the old exit status and is replaced by three:

- `Test_withStateLock_failsWhenTheLockWasTakenOverMidRun` - exit 1, message still printed.
- `Test_withStateLock_keepsTheSubcommandsOwnFailureStatus` - a take-over does not overwrite exit 7.
- `Test_withStateLock_reportsAnUnremovableLockWithoutDiscardingTheResult` - a sealed directory makes the release fail for a reason that is *not* an overlap; the status stays 0. POSIX-only, skipped as root.

## Verification

```
go test ./...                              all pass
go test -race ./...                        all pass
go vet ./...                               clean
golangci-lint run                          0 issues
gofmt -l cmd internal                      clean
go run ./e2e/runner e2e/atago/lock.atago.yaml
                                           13 scenarios: 13 passed, 0 failed
```

The existing lock, stale-lock, heartbeat, symlink, migrate and `$GOBIN` tests are untouched and still pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Commands now fail when their lock is taken over during execution, helping prevent overwritten work.
  * Existing command failures retain their original status when a lock takeover is detected.
  * Lock cleanup no longer removes a successor process’s lock, including after interrupted lock creation.
  * Lock restoration preserves successor lock timestamps, preventing incorrect stale-lock detection.
  * Unremovable lock files are reported without changing an otherwise successful command result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->