### PR TITLE
fix(import): accept empty exported configurations

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -105,8 +105,8 @@ func runImport(p *print.Printer, cmd *cobra.Command, _ []string) int {
 	}
 
 	if len(pkgs) == 0 {
-		p.Err("unable to import package: no package information")
-		return 1
+		p.Info("nothing to import from " + confFile)
+		return 0
 	}
 
 	p.Info("start import based on " + confFile)

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -52,11 +52,6 @@ versions recorded in that gup.json.`,
 }
 
 func runImport(p *print.Printer, cmd *cobra.Command, _ []string) int {
-	if err := ensureGoCommandAvailable(); err != nil {
-		p.Err(err)
-		return 1
-	}
-
 	dryRun, err := getFlagBool(cmd, "dry-run")
 	if err != nil {
 		p.Err(err)
@@ -107,6 +102,11 @@ func runImport(p *print.Printer, cmd *cobra.Command, _ []string) int {
 	if len(pkgs) == 0 {
 		p.Info("nothing to import from " + confFile)
 		return 0
+	}
+
+	if err := ensureGoCommandAvailable(); err != nil {
+		p.Err(err)
+		return 1
 	}
 
 	p.Info("start import based on " + confFile)

--- a/cmd/import_empty_test.go
+++ b/cmd/import_empty_test.go
@@ -1,0 +1,93 @@
+//nolint:paralleltest
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func Test_importEmptyExport(t *testing.T) {
+	for _, dryRun := range []string{"false", "true"} {
+		t.Run("dry-run="+dryRun, func(t *testing.T) {
+			setupXDGBase(t)
+			gobin := t.TempDir()
+			t.Setenv("GOBIN", gobin)
+			confPath := filepath.Join(t.TempDir(), "gup.json")
+			exportCmd := newExportCmd()
+			if err := exportCmd.Flags().Set("file", confPath); err != nil {
+				t.Fatal(err)
+			}
+			p, buf := newTestPrinter()
+			if code := export(p, exportCmd, nil); code != 0 {
+				t.Fatalf("export() = %d: %s", code, buf.String())
+			}
+			before, err := os.ReadFile(confPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			original := installByVersionCtx
+			installByVersionCtx = func(context.Context, string, string) error {
+				t.Error("empty import must not install a package")
+				return nil
+			}
+			t.Cleanup(func() { installByVersionCtx = original })
+			cmd := newImportCmd()
+			if err := cmd.Flags().Set("file", confPath); err != nil {
+				t.Fatal(err)
+			}
+			if err := cmd.Flags().Set("dry-run", dryRun); err != nil {
+				t.Fatal(err)
+			}
+			buf.Reset()
+			if code := runImport(p, cmd, nil); code != 0 {
+				t.Fatalf("import of empty export = %d: %s", code, buf.String())
+			}
+			if !strings.Contains(buf.String(), "nothing to import") || !strings.Contains(buf.String(), confPath) {
+				t.Errorf("expected no-work message naming configuration: %s", buf.String())
+			}
+			after, err := os.ReadFile(confPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(before) != string(after) {
+				t.Error("import changed the exported configuration")
+			}
+			entries, err := os.ReadDir(gobin)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(entries) != 0 || os.Getenv("GOBIN") != gobin {
+				t.Error("empty import changed GOBIN or its contents")
+			}
+		})
+	}
+}
+
+func Test_runImport_invalidEmptyConfiguration(t *testing.T) {
+	for _, input := range []string{
+		`{"schema_version":`,
+		`{"schema_version":99,"packages":[]}`,
+		`{"schema_version":1,"packages":[{}]}`,
+	} {
+		t.Run(input, func(t *testing.T) {
+			confPath := filepath.Join(t.TempDir(), "gup.json")
+			if err := os.WriteFile(confPath, []byte(input), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cmd := newImportCmd()
+			if err := cmd.Flags().Set("file", confPath); err != nil {
+				t.Fatal(err)
+			}
+			p, buf := newTestPrinter()
+			if code := runImport(p, cmd, nil); code != 1 {
+				t.Errorf("invalid configuration import = %d, want 1", code)
+			}
+			if !strings.Contains(buf.String(), confPath) || strings.Contains(buf.String(), "nothing to import") {
+				t.Errorf("expected configuration error naming the file: %s", buf.String())
+			}
+		})
+	}
+}

--- a/cmd/import_empty_test.go
+++ b/cmd/import_empty_test.go
@@ -24,7 +24,7 @@ func Test_importEmptyExport(t *testing.T) {
 			if code := export(p, exportCmd, nil); code != 0 {
 				t.Fatalf("export() = %d: %s", code, buf.String())
 			}
-			before, err := os.ReadFile(confPath)
+			before, err := os.ReadFile(confPath) //nolint:gosec // fixed filename under t.TempDir(), not user-controlled
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -50,7 +50,7 @@ func Test_importEmptyExport(t *testing.T) {
 			if !strings.Contains(buf.String(), "nothing to import") || !strings.Contains(buf.String(), confPath) {
 				t.Errorf("expected no-work message naming configuration: %s", buf.String())
 			}
-			after, err := os.ReadFile(confPath)
+			after, err := os.ReadFile(confPath) //nolint:gosec // fixed filename under t.TempDir(), not user-controlled
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/import_empty_test.go
+++ b/cmd/import_empty_test.go
@@ -42,6 +42,8 @@ func Test_importEmptyExport(t *testing.T) {
 				t.Fatal(err)
 			}
 			buf.Reset()
+			// Importing an empty export must not require the Go toolchain.
+			t.Setenv("PATH", "")
 			if code := runImport(p, cmd, nil); code != 0 {
 				t.Fatalf("import of empty export = %d: %s", code, buf.String())
 			}

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -166,12 +166,12 @@ func Test_runImport_emptyConf(t *testing.T) {
 
 	got := runImport(p, cmd, nil)
 
-	if got != 1 {
-		t.Errorf("runImport() = %v, want 1", got)
+	if got != 0 {
+		t.Errorf("runImport() = %v, want 0", got)
 	}
 
-	if !strings.Contains(buf.String(), "unable to import package") {
-		t.Errorf("expected 'unable to import package' error, got: %s", buf.String())
+	if !strings.Contains(buf.String(), "nothing to import from "+confPath) {
+		t.Errorf("expected empty configuration message, got: %s", buf.String())
 	}
 }
 
@@ -196,9 +196,9 @@ func Test_runImport_jobsClamp(t *testing.T) {
 	// Should not panic with jobs=0 (clamped to 1)
 	got := runImport(p, cmd, nil)
 
-	// Expect exit code 1 because the conf file has no packages
-	if got != 1 {
-		t.Errorf("runImport() = %v, want 1", got)
+	// An empty configuration succeeds without installing anything.
+	if got != 0 {
+		t.Errorf("runImport() = %v, want 0", got)
 	}
 }
 

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -87,8 +87,15 @@ func Test_runImport_flagErrors(t *testing.T) {
 
 func Test_runImport_notUseGoCmd(t *testing.T) {
 	t.Setenv("PATH", "")
+	confPath := filepath.Join(t.TempDir(), "gup.json")
+	if err := os.WriteFile(confPath, []byte(validImportConf), 0o600); err != nil {
+		t.Fatal(err)
+	}
 
 	cmd := newImportCmd()
+	if err := cmd.Flags().Set("file", confPath); err != nil {
+		t.Fatal(err)
+	}
 
 	p, buf := newTestPrinter()
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -712,7 +712,7 @@ func TestExecute_Import_WithInputOption(t *testing.T) {
 	}
 }
 
-func TestExecute_Import_WithBadInputFile(t *testing.T) {
+func TestExecute_Import_WithMissingOrEmptyInputFile(t *testing.T) {
 	setupXDGBase(t)
 
 	tests := []struct {
@@ -732,7 +732,7 @@ func TestExecute_Import_WithBadInputFile(t *testing.T) {
 			name:      "specify empty file",
 			inputFile: "testdata/gup_config/empty.json",
 			want: []string{
-				"gup:ERROR: unable to import package: no package information",
+				"nothing to import from testdata/gup_config/empty.json",
 				"",
 			},
 		},


### PR DESCRIPTION
> AI disclosure: Prepared and submitted by Codex on behalf of pentaoa. The reproductions and tests described below were run locally.

## Summary

Make importing an empty configuration a successful no-op, matching `gup export`'s existing behaviour for an empty installation directory.

Currently, exporting an empty `GOBIN` succeeds and writes a valid configuration, but importing that exact file exits 1. After this change, both regular import and `--dry-run` report `nothing to import from <path>` and exit 0 before starting installation or dry-run environment setup.

The configuration reader already accepts blank files as an empty package list; these now receive the same no-work result. Invalid JSON, unsupported schema versions, invalid package entries and missing files continue to fail.

## Related issue

Addresses the export/import round-trip portion of #422. The separate confirmation-EOF message request is not changed, so this PR does not close the whole issue.

## Tests

- New export-to-import regression tests failed before the fix for both regular and dry-run imports (exit 1).
- The tests verify the exported configuration and installation directory are unchanged, the installer is not invoked, and the no-work message names the configuration file.
- Added invalid-configuration controls and updated existing empty-file expectations.
- `go test -race ./... -count=1` passed.
- `make test`, `make vet`, and `make fmt` passed on Go 1.26.3, macOS arm64.
- Coverage treemap generation passed using `go tool go-cover-treemap -statements -coverprofile cover.out`, with output placed outside the repository to avoid unrelated generated image changes.
- Built the real CLI and successfully ran empty export, import and dry-run import in an isolated temporary directory.

Limitations: the optional atago E2E suite and Linux/Windows runs were not executed locally. `govulncheck` v1.7.0 was run and reports six reachable advisories in the local Go 1.26.3 standard library (GO-2026-6090, 6089, 5972, 5856, 5039 and 5037). These concern existing standard-library calls; this PR changes no dependencies or toolchain settings. The scan is not claimed clean.

## Checklist

- [x] Added or updated unit tests for the change
- [x] `make test` / `make vet` / `make fmt` pass locally
- [x] README.md is unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - `gup import` now treats configuration files with no package information as a successful no-op.
  - Displays an informational message identifying the empty configuration file.
  - No longer requires the Go command or attempts installation when there is nothing to import.
  - Leaves empty configuration files unchanged.
  - Invalid or unsupported configuration files continue to return an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->