### PR TITLE
chore(release): prepare v1.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## [v1.9.2](https://github.com/nao1215/gup/compare/v1.9.1...v1.9.2) (2026-09-12)
+
 ### Bug Fixes
 
 * `gup remove <tool> < /dev/null` refuses up front and names `--force`, instead of printing the confirmation prompt and then failing on the EOF that comes straight back. Whether a confirmation may be asked for was decided from stdin's file mode, and `/dev/null` carries the same `ModeDevice|ModeCharDevice` bits a terminal does, so the guard added for a non-TTY stdin never fired for it. The distinction between a terminal and any other character device exists only in the kernel, and gup now asks it. A redirect from a regular file or a pipe was already refused correctly; a device file was the one shape that reached the prompt.


### PR DESCRIPTION
## Summary

Cuts v1.9.2. The Unreleased section holds two user-visible changes since v1.9.1: the `gup remove` confirmation guard now answers correctly for a stdin redirected from a device file, and the Scoop bucket's removal is announced to anyone who had added it.

## Changes

- `CHANGELOG.md`: `## Unreleased` becomes `## [v1.9.2]` dated 2026-09-12, with a fresh empty `## Unreleased` above it.

## Design Decisions

A patch, not a minor: both entries are fixes, and nothing new is offered. No file outside the changelog carries the version — the binary takes it from the build — so this is the whole of the preparation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - `gup remove <tool> < /dev/null` now stops immediately and clearly indicates that `--force` is required.
  - Improved detection of terminal input to prevent incorrect confirmation prompts when input comes from non-terminal devices.

- **Removed**
  - Removed the Scoop bucket; the previous Scoop installation method is no longer available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->