### PR TITLE
ci: lint gup for every system it has code for

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,8 +11,20 @@ permissions:
 
 jobs:
   golangci-lint:
-    name: golangci-lint
+    # A linter only sees the files that build for its GOOS, so the systems
+    # gup has code for are each their own leg. The BSDs reach gup through
+    # cmd/bug_report_nobrowser.go and the !windows halves of cmd and
+    # internal/lockfile, which nothing compiled until they were listed
+    # here. Cross-compiling costs seconds and the repository is public, so
+    # every leg runs on every change.
+    name: golangci-lint (${{ matrix.goos }})
+    strategy:
+      fail-fast: false
+      matrix:
+        goos: [linux, darwin, windows, freebsd, openbsd, netbsd]
     runs-on: ubuntu-latest
+    env:
+      GOOS: ${{ matrix.goos }}
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,20 +11,8 @@ permissions:
 
 jobs:
   golangci-lint:
-    # A linter only sees the files that build for its GOOS, so the systems
-    # gup has code for are each their own leg. The BSDs reach gup through
-    # cmd/bug_report_nobrowser.go and the !windows halves of cmd and
-    # internal/lockfile, which nothing compiled until they were listed
-    # here. Cross-compiling costs seconds and the repository is public, so
-    # every leg runs on every change.
-    name: golangci-lint (${{ matrix.goos }})
-    strategy:
-      fail-fast: false
-      matrix:
-        goos: [linux, darwin, windows, freebsd, openbsd, netbsd]
+    name: golangci-lint
     runs-on: ubuntu-latest
-    env:
-      GOOS: ${{ matrix.goos }}
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -45,6 +33,38 @@ jobs:
           go-version: "1.25"
 
       - name: Run golangci-lint as an enforced gate
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          version: v2.12.2
+
+  # A linter only sees the files that build for its GOOS. The job above is
+  # the required check and stays as it is; this one covers the other
+  # systems gup has code for, including the BSDs, which reach gup through
+  # cmd/bug_report_nobrowser.go and the !windows halves of cmd and
+  # internal/lockfile and were compiled by nothing until now.
+  # Cross-compiling costs seconds and the repository is public, so every
+  # leg runs on every change.
+  golangci-lint-cross:
+    name: golangci-lint (${{ matrix.goos }})
+    strategy:
+      fail-fast: false
+      matrix:
+        goos: [darwin, windows, freebsd, openbsd, netbsd]
+    runs-on: ubuntu-latest
+    env:
+      GOOS: ${{ matrix.goos }}
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.25"
+
+      - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v2.12.2


### PR DESCRIPTION
## Summary

golangci-lint ran once, for whatever GOOS the runner happened to be. A linter only sees the files that build for its GOOS, so the Windows and macOS halves of `cmd` and `internal/lockfile` were analysed on no change, and the BSDs were analysed on none at all — `cmd/bug_report_nobrowser.go` and the `!windows` files are the path a FreeBSD, OpenBSD or NetBSD build takes, and nothing compiled them.

## Changes

- `.github/workflows/golangci-lint.yml`: a `goos` matrix of linux, darwin, windows, freebsd, openbsd and netbsd, with `GOOS` in the job environment.

## Design Decisions

Every leg runs on every change rather than on a schedule: cross-compiling costs seconds, the repository is public so a standard runner is free, and a check that only runs at night is a check whose failures arrive after the change has landed.

All six are clean today (`GOOS=… golangci-lint run` locally reports 0 issues for each), which is the point — this keeps them that way rather than fixing anything. gup releases no BSD binary, but `go install` builds one, and the code that would run there now gets compiled and analysed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Linting now runs as an enforced check on Linux.
  * Added cross-platform linting checks for macOS, Windows, and BSD operating systems.
  * Cross-platform linting continues across all configured platforms even if one check fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->