### PR TITLE
fix(release): open the Scoop manifest as a pull request instead of pushing it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,14 @@ jobs:
           # Fork-scoped token so the winget manifests can be pushed to
           # nao1215/winget-pkgs and the pull request opened upstream.
           WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
+          # The Scoop manifest opens a pull request against this repository's own
+          # protected main, which the built-in GITHUB_TOKEN cannot do usefully:
+          # GitHub starts no workflow runs for events that token causes, so the
+          # required checks would never report and the pull request could never
+          # merge. WINGET_GITHUB_TOKEN is a classic `public_repo` token and can
+          # already write here, so it stands in until this gets a secret of its
+          # own - at which point nothing but the secret has to change.
+          SCOOP_GITHUB_TOKEN: ${{ secrets.SCOOP_GITHUB_TOKEN || secrets.WINGET_GITHUB_TOKEN }}
       - name: Attest build provenance
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -188,19 +188,40 @@ winget:
 #   scoop bucket add nao1215 https://github.com/nao1215/gup
 #   scoop install nao1215/gup
 #
-# Keeping the bucket here means GoReleaser publishes the manifest with the
-# release workflow's built-in GITHUB_TOKEN - no cross-repository token to
-# provision, and no second repository whose only content is one generated JSON
-# file. The manifest's architecture keys are generated from the `builds.goarch`
-# list above, so the Windows amd64/arm64 zip URLs and their SHA-256 hashes come
-# from the same artifacts the release publishes. Skipped by `--skip=publish`,
-# so snapshot builds stay hermetic.
+# Keeping the bucket here means no second repository whose only content is one
+# generated JSON file. The manifest's architecture keys are generated from the
+# `builds.goarch` list above, so the Windows amd64/arm64 zip URLs and their
+# SHA-256 hashes come from the same artifacts the release publishes. Skipped by
+# `--skip=publish`, so snapshot builds stay hermetic.
+#
+# The manifest arrives as a PULL REQUEST rather than a commit, and both halves of
+# that are forced by this repository rather than chosen. `main` is protected with
+# admin enforcement, so nothing pushes to it directly - v1.9.0's release job got
+# a 409 ("Changes must be made through a pull request") after the release itself
+# had already published, which took the provenance attestation down with it. And
+# the pull request has to come from a personal access token, not the workflow's
+# built-in GITHUB_TOKEN: GitHub deliberately does not start workflow runs for
+# events that token causes, so a pull request it opened would sit with all eight
+# required checks reported as never-run and could not be merged by anyone.
+#
+# SCOOP_GITHUB_TOKEN is that token. The release workflow falls back to
+# WINGET_GITHUB_TOKEN when it is not set, which is a classic token with the
+# `public_repo` scope and therefore already able to write here - so this needs
+# nothing provisioned, while leaving room to narrow it to its own secret later.
 scoops:
   - name: gup
     repository:
       owner: nao1215
       name: gup
-      branch: main
+      branch: "scoop-gup-{{ .Version }}"
+      token: "{{ .Env.SCOOP_GITHUB_TOKEN }}"
+      pull_request:
+        enabled: true
+        draft: false
+        base:
+          owner: nao1215
+          name: gup
+          branch: main
     directory: bucket
     homepage: "https://github.com/nao1215/gup"
     description: 'Fast manager for Go-installed binaries in $GOBIN: update, export/import, and migrate toolsets across machines'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes
+
+* The release publishes its Scoop manifest again. `bucket/gup.json` was committed straight to `main`, which is protected with admin enforcement, so v1.9.0's release job was refused with "Changes must be made through a pull request" — after the release itself had published, and before the step that attests build provenance, which therefore never ran. The Scoop bucket had been added since the previous tag, so v1.9.0 was the first release to exercise it. The manifest now arrives as a `scoop-gup-<version>` pull request, opened by a personal access token rather than the workflow's own: GitHub starts no workflow runs for events that token causes, so a pull request it opened would have every required check reported as never-run and could not be merged by anyone.
+
 ## [v1.9.0](https://github.com/nao1215/gup/compare/v1.8.1...v1.9.0) (2026-08-31)
 
 ### Features

--- a/bucket/README.md
+++ b/bucket/README.md
@@ -14,6 +14,12 @@ release's Windows `amd64`/`arm64` archive URLs and their SHA-256 hashes, so it
 cannot be edited by hand without going stale at the next tag. Change
 [`.goreleaser.yml`](../.goreleaser.yml) instead.
 
