### PR TITLE
docs(release): say how the release tokens are made, not only what they are

### DIFF
--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -46,6 +46,85 @@ Packaging that needs nothing from us: the [homebrew-core formula](https://formul
 - `WINGET_GITHUB_TOKEN`: a classic token with the `public_repo` scope, used to commit the winget manifests to `nao1215/winget-pkgs` and open the upstream pull request. A fine-grained token does not work here: it can only be scoped to repositories you own, and opening the pull request is a write against microsoft/winget-pkgs. A failure is logged without failing the release, so a rejected or delayed pull request never blocks a version.
 - `SCOOP_GITHUB_TOKEN`: optional. The token that opens the Scoop manifest pull request on this repository; `WINGET_GITHUB_TOKEN` is used when it is unset, and already has the access. It cannot be the workflow's built-in `GITHUB_TOKEN`: GitHub starts no workflow runs for events that token causes, so the pull request would have all eight required checks reported as never-run and could not be merged by anyone. If you narrow it to its own secret, it needs write access to `nao1215/gup` and permission to open pull requests there.
 
+### Creating them
+
+Two of the three are personal access tokens you create by hand. Which *kind* of
+token is not a preference:
+
+| Secret | Writes to | Kind | Permissions |
+|:--|:--|:--|:--|
+| `TAP_GITHUB_TOKEN` | `nao1215/homebrew-tap` | fine-grained | Contents: Read and write |
+| `WINGET_GITHUB_TOKEN` | `nao1215/winget-pkgs`, and a pull request on `microsoft/winget-pkgs` | **classic** | `public_repo` |
+| `SCOOP_GITHUB_TOKEN` | this repository (a branch, and a pull request) | fine-grained | Contents: Read and write, Pull requests: Read and write |
+
+**A fine-grained token** ([new token](https://github.com/settings/personal-access-tokens/new)):
+set *Resource owner* to `nao1215`, *Repository access* to **Only select
+repositories** and pick the target, then grant the permissions above under
+*Repository permissions*. `Metadata: Read-only` is added for you. One token can
+cover several repositories, so the Scoop token can be issued once and reused.
+
+**A classic token** ([new token](https://github.com/settings/tokens/new)): tick
+`public_repo` and nothing else.
+
+Only winget needs a classic token, and it is not a shortcut: a fine-grained token
+can only be scoped to repositories you own, and opening the pull request is a
+write against microsoft/winget-pkgs.
+
+Do **not** add the `workflow` scope to it. The release log carries a warning from
+the fork-sync step without it:
+
+> could not sync fork: 422 refusing to allow a Personal Access Token to create or
+> update workflow `…` without `workflow` scope
+
+That step is a convenience — GoReleaser pushes the branch and opens the pull
+request regardless — while the scope would let a token that lives in CI rewrite
+the workflows of every public repository it can write to. The warning is the
+cheaper of the two.
+
+### Storing them
+
+```shell
+gh secret set SCOOP_GITHUB_TOKEN --repo nao1215/gup
+```
+
+With no value on the command line it prompts for one, which keeps the token out
+of your shell history and out of `ps`. Prefer that to `--body`.
+
+A personal account has no organization-level Actions secrets, so each repository
+needs its own copy. The token itself can be shared between them.
+
+### Checking them before a release needs them
+
+`gh secret list --repo nao1215/gup` shows names and update times; the values
+cannot be read back. So a wrong token is not discovered until a tag is pushed,
+which is the worst moment to discover it — a publish failure lands *after* the
+GitHub Release exists and *before* provenance is attested, and provenance cannot
+be added to a published tag afterwards (see [If a release fails](#if-a-release-fails)).
+
+Check the token where you created it, before storing it:
+
+```shell
+GH_TOKEN=<value> gh api user --jq .login
+```
+
+To prove it can actually write, create a throwaway ref and delete it again:
+
+```shell
+SHA=$(gh api repos/nao1215/gup/git/ref/heads/main --jq .object.sha)
+GH_TOKEN=<value> gh api -X POST repos/nao1215/gup/git/refs -f ref=refs/heads/token-check -f sha=$SHA
+GH_TOKEN=<value> gh api -X DELETE repos/nao1215/gup/git/refs/heads/token-check
+```
+
+Pull-request permission has no equally cheap check; confirm it was granted when
+the token was created.
+
+### Expiry
+
+A fine-grained token lasts a year at most, and an expired one fails exactly the
+way a wrong one does — at publish time, on a release that has already been
+created. Give all three the same expiry date and put it in a calendar, so they
+are renewed together rather than discovered one at a time.
+
 ## The winget pull request
 A **stable** tagged release opens a pull request on microsoft/winget-pkgs; a moderator merges it once their validation pipeline passes, usually within a day. A pre-release tag opens nothing: `skip_upload: auto` skips the winget pipe whenever the tag carries a pre-release suffix, because the community repository takes stable versions only.
 


### PR DESCRIPTION
`doc/RELEASE.md` listed the three release secrets and the access each one needs.
That is enough to recognise a token that is wrong, and not enough to create one
that is right — so this fills in the gap: what kind of token, which permissions,
how to store it, and how to find out it is wrong before a tag does.

## Which kind of token is not a preference

| Secret | Writes to | Kind | Permissions |
|:--|:--|:--|:--|
| `TAP_GITHUB_TOKEN` | `nao1215/homebrew-tap` | fine-grained | Contents: RW |
| `WINGET_GITHUB_TOKEN` | `nao1215/winget-pkgs`, plus a PR on `microsoft/winget-pkgs` | **classic** | `public_repo` |
| `SCOOP_GITHUB_TOKEN` | this repository (branch + PR) | fine-grained | Contents: RW, Pull requests: RW |

Only winget needs a classic token, and the reason is worth stating where someone
will hit it: a fine-grained token can only be scoped to repositories you own, and
opening that pull request is a write against microsoft/winget-pkgs.

## What not to do

The `workflow` scope would silence this warning, which every release currently
logs from the winget fork-sync step:

> could not sync fork: 422 refusing to allow a Personal Access Token to create or
> update workflow `…` without `workflow` scope

The section says to leave it off. That step is a convenience — GoReleaser pushes
the branch and opens the pull request either way — while the scope would let a
token that lives in CI rewrite the workflows of every public repository it can
write to.

## Finding out a token is wrong before a tag does

Secret values cannot be read back, so a wrong or expired token is otherwise
discovered at publish time — *after* the GitHub Release exists and *before*
provenance is attested, which is the failure v1.9.0 already paid for and the one
thing about a release that cannot be repaired afterwards.

So the section adds a check to run where the token is created, including a
throwaway-ref create/delete that actually proves write access, and says to give
all three tokens the same expiry date so they are renewed together rather than
discovered one at a time.

## Scope

Documentation only — `doc/RELEASE.md`. No configuration or workflow changes, and
nothing here needs a token to exist before it merges.

`go test ./...` is clean.