### PR TITLE
ci(e2e): run the suite with atago v0.22.0

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,10 +42,9 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          # v0.21.0 is the version the cross-platform specs were written and
-          # verified against; the per-OS `skip:`/`only:` gates they use are
-          # validated by its loader.
-          version: v0.21.0
+          # The version the cross-platform specs are verified against; the per-OS
+          # `skip:`/`only:` gates they use are validated by its loader.
+          version: v0.22.0
 
       # Combines unit-test coverage with self-hosted E2E coverage, then merges
       # both into cover.out. The E2E suite is fully offline (it starts its own

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,10 +63,9 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          # v0.21.0 is the version the cross-platform specs were written and
-          # verified against; the per-OS `skip:`/`only:` gates they use are
-          # validated by its loader.
-          version: v0.21.0
+          # The version the cross-platform specs are verified against; the per-OS
+          # `skip:`/`only:` gates they use are validated by its loader.
+          version: v0.22.0
 
       # The runner picks the specs classified for this OS and prints how many of
       # the total it is running, so a shrunken leg is visible in the log rather


### PR DESCRIPTION
## Summary

gup was the one repository left pinning atago v0.21.0 in CI. Every other repository that runs an atago suite moved to v0.22.0 on 2026-09-12; gup was missed, so its offline E2E and the coverage job that reuses it were still loading specs with the older loader.

## Changes

- `.github/workflows/e2e.yml` and `.github/workflows/coverage.yml`: `nao1215/setup-atago` installs v0.22.0. The comment loses the version number it repeated — the `version:` line below it already carries that, and the two drifted apart the moment one was edited.

## Design Decisions

The whole suite was run locally against atago v0.22.0 before the pin moved: 158 scenarios, 155 passed and 3 skipped by their own `skip:` gates, which is what the v0.21.0 pin produces as well. The per-OS `skip:`/`only:` gates the comment is about are therefore still honoured by the newer loader.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Atago version used by automated coverage and end-to-end testing workflows.
  - Clarified workflow comments describing version validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->