### PR TITLE
ci: move golangci-lint to v2.13.2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Run golangci-lint as an enforced gate
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.12.2
+          version: v2.13.2
 
   # A linter only sees the files that build for its GOOS. The job above is
   # the required check and stays as it is; this one covers the other
@@ -67,4 +67,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.12.2
+          version: v2.13.2


### PR DESCRIPTION
## Summary

gup was still running golangci-lint v2.12.2 while every other repository moved to v2.13.2 on 2026-09-12. Both jobs in this workflow — the enforced gate and the per-GOOS cross legs — take the newer release.

## Changes

- `.github/workflows/golangci-lint.yml`: `version: v2.13.2` in `golangci-lint` and `golangci-lint-cross`.

## Design Decisions

v2.13.2 was run locally over the whole tree for each GOOS this workflow lints — the native leg plus darwin, windows, freebsd, openbsd and netbsd — and reports 0 issues in all six, so the gate does not change colour with the version. That mattered here more than usual: v2.13.2's staticcheck reports SA4023 on platform stubs whose error is always non-nil for the GOOS being linted, which is the shape gup has in `cmd/bug_report_nobrowser.go` and the `!windows` halves of `internal/lockfile`. None of them trip it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the code quality checks to use a newer linting tool version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->