### PR TITLE
ci: move actionlint to v1.73.4

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: reviewdog/action-actionlint@dbe5299849118fd6f099ba563d263d770955a64a # v1.73.2
+      - uses: reviewdog/action-actionlint@d290e336d5a743810aef4404f757dc862276d2ae # v1.73.4
         with:
           reporter: github-pr-review
           level: warning


### PR DESCRIPTION
## Summary

The one dependabot bump gup can take this pass.

## Changes

- `.github/workflows/reviewdog.yml`: reviewdog/action-actionlint v1.73.2 to v1.73.4. Closes the dependabot PR #474.

## Design Decisions

golang.org/x/sys 0.48.0 (#475) is not taken. The golang.org/x family now declares `go 1.26.0`, and gup's floor is 1.25.0 — the oldest Go its own code compiles under, and the floor its unit test matrix verifies on every change. x/sys is a direct dependency here, so taking it would move the floor rather than only the module graph, and nothing in the advisory database affects 0.47.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated workflow validation tooling to a newer version.
  - Improved reliability and maintenance of configuration checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->