### PR TITLE
ci: move misspell to v1.28.0, whose base image still has a package index

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           persist-credentials: false
       - name: misspell
-        uses: reviewdog/action-misspell@d6429416b12b09b4e2768307d53bef58d172e962 # v1.27.0
+        uses: reviewdog/action-misspell@ba7ac4030fa6812f8c8b2d4e516af8bc99553c32 # v1.28.0
         with:
           reporter: github-pr-review
           level: warning


### PR DESCRIPTION
## Summary

The misspell job fails on every pull request opened now, before reading a single file. `reviewdog/action-misspell` v1.27.0 builds its container from Debian bullseye, whose security suite stopped being served: `apt-get update` reports the Release file as expired and exits 100, so the image never builds.

## Changes

- `.github/workflows/reviewdog.yml`: `reviewdog/action-misspell` pinned to the commit behind v1.28.0 instead of v1.27.0.

## Design Decisions

Nothing in this repository can work around an expired package index in someone else's image, and pinning by commit is what makes the version explicit, so the fix is to take the release that was cut after bullseye went out of support. The job's inputs are unchanged. The same change fixed nao1215/atago#644.

It is on its own branch because it blocks every other pull request, not only the one that found it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated spelling checks to use a newer review tool version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->