+It arrives as a pull request, `scoop-gup-<version>`, rather than as a commit:
+`main` is protected, and the release job is not exempt from that. Merging it is
+the last step of a release — until it lands, the bucket still describes the
+previous version, which is the safe direction for a file whose hashes have to
+match the artifacts a user downloads.
+
 Scoop and [winget](https://github.com/microsoft/winget-pkgs) are both published
 from the same release: winget carries the `nao1215.gup` package identifier, this
 bucket carries the `nao1215/gup` Scoop app. Installing through one does not

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -34,7 +34,8 @@ The release workflow then:
 - signs the checksums with cosign (keyless) and attaches an SBOM;
 - attests build provenance via GitHub OIDC;
 - updates the Homebrew tap (`nao1215/homebrew-tap`);
-- pushes the winget manifests to `nao1215/winget-pkgs` and opens the pull request against [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs).
+- pushes the winget manifests to `nao1215/winget-pkgs` and opens the pull request against [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs);
+- opens a `scoop-gup-<version>` pull request on this repository with the updated [Scoop manifest](../bucket/README.md), which is the one step of a release that is finished by hand.
 
 Packaging that needs nothing from us: the [homebrew-core formula](https://formulae.brew.sh/formula/gup) carries `autobump`, so Homebrew opens its own bump pull request from the new tag, and the AUR packages (`gup`, `gup-bin`) plus the nixpkgs `gogup` attribute are maintained by other people on their own schedule.
 
@@ -43,6 +44,7 @@ Packaging that needs nothing from us: the [homebrew-core formula](https://formul
 - `TAP_GITHUB_TOKEN`: a token with write access to `nao1215/homebrew-tap`,
   used to push the updated formula.
 - `WINGET_GITHUB_TOKEN`: a classic token with the `public_repo` scope, used to commit the winget manifests to `nao1215/winget-pkgs` and open the upstream pull request. A fine-grained token does not work here: it can only be scoped to repositories you own, and opening the pull request is a write against microsoft/winget-pkgs. A failure is logged without failing the release, so a rejected or delayed pull request never blocks a version.
+- `SCOOP_GITHUB_TOKEN`: optional. The token that opens the Scoop manifest pull request on this repository; `WINGET_GITHUB_TOKEN` is used when it is unset, and already has the access. It cannot be the workflow's built-in `GITHUB_TOKEN`: GitHub starts no workflow runs for events that token causes, so the pull request would have all eight required checks reported as never-run and could not be merged by anyone. If you narrow it to its own secret, it needs write access to `nao1215/gup` and permission to open pull requests there.
 
 ## The winget pull request
 A **stable** tagged release opens a pull request on microsoft/winget-pkgs; a moderator merges it once their validation pipeline passes, usually within a day. A pre-release tag opens nothing: `skip_upload: auto` skips the winget pipe whenever the tag carries a pre-release suffix, because the community repository takes stable versions only.
@@ -50,6 +52,10 @@ A **stable** tagged release opens a pull request on microsoft/winget-pkgs; a mod
 Until this was wired up a third-party bot submitted gup's manifests on its own schedule, which is why v1.5.1, v1.6.0, and v1.7.0 never reached winget. The bot skips a version that is already present, so publishing from the release simply takes over.
 
 ## After releasing
+- Merge the `scoop-gup-<version>` pull request. It is the only publishing step a
+  human finishes, because `main` is protected and the release job is not exempt.
+  Until it merges, `scoop install nao1215/gup` still installs the previous
+  version.
 - Check the [Releases page](https://github.com/nao1215/gup/releases) for the
   generated notes and artifacts.
 - Verify a downloaded artifact as described in

--- a/release_test.go
+++ b/release_test.go
@@ -369,11 +369,17 @@ func Test_goreleaser_scoopBucket(t *testing.T) {
 	}
 
 	// Nothing may be pushed to main: it is protected, and the release job is not
-	// exempt from that.
+	// exempt from that. The branch also has to be a new one per release - a fixed
+	// name would have two releases reusing one branch and one pull request, so a
+	// tag cut while the previous manifest is still unmerged rewrites it.
 	branch, _ := repo["branch"].(string)
-	if branch == "" || branch == defaultBranch {
+	switch {
+	case branch == "" || branch == defaultBranch:
 		t.Errorf("scoops[0].repository.branch = %q, want a per-release branch; %q is protected and refuses a direct push",
 			branch, defaultBranch)
+	case !strings.Contains(branch, "{{ .Version }}"):
+		t.Errorf("scoops[0].repository.branch = %q, want it to carry {{ .Version }}; a fixed branch makes two releases share one pull request",
+			branch)
 	}
 
 	pr, ok := repo["pull_request"].(map[string]any)
@@ -391,14 +397,20 @@ func Test_goreleaser_scoopBucket(t *testing.T) {
 	}
 
 	// A pull request the built-in token opened could never be merged, so the
-	// token has to be one this configuration names for itself.
-	token, _ := repo["token"].(string)
-	if !strings.Contains(token, ".Env.") {
-		t.Errorf("scoops[0].repository.token = %q, want a token from the environment; the built-in GITHUB_TOKEN opens a pull request whose required checks never run",
-			token)
+	// token has to be one this configuration names for itself - and the release
+	// workflow has to put that exact name in the GoReleaser step's environment,
+	// or the template renders empty and the pipe fails after the release has
+	// published. The two halves are asserted together because either one alone
+	// passes happily while the other names something else.
+	if token, _ := repo["token"].(string); token != scoopTokenTemplate {
+		t.Errorf("scoops[0].repository.token = %q, want %q; the built-in GITHUB_TOKEN opens a pull request whose required checks never run",
+			token, scoopTokenTemplate)
 	}
-	if !strings.Contains(releaseWorkflowSource(t), scoopTokenEnv) {
-		t.Errorf("the release workflow does not set %s, so the Scoop pull request has no token to open with", scoopTokenEnv)
+	if wiring := goreleaserStepEnv(t)[scoopTokenEnv]; wiring == "" {
+		t.Errorf("the release workflow's GoReleaser step does not set %s, so the Scoop pull request has no token to open with",
+			scoopTokenEnv)
+	} else if !strings.Contains(wiring, "secrets.") {
+		t.Errorf("the release workflow sets %s to %q, which reads no secret", scoopTokenEnv, wiring)
 	}
 
 	// The bucket has to be a real directory in the repository, or `scoop bucket
@@ -412,20 +424,55 @@ func Test_goreleaser_scoopBucket(t *testing.T) {
 const defaultBranch = "main"
 
 // scoopTokenEnv is the environment variable the Scoop pull request is opened
-// with. The release workflow has to set it, or GoReleaser fails while rendering
-// the token template - after the release has published.
-const scoopTokenEnv = "SCOOP_GITHUB_TOKEN" //nolint:gosec // G101: the NAME of a secret, not one
+// with, and scoopTokenTemplate is how .goreleaser.yml has to spell it. The
+// release workflow has to set that exact name, or GoReleaser renders an empty
+// token and the pipe fails after the release has published.
+const (
+	scoopTokenEnv      = "SCOOP_GITHUB_TOKEN" //nolint:gosec // G101: the NAME of a secret, not one
+	scoopTokenTemplate = "{{ .Env." + scoopTokenEnv + " }}"
+)
 
-// releaseWorkflowSource returns the release workflow as text. The token wiring is
-// asserted against the source rather than the parsed document because what it has
-// to contain is an expression GitHub evaluates, not a value YAML can compare.
-func releaseWorkflowSource(t *testing.T) string {
+// goreleaserStepEnv returns the environment of the release workflow's GoReleaser
+// step, which is where every publishing token is wired in.
+func goreleaserStepEnv(t *testing.T) map[string]string {
 	t.Helper()
-	raw, err := os.ReadFile(filepath.Join(workflowDir, "release.yml"))
-	if err != nil {
-		t.Fatalf("failed to read the release workflow: %v", err)
+
+	doc := readYAMLFile(t, filepath.Join(workflowDir, "release.yml"))
+	jobs, ok := doc["jobs"].(map[string]any)
+	if !ok {
+		t.Fatal("the release workflow has no jobs")
 	}
-	return string(raw)
+	release, ok := jobs["release"].(map[string]any)
+	if !ok {
+		t.Fatal("the release workflow has no release job")
+	}
+	steps, ok := release["steps"].([]any)
+	if !ok {
+		t.Fatal("the release job has no steps")
+	}
+	for _, raw := range steps {
+		step, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		uses, _ := step["uses"].(string)
+		if !strings.HasPrefix(uses, "goreleaser/goreleaser-action@") {
+			continue
+		}
+		env, ok := step["env"].(map[string]any)
+		if !ok {
+			return nil
+		}
+		out := make(map[string]string, len(env))
+		for name, value := range env {
+			if text, ok := value.(string); ok {
+				out[name] = text
+			}
+		}
+		return out
+	}
+	t.Fatal("the release job does not run goreleaser-action, so nothing publishes")
+	return nil
 }
 
 // stringSlice converts a YAML sequence of scalars into []string.

--- a/release_test.go
+++ b/release_test.go
@@ -327,9 +327,23 @@ func Test_goreleaser_explicitArchitectures(t *testing.T) {
 }
 
 // Test_goreleaser_scoopBucket asserts the Scoop manifest is published into this
-// repository's own bucket/ directory. Pointing it at a separate repository would
-// need a cross-repository token the release workflow does not have, so the
-// release would fail at publish time - after the GitHub Release already exists.
+// repository's own bucket/ directory, as a pull request, with a token that is
+// not the workflow's own.
+//
+// Every one of those is a lesson from v1.9.0, whose release job published the
+// GitHub Release, the winget pull request and the Homebrew tap and then failed:
+// it committed bucket/gup.json straight to main, which is protected with admin
+// enforcement, so the API refused it with "Changes must be made through a pull
+// request". The failure also took down the step that came after it, and build
+// provenance is the one part of a published release that cannot be added later.
+//
+// The token matters just as much and is easier to get wrong, because using the
+// built-in one LOOKS like the tidy choice. GitHub deliberately starts no
+// workflow runs for events GITHUB_TOKEN causes, and every required check here
+// comes from a pull_request event - so a pull request that token opened would
+// report all of them as never-run and could not be merged by anyone, admin
+// included. A release would then succeed while leaving a pull request nobody can
+// land, which is a worse failure than the loud one above.
 func Test_goreleaser_scoopBucket(t *testing.T) {
 	t.Parallel()
 	doc := readYAMLFile(t, ".goreleaser.yml")
@@ -350,17 +364,68 @@ func Test_goreleaser_scoopBucket(t *testing.T) {
 		t.Fatal("scoops[0].repository is missing in .goreleaser.yml")
 	}
 	if repo["owner"] != "nao1215" || repo["name"] != "gup" {
-		t.Errorf("scoops[0].repository = %v/%v, want nao1215/gup so the built-in GITHUB_TOKEN can publish it",
+		t.Errorf("scoops[0].repository = %v/%v, want nao1215/gup, where the bucket lives",
 			repo["owner"], repo["name"])
 	}
-	if _, ok := repo["token"]; ok {
-		t.Error("scoops[0].repository declares a token; publishing into this same repository needs only the workflow's GITHUB_TOKEN")
+
+	// Nothing may be pushed to main: it is protected, and the release job is not
+	// exempt from that.
+	branch, _ := repo["branch"].(string)
+	if branch == "" || branch == defaultBranch {
+		t.Errorf("scoops[0].repository.branch = %q, want a per-release branch; %q is protected and refuses a direct push",
+			branch, defaultBranch)
 	}
+
+	pr, ok := repo["pull_request"].(map[string]any)
+	if !ok {
+		t.Fatal("scoops[0].repository.pull_request is missing; the manifest can only reach main through a pull request")
+	}
+	if pr["enabled"] != true {
+		t.Errorf("scoops[0].repository.pull_request.enabled = %v, want true", pr["enabled"])
+	}
+	if base, ok := pr["base"].(map[string]any); !ok {
+		t.Error("scoops[0].repository.pull_request.base is missing, so the pull request has no stated target")
+	} else if base["owner"] != "nao1215" || base["name"] != "gup" || base["branch"] != defaultBranch {
+		t.Errorf("scoops[0].repository.pull_request.base = %v/%v %v, want nao1215/gup %s",
+			base["owner"], base["name"], base["branch"], defaultBranch)
+	}
+
+	// A pull request the built-in token opened could never be merged, so the
+	// token has to be one this configuration names for itself.
+	token, _ := repo["token"].(string)
+	if !strings.Contains(token, ".Env.") {
+		t.Errorf("scoops[0].repository.token = %q, want a token from the environment; the built-in GITHUB_TOKEN opens a pull request whose required checks never run",
+			token)
+	}
+	if !strings.Contains(releaseWorkflowSource(t), scoopTokenEnv) {
+		t.Errorf("the release workflow does not set %s, so the Scoop pull request has no token to open with", scoopTokenEnv)
+	}
+
 	// The bucket has to be a real directory in the repository, or `scoop bucket
 	// add` clones something Scoop cannot read.
 	if _, err := os.Stat("bucket/README.md"); err != nil {
 		t.Errorf("bucket/README.md is missing: %v", err)
 	}
+}
+
+// defaultBranch is the protected branch nothing in a release may push to.
+const defaultBranch = "main"
+
+// scoopTokenEnv is the environment variable the Scoop pull request is opened
+// with. The release workflow has to set it, or GoReleaser fails while rendering
+// the token template - after the release has published.
+const scoopTokenEnv = "SCOOP_GITHUB_TOKEN" //nolint:gosec // G101: the NAME of a secret, not one
+
+// releaseWorkflowSource returns the release workflow as text. The token wiring is
+// asserted against the source rather than the parsed document because what it has
+// to contain is an expression GitHub evaluates, not a value YAML can compare.
+func releaseWorkflowSource(t *testing.T) string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(workflowDir, "release.yml"))
+	if err != nil {
+		t.Fatalf("failed to read the release workflow: %v", err)
+	}
+	return string(raw)
 }
 
 // stringSlice converts a YAML sequence of scalars into []string.


### PR DESCRIPTION
## What broke

v1.9.0's release job **published the release, opened the winget pull request and
updated the Homebrew tap, and then failed.** The Scoop pipe commits
`bucket/gup.json` straight to `main`, and `main` is protected with admin
enforcement, so the API refused it:

```
scoop manifests: could not update "bucket/gup.json":
PUT .../contents/bucket/gup.json: 409 Could not create file:
Changes must be made through a pull request. 8 of 8 required status checks are expected.
```

The Scoop bucket was added after v1.8.1, so v1.9.0 was the first release to reach
that step at all.

Two things fell out of it:

* **No Scoop manifest.** `bucket/gup.json` has never been published, so the
  `scoop install nao1215/gup` that `bucket/README.md`, the README and the
  documentation site all describe does not work yet.
* **No build provenance for v1.9.0.** `Attest build provenance` runs after
  GoReleaser in the same job, so it never ran. `v1.8.1` has one attestation;
  `v1.9.0` returns 404. The release notes header says every artifact "ships with
  an SBOM and build provenance", which is true of the SBOM and not of the
  provenance. That one is not recoverable for a published tag — it is fixed
  forward by v1.9.1, prepared separately.

## The fix

The manifest goes to a `scoop-gup-<version>` branch and opens a pull request
against `main`, the way the winget manifests already do.

**It is opened by a personal access token, and that is a constraint rather than
a preference.** GitHub deliberately starts no workflow runs for events caused by
the built-in `GITHUB_TOKEN`, and every required check here comes from a
`pull_request` event — so a pull request that token opened would show all eight
required checks as never-run and could not be merged by anyone, admin included.

`SCOOP_GITHUB_TOKEN` names it, and the workflow falls back to
`WINGET_GITHUB_TOKEN` when it is unset:

```yaml
SCOOP_GITHUB_TOKEN: ${{ secrets.SCOOP_GITHUB_TOKEN || secrets.WINGET_GITHUB_TOKEN }}
```

`WINGET_GITHUB_TOKEN` is documented as a classic token with the `public_repo`
scope, and v1.9.0's log confirms it (the fork-sync step failed on a missing
`workflow` scope, which only a classic token reports) — so it can already write
here, **nothing has to be provisioned before the next tag**, and the secret can
still be split later without touching `.goreleaser.yml`.

No new workflow permission is granted: the Scoop pipe uses its own token for both
the push and the pull request, so the job keeps `contents`/`id-token`/
`attestations` and nothing more.

## Also updated

* [doc/RELEASE.md](doc/RELEASE.md): the Scoop pull request is listed as a release
  step, `SCOOP_GITHUB_TOKEN` is documented with the reason it cannot be
  `GITHUB_TOKEN`, and "merge the `scoop-gup-<version>` pull request" is the first
  item under *After releasing* — it is the one publishing step a human finishes.
* [bucket/README.md](bucket/README.md): says the manifest arrives as a pull
  request, and that the bucket describes the previous version until it merges,
  which is the safe direction for a file whose hashes must match the artifacts
  a user downloads.
* `CHANGELOG.md`: an `Unreleased` entry.

## Verification

* `goreleaser check` — the configuration is valid. (It also reports the
  pre-existing `brews` deprecation, which is untouched here.)
* `goreleaser release --snapshot --clean --skip=publish,sign,sbom` — builds
  clean and writes `dist/scoop/bucket/gup.json`, which is the same command the
  release-smoke job runs on this PR.
* The publish path itself cannot be exercised before a tag; v1.9.1 is what
  proves it, and its Scoop pull request is the visible result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scoop manifests are now published through version-specific pull requests, supporting protected branches and release verification.
  * Releases can use a dedicated Scoop publishing token, with an automatic fallback to the existing release token.
* **Documentation**
  * Updated release instructions and Scoop bucket guidance to explain the pull-request workflow.
  * Clarified that the pull request must be merged before the latest version is available through Scoop.
  * Updated the changelog with the revised publishing process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